### PR TITLE
🧪 Add edge case tests for output.Write

### DIFF
--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -3,6 +3,7 @@ package output_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/ks1686/genv/internal/output"
@@ -183,5 +184,33 @@ func TestWrite_EndsWithNewline(t *testing.T) {
 	b := buf.Bytes()
 	if len(b) == 0 || b[len(b)-1] != '\n' {
 		t.Errorf("Write should end with newline, got: %q", string(b))
+	}
+}
+
+type errorWriter struct{}
+
+func (e errorWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("write error")
+}
+
+func TestWrite_WriterError(t *testing.T) {
+	err := output.Write(errorWriter{}, output.Envelope{Command: "test", OK: true})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "write error" {
+		t.Errorf("expected write error, got %v", err)
+	}
+}
+
+func TestWrite_MarshalError(t *testing.T) {
+	// Channels cannot be marshaled to JSON.
+	err := output.Write(&bytes.Buffer{}, output.Envelope{
+		Command: "test",
+		OK:      true,
+		Data:    make(chan int),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing edge case tests for `output.Write`.
📊 **Coverage:** The scenarios now tested include handling errors returned by the underlying `io.Writer` and dealing with `json.Encoder.Encode` failures (using an unmarshable type).
✨ **Result:** Increased test coverage for the error paths of the JSON output wrapper, ensuring failures propagate gracefully.

---
*PR created automatically by Jules for task [2125691581990551641](https://jules.google.com/task/2125691581990551641) started by @ks1686*