### PR TITLE
🧪 Add tests for helpers.go

### DIFF
--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestKnownManagerList(t *testing.T) {
+	// The expected output depends on the keys of schema.KnownManagers being joined and sorted.
+	// Since schema.KnownManagers is defined as:
+	// "apt", "dnf", "pacman", "paru", "yay", "flatpak", "snap", "brew", "macports", "linuxbrew"
+	expected := "apt, brew, dnf, flatpak, linuxbrew, macports, pacman, paru, snap, yay"
+
+	result := KnownManagerList()
+	if result != expected {
+		t.Errorf("KnownManagerList() = %q, want %q", result, expected)
+	}
+
+	// Double check that it contains at least one known manager to be safe against schema changes
+	if !strings.Contains(result, "apt") {
+		t.Errorf("KnownManagerList() output does not contain expected manager %q", "apt")
+	}
+}
+
+func TestRedactValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		sensitive bool
+		want      string
+	}{
+		{"empty string, not sensitive", "", false, ""},
+		{"empty string, sensitive", "", true, ""},
+		{"value, not sensitive", "mysecret", false, "mysecret"},
+		{"value, sensitive", "mysecret", true, "[redacted]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RedactValue(tt.value, tt.sensitive); got != tt.want {
+				t.Errorf("RedactValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Tests were missing for `KnownManagerList` and `RedactValue` functions in `internal/commands/helpers.go`. A new test file `helpers_test.go` has been added to provide coverage for these helper functions.

📊 **Coverage:** What scenarios are now tested
- `KnownManagerList`: Confirmed that the returned string is a properly comma-separated and alphabetically sorted list of expected known package managers. Verified that it acts effectively as a snapshot against unexpected schema changes.
- `RedactValue`: Tested combinations of sensitive vs non-sensitive values and empty vs non-empty strings.

✨ **Result:** The improvement in test coverage
The CLI `helpers.go` file now has unit tests, which increases overall codebase reliability and allows developers to catch regressions if known managers are removed or refactored incorrectly.

---
*PR created automatically by Jules for task [2993883351490854904](https://jules.google.com/task/2993883351490854904) started by @ks1686*