### PR TITLE
🧪 test: add unit tests for RedactValue function

### DIFF
--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestRedactValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		sensitive bool
+		want      string
+	}{
+		{
+			name:      "not sensitive, empty value",
+			value:     "",
+			sensitive: false,
+			want:      "",
+		},
+		{
+			name:      "not sensitive, non-empty value",
+			value:     "secret-123",
+			sensitive: false,
+			want:      "secret-123",
+		},
+		{
+			name:      "sensitive, empty value",
+			value:     "",
+			sensitive: true,
+			want:      "",
+		},
+		{
+			name:      "sensitive, non-empty value",
+			value:     "secret-123",
+			sensitive: true,
+			want:      "[redacted]",
+		},
+		{
+			name:      "sensitive, single space",
+			value:     " ",
+			sensitive: true,
+			want:      "[redacted]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RedactValue(tt.value, tt.sensitive); got != tt.want {
+				t.Errorf("RedactValue(%q, %v) = %q, want %q", tt.value, tt.sensitive, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing unit tests for the `RedactValue` utility function in `internal/commands/helpers.go`.

📊 **Coverage:** What scenarios are now tested
- Non-sensitive, empty value.
- Non-sensitive, non-empty value.
- Sensitive, empty value.
- Sensitive, non-empty value.
- Sensitive, single space.

✨ **Result:** The improvement in test coverage
- Added robust, table-driven unit tests providing complete test coverage for `RedactValue`, ensuring accurate redaction of secrets in user-facing output.

---
*PR created automatically by Jules for task [1769705876965796377](https://jules.google.com/task/1769705876965796377) started by @ks1686*