### PR TITLE
⚡ Cache isWSL() result to avoid repeated file I/O

### DIFF
--- a/baseline.txt
+++ b/baseline.txt
@@ -1,0 +1,7 @@
+goos: linux
+goarch: amd64
+pkg: github.com/ks1686/genv/internal/adapter
+cpu: Intel(R) Xeon(R) Processor @ 2.30GHz
+BenchmarkIsWSL-4   	   69784	     17008 ns/op	    2120 B/op	       8 allocs/op
+PASS
+ok  	github.com/ks1686/genv/internal/adapter	8.934s

--- a/internal/adapter/wsl.go
+++ b/internal/adapter/wsl.go
@@ -4,6 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+)
+
+var (
+	wslOnce sync.Once
+	wslMemo bool
 )
 
 // isWSL reports whether the current process is running inside a WSL (Windows
@@ -11,11 +17,13 @@ import (
 // "microsoft" string that the WSL kernel injects into that file.
 // Returns false on any non-Linux host or when the file cannot be read.
 func isWSL() bool {
-	data, err := os.ReadFile("/proc/version")
-	if err != nil {
-		return false
-	}
-	return strings.Contains(strings.ToLower(string(data)), "microsoft")
+	wslOnce.Do(func() {
+		data, err := os.ReadFile("/proc/version")
+		if err == nil {
+			wslMemo = strings.Contains(strings.ToLower(string(data)), "microsoft")
+		}
+	})
+	return wslMemo
 }
 
 // sanitizePathForWSL removes Windows-host path entries from a PATH string.

--- a/internal/adapter/wsl_test.go
+++ b/internal/adapter/wsl_test.go
@@ -88,3 +88,9 @@ func TestSanitizePathForWSL_NoWindowsPaths(t *testing.T) {
 		t.Errorf("sanitizePathForWSL with no Windows paths modified the PATH: got %q, want %q", got, input)
 	}
 }
+
+func BenchmarkIsWSL(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		isWSL()
+	}
+}

--- a/optimized.txt
+++ b/optimized.txt
@@ -1,0 +1,7 @@
+goos: linux
+goarch: amd64
+pkg: github.com/ks1686/genv/internal/adapter
+cpu: Intel(R) Xeon(R) Processor @ 2.30GHz
+BenchmarkIsWSL-4   	511551787	         2.433 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/ks1686/genv/internal/adapter	4.150s


### PR DESCRIPTION
💡 **What:**
The `isWSL()` function in `internal/adapter/wsl.go` has been optimized to cache its result using `sync.Once`. A new benchmark `BenchmarkIsWSL` was added to `internal/adapter/wsl_test.go` to measure the performance impact.

🎯 **Why:**
Previously, `isWSL()` read and parsed `/proc/version` every time it was called. Because the host environment (whether the process is running in WSL or not) is static for the duration of the program, there's no need to perform this file I/O and string manipulation repeatedly. Caching the result prevents unnecessary CPU and I/O overhead.

📊 **Measured Improvement:**
A benchmark was created and run before and after the change.

**Baseline:**
```
goos: linux
goarch: amd64
pkg: github.com/ks1686/genv/internal/adapter
cpu: Intel(R) Xeon(R) Processor @ 2.30GHz
BenchmarkIsWSL-4   	   69784	     17008 ns/op	    2120 B/op	       8 allocs/op
```

**Optimized:**
```
goos: linux
goarch: amd64
pkg: github.com/ks1686/genv/internal/adapter
cpu: Intel(R) Xeon(R) Processor @ 2.30GHz
BenchmarkIsWSL-4   	511551787	         2.433 ns/op	       0 B/op	       0 allocs/op
```

**Comparison (`benchstat`):**
```
        │   baseline.txt   │          optimized.txt          │
        │      sec/op      │    sec/op     vs base           │
IsWSL-4   17008.000n ± ∞ ¹   2.433n ± ∞ ¹  ~ (p=1.000 n=1) ²

        │ baseline.txt  │          optimized.txt           │
        │     B/op      │     B/op       vs base           │
IsWSL-4   2.070Ki ± ∞ ¹   0.000Ki ± ∞ ¹  ~ (p=1.000 n=1) ²

        │ baseline.txt │         optimized.txt          │
        │  allocs/op   │  allocs/op   vs base           │
IsWSL-4    8.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
```
The execution time dropped from ~17 µs/op to ~2.4 ns/op. Allocations went from 8 per operation (2120 B/op) to 0. This is a substantial improvement for any code path that frequently queries the WSL state.

---
*PR created automatically by Jules for task [15753221866003829886](https://jules.google.com/task/15753221866003829886) started by @ks1686*