### PR TITLE
Fix CI pipeline and CLI service command bugs

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -219,8 +219,11 @@ func IsSystemdAvailable() bool {
 	if runtime.GOOS != "linux" {
 		return false
 	}
-	_, err := exec.LookPath("systemctl")
-	return err == nil
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return false
+	}
+	// Ensure systemd is actually running for the user
+	return exec.Command("systemctl", "--user", "show-environment").Run() == nil
 }
 
 // IsLaunchdAvailable reports whether launchctl is available on the path.

--- a/main.go
+++ b/main.go
@@ -2527,20 +2527,20 @@ func serviceRemoveCmd(args []string) int {
 	}
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
 
-	if err := fs.Parse(args); err != nil {
+	name, flagArgs := extractPositional(args)
+	if err := fs.Parse(flagArgs); err != nil {
 		return exitUsage
 	}
-	if fs.NArg() < 1 {
+	if name == "" {
 		fPrintln(os.Stderr, "genv service remove: name is required")
 		fs.Usage()
 		return exitUsage
 	}
-	name := fs.Arg(0)
 
 	f, err := genvfile.Read(*file)
 	if err != nil {
 		if errors.Is(err, genvfile.ErrNotFound) {
-			fprintf(os.Stderr, "genv: %s not found\n", *file)
+			fprintf(os.Stderr, "genv: %v\n", err)
 			return exitLogic
 		}
 		fprintf(os.Stderr, "genv: %v\n", err)
@@ -2603,14 +2603,15 @@ func serviceListCmd(args []string) int {
 func serviceStartCmd(args []string) int {
 	fs := flag.NewFlagSet("service start", flag.ContinueOnError)
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
-	if err := fs.Parse(args); err != nil {
+
+	name, flagArgs := extractPositional(args)
+	if err := fs.Parse(flagArgs); err != nil {
 		return exitUsage
 	}
-	if fs.NArg() < 1 {
+	if name == "" {
 		fPrintln(os.Stderr, "genv service start: name is required")
 		return exitUsage
 	}
-	name := fs.Arg(0)
 
 	f, err := genvfile.Read(*file)
 	if err != nil {
@@ -2648,14 +2649,15 @@ func serviceStartCmd(args []string) int {
 func serviceStopCmd(args []string) int {
 	fs := flag.NewFlagSet("service stop", flag.ContinueOnError)
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
-	if err := fs.Parse(args); err != nil {
+
+	name, flagArgs := extractPositional(args)
+	if err := fs.Parse(flagArgs); err != nil {
 		return exitUsage
 	}
-	if fs.NArg() < 1 {
+	if name == "" {
 		fPrintln(os.Stderr, "genv service stop: name is required")
 		return exitUsage
 	}
-	name := fs.Arg(0)
 
 	f, err := genvfile.Read(*file)
 	if err != nil {
@@ -2689,14 +2691,15 @@ func serviceStopCmd(args []string) int {
 func serviceStatusCmd(args []string) int {
 	fs := flag.NewFlagSet("service status", flag.ContinueOnError)
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
-	if err := fs.Parse(args); err != nil {
+
+	name, flagArgs := extractPositional(args)
+	if err := fs.Parse(flagArgs); err != nil {
 		return exitUsage
 	}
-	if fs.NArg() < 1 {
+	if name == "" {
 		fPrintln(os.Stderr, "genv service status: name is required")
 		return exitUsage
 	}
-	name := fs.Arg(0)
 
 	f, err := genvfile.Read(*file)
 	if err != nil {


### PR DESCRIPTION
Fixes issues where GitHub actions pipelines were failing due to incorrect systemd detection in headless CI environments. In docker containers, `systemctl` is often in the path but the daemon isn't running, causing `systemd` commands to fail. The new `IsSystemdAvailable` check verifies the user's systemd environment explicitly.

Also fixes a CLI bug where the flag parser would stop when it encountered the positional service name (e.g. `genv service remove test-svc --file ...`). By extracting the positional argument first, flags can be placed anywhere. The missing spec file error message was also updated to align with the standard error.

---
*PR created automatically by Jules for task [9234926406992870726](https://jules.google.com/task/9234926406992870726) started by @ks1686*