### PR TITLE
🔒 fix: mitigate command injection in edit commands via os.Getenv

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 
@@ -48,6 +49,14 @@ var (
 	commit  = "none"
 	date    = "unknown"
 )
+
+var safeEditors = map[string]bool{
+	"vi":    true,
+	"vim":   true,
+	"nano":  true,
+	"emacs": true,
+	"code":  true,
+}
 
 func main() {
 	os.Exit(run(os.Args[1:]))
@@ -1435,12 +1444,17 @@ func shellEditCmd(args []string) int {
 		editor = "vi"
 	}
 
-	cmd := exec.Command(editor, *file)
+	cmd, err := buildEditorCmd(editor, *file)
+	if err != nil {
+		fprintf(os.Stderr, "genv shell edit: %v\n", err)
+		return exitLogic
+	}
+
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		fprintf(os.Stderr, "genv: editor exited with error: %v\n", err)
+		fprintf(os.Stderr, "genv shell edit: editor exited with error: %v\n", err)
 		return exitLogic
 	}
 	return exitOK
@@ -1906,6 +1920,24 @@ func cleanCmd(args []string) int {
 	return exitCode
 }
 
+// buildEditorCmd parses the editor string, validates the executable against a
+// whitelist of safe editors, and returns an exec.Cmd ready to run.
+func buildEditorCmd(editor, file string) (*exec.Cmd, error) {
+	fields := strings.Fields(editor)
+	if len(fields) == 0 {
+		return exec.Command("vi", file), nil
+	}
+
+	bin := fields[0]
+	base := filepath.Base(bin)
+	if !safeEditors[base] {
+		return nil, fmt.Errorf("editor %q is not allowed; must be one of: vi, vim, nano, emacs, code", bin)
+	}
+
+	args := append(fields[1:], file)
+	return exec.Command(bin, args...), nil
+}
+
 // editCmd implements `genv edit`.
 // Opens genv.json in the user's preferred editor ($VISUAL, $EDITOR, or vi).
 func editCmd(args []string) int {
@@ -1923,7 +1955,12 @@ func editCmd(args []string) int {
 		editor = "vi"
 	}
 
-	cmd := exec.Command(editor, *file)
+	cmd, err := buildEditorCmd(editor, *file)
+	if err != nil {
+		fprintf(os.Stderr, "genv edit: %v\n", err)
+		return exitLogic
+	}
+
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/main_test.go
+++ b/main_test.go
@@ -1150,3 +1150,51 @@ func TestExtractPositional(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildEditorCmd(t *testing.T) {
+	tests := []struct {
+		editor   string
+		file     string
+		wantErr  bool
+		wantPath string // only check base name if not empty
+		wantArgs []string
+	}{
+		{"vi", "test.json", false, "vi", []string{"vi", "test.json"}},
+		{"code --wait", "test.json", false, "code", []string{"code", "--wait", "test.json"}},
+		{"/usr/bin/vim -R", "test.json", false, "vim", []string{"/usr/bin/vim", "-R", "test.json"}},
+		{"rm -rf", "test.json", true, "", nil},
+		{"", "test.json", false, "vi", []string{"vi", "test.json"}},
+		{"   ", "test.json", false, "vi", []string{"vi", "test.json"}},
+		{"code", "test.json", false, "code", []string{"code", "test.json"}},
+		{"/usr/bin/nano", "test.json", false, "nano", []string{"/usr/bin/nano", "test.json"}},
+		{"emacs -nw", "test.json", false, "emacs", []string{"emacs", "-nw", "test.json"}},
+		{"/bin/sh -c 'rm -rf /'", "test.json", true, "", nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.editor, func(t *testing.T) {
+			cmd, err := buildEditorCmd(tc.editor, tc.file)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("buildEditorCmd(%q, %q): expected error, got nil", tc.editor, tc.file)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildEditorCmd(%q, %q): unexpected error: %v", tc.editor, tc.file, err)
+			}
+			if filepath.Base(cmd.Path) != tc.wantPath {
+				t.Errorf("buildEditorCmd path: got %q, want base %q", cmd.Path, tc.wantPath)
+			}
+			if len(cmd.Args) != len(tc.wantArgs) {
+				t.Errorf("buildEditorCmd args length: got %d, want %d (args: %v, want: %v)", len(cmd.Args), len(tc.wantArgs), cmd.Args, tc.wantArgs)
+			} else {
+				for i := range cmd.Args {
+					if cmd.Args[i] != tc.wantArgs[i] {
+						t.Errorf("buildEditorCmd args[%d]: got %q, want %q", i, cmd.Args[i], tc.wantArgs[i])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in `editCmd` and `shellEditCmd` which allowed arbitrary commands via `VISUAL`/`EDITOR` environment variables.
⚠️ **Risk:** An attacker could craft a malicious environment variable, leading to arbitrary code execution when running the edit commands.
🛡️ **Solution:** Implemented `buildEditorCmd`, which uses `strings.Fields` to parse the editor string, extracting the base executable name and validating it against a predefined whitelist of safe editors (`vi`, `vim`, `nano`, `emacs`, `code`). Invalid editors are rejected, mitigating the risk of command injection while preserving the ability to pass arguments (like `-w`). Added extensive tests.

---
*PR created automatically by Jules for task [2825331208422829020](https://jules.google.com/task/2825331208422829020) started by @ks1686*