### PR TITLE
🧹 Refactor upgradeCmd into resolver package

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -173,6 +173,63 @@ func Execute(ctx context.Context, actions []Action, stdin io.Reader, stdout, std
 	return errs
 }
 
+// ---- Upgrade (genv upgrade) --------------------------------------------------
+
+// UpgradeAction is the resolved upgrade action for a single package.
+type UpgradeAction struct {
+	LP  genvfile.LockedPackage
+	Mgr adapter.Adapter
+	Cmd []string
+}
+
+// SkippedPackage records a package that was skipped during upgrade planning
+// because its recorded package manager adapter is no longer registered.
+type SkippedPackage struct {
+	ID      string
+	Manager string
+}
+
+// PlanUpgrade builds an upgrade plan for all packages tracked in the lock file.
+// It returns a list of actions and a list of packages that were skipped because
+// their recorded package manager adapter is no longer registered.
+func PlanUpgrade(packages []genvfile.LockedPackage) (plan []UpgradeAction, skipped []SkippedPackage) {
+	for _, lp := range packages {
+		mgr := adapter.ByName(lp.Manager)
+		if mgr == nil {
+			skipped = append(skipped, SkippedPackage{ID: lp.ID, Manager: lp.Manager})
+			continue
+		}
+		plan = append(plan, UpgradeAction{LP: lp, Mgr: mgr, Cmd: mgr.PlanUpgrade(lp.PkgName)})
+	}
+	return plan, skipped
+}
+
+// UpgradeExecution records the outcome of ExecuteUpgrade so the caller can update
+// the lock file with new versions.
+type UpgradeExecution struct {
+	Upgraded []genvfile.LockedPackage
+	Errors   []error
+}
+
+// ExecuteUpgrade runs each resolved upgrade action sequentially, updating the
+// InstalledVersion on success. Returns an UpgradeExecution holding the updated
+// packages and any errors encountered.
+func ExecuteUpgrade(ctx context.Context, plan []UpgradeAction, stdin io.Reader, stdout, stderr io.Writer) UpgradeExecution {
+	var out UpgradeExecution
+	for _, a := range plan {
+		if err := runSubcmd(ctx, a.Cmd, stdin, stdout, stderr); err != nil {
+			out.Errors = append(out.Errors, fmt.Errorf("upgrade %q: %w", a.LP.ID, err))
+			continue
+		}
+		// Update InstalledVersion in lock for successfully upgraded packages.
+		if v, err := a.Mgr.QueryVersion(a.LP.PkgName); err == nil && v != "" {
+			a.LP.InstalledVersion = v
+		}
+		out.Upgraded = append(out.Upgraded, a.LP)
+	}
+	return out
+}
+
 // ---- Reconcile (genv apply) --------------------------------------------------
 
 // versionDrifted reports whether the InstalledVersion recorded for lp fails the

--- a/main.go
+++ b/main.go
@@ -2068,20 +2068,9 @@ func upgradeCmd(args []string) int {
 		return exitOK
 	}
 
-	// Build upgrade plan, storing each adapter to avoid repeated ByName lookups.
-	type upgradeAction struct {
-		lp  genvfile.LockedPackage
-		mgr adapter.Adapter
-		cmd []string
-	}
-	var plan []upgradeAction
-	for _, lp := range lf.Packages {
-		mgr := adapter.ByName(lp.Manager)
-		if mgr == nil {
-			fprintf(os.Stderr, "genv upgrade: adapter %q not registered for %s — skipping\n", lp.Manager, lp.ID)
-			continue
-		}
-		plan = append(plan, upgradeAction{lp: lp, mgr: mgr, cmd: mgr.PlanUpgrade(lp.PkgName)})
+	plan, skipped := resolver.PlanUpgrade(lf.Packages)
+	for _, s := range skipped {
+		fprintf(os.Stderr, "genv upgrade: adapter %q not registered for %s — skipping\n", s.Manager, s.ID)
 	}
 
 	if len(plan) == 0 {
@@ -2091,7 +2080,7 @@ func upgradeCmd(args []string) int {
 
 	fPrintln(os.Stdout, "upgrade plan:")
 	for _, a := range plan {
-		fprintf(os.Stdout, "  %s  via %s  ==> %s\n", a.lp.ID, a.lp.Manager, strings.Join(a.cmd, " "))
+		fprintf(os.Stdout, "  %s  via %s  ==> %s\n", a.LP.ID, a.LP.Manager, strings.Join(a.Cmd, " "))
 	}
 
 	if *dryRun {
@@ -2103,29 +2092,24 @@ func upgradeCmd(args []string) int {
 		return exitOK
 	}
 
+	execResult := resolver.ExecuteUpgrade(context.Background(), plan, os.Stdin, os.Stdout, os.Stderr)
+
+	exitCode := exitOK
+	if len(execResult.Errors) > 0 {
+		for _, err := range execResult.Errors {
+			fprintf(os.Stderr, "genv upgrade: %v\n", err)
+		}
+		exitCode = exitLogic
+	}
+
 	// Build an ID→index map so each version update is O(1), not O(n).
 	lockIndex := make(map[string]int, len(lf.Packages))
 	for i, lp := range lf.Packages {
 		lockIndex[lp.ID] = i
 	}
-
-	exitCode := exitOK
-	for _, a := range plan {
-		fprintf(os.Stdout, "\n==> %s\n", strings.Join(a.cmd, " "))
-		cmd := exec.Command(a.cmd[0], a.cmd[1:]...)
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			fprintf(os.Stderr, "genv upgrade: %s: %v\n", a.lp.ID, err)
-			exitCode = exitLogic
-			continue
-		}
-		// Update InstalledVersion in lock for successfully upgraded packages.
-		if v, err := a.mgr.QueryVersion(a.lp.PkgName); err == nil && v != "" {
-			if idx, ok := lockIndex[a.lp.ID]; ok {
-				lf.Packages[idx].InstalledVersion = v
-			}
+	for _, upgraded := range execResult.Upgraded {
+		if idx, ok := lockIndex[upgraded.ID]; ok {
+			lf.Packages[idx].InstalledVersion = upgraded.InstalledVersion
 		}
 	}
 


### PR DESCRIPTION
🎯 **What:** The `upgradeCmd` function in `main.go` was overly complex, mixing CLI argument parsing, user confirmation, and error reporting with the actual domain logic of planning and executing package manager upgrades. The core execution logic has been extracted into `internal/resolver/resolver.go`.

💡 **Why:** Separating the CLI concerns from the execution logic results in cleaner, more maintainable code that is easier to test and reason about.

✅ **Verification:** Verified by building the project (`go build ./...`) and running the full test suite (`go test ./...`) to ensure no regressions were introduced.

✨ **Result:** A simplified `main.go` that strictly orchestrates the CLI experience, while the robust execution operations reside in the `resolver` domain package where they belong.

---
*PR created automatically by Jules for task [11687348443789423068](https://jules.google.com/task/11687348443789423068) started by @ks1686*