### PR TITLE
🧹 Refactor complex function removeCmd

### DIFF
--- a/main.go
+++ b/main.go
@@ -379,11 +379,15 @@ func removeCmd(args []string) int {
 	}
 	id := fs.Arg(0)
 
+	return runRemove(*file, id)
+}
+
+func runRemove(file, id string) int {
 	// 0. When stdin is a terminal and id has no exact match in the spec,
 	//    fall back to substring matching so users can type short names
 	//    (e.g. "firefox" resolving to a tracked id like "org.mozilla.firefox").
 	if isTerminal() {
-		if f, err := genvfile.Read(*file); err == nil {
+		if f, err := genvfile.Read(file); err == nil {
 			idLower := strings.ToLower(id)
 			exact := false
 			var matches []string
@@ -417,7 +421,7 @@ func removeCmd(args []string) int {
 	}
 
 	// 1. Update genv.json and read lock.
-	lf, lockPath, exit := removeFromSpecAndReadLock(*file, id)
+	lf, lockPath, exit := removeFromSpecAndReadLock(file, id)
 	if exit != exitOK {
 		return exit
 	}


### PR DESCRIPTION
🎯 **What:** The `removeCmd` function was refactored to separate flag parsing from core execution logic. A new `runRemove` function was created to handle the execution.
💡 **Why:** CLI command functions that mix argument parsing with execution are harder to read and test. Separating them follows standard codebase conventions and improves maintainability.
✅ **Verification:** Verified by running `go fmt ./...`, unit tests (`go test ./...`), and integration tests (`go test -tags integration ./e2e/...`). All checks passed successfully. 
✨ **Result:** The `removeCmd` function is now much simpler, focused only on flag definition and parsing, delegating execution to `runRemove`.

---
*PR created automatically by Jules for task [454914720575474634](https://jules.google.com/task/454914720575474634) started by @ks1686*