### PR TITLE
🧪 Add tests for fprintf wrappers in resolver

### DIFF
--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -10,6 +11,43 @@ import (
 	"github.com/ks1686/genv/internal/genvfile"
 	"github.com/ks1686/genv/internal/schema"
 )
+
+type errorWriter struct{}
+
+func (errorWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("simulated write error")
+}
+
+func TestFprintfWrappers(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		fprintf(&buf, "hello %s", "world")
+		if got := buf.String(); got != "hello world" {
+			t.Errorf("fprintf: got %q, want %q", got, "hello world")
+		}
+		buf.Reset()
+
+		fprint(&buf, "hello", " world")
+		if got := buf.String(); got != "hello world" {
+			t.Errorf("fprint: got %q, want %q", got, "hello world")
+		}
+		buf.Reset()
+
+		fPrintln(&buf, "hello world")
+		if got := buf.String(); got != "hello world\n" {
+			t.Errorf("fPrintln: got %q, want %q", got, "hello world\n")
+		}
+	})
+
+	t.Run("error discarding", func(t *testing.T) {
+		var ew errorWriter
+		// These should not panic or return errors
+		fprintf(ew, "test")
+		fprint(ew, "test")
+		fPrintln(ew, "test")
+	})
+}
 
 func TestPlan_PreferredManagerAvailable(t *testing.T) {
 	f := &schema.GenvFile{


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of test coverage for the simple formatting wrappers (`fprintf`, `fprint`, `fPrintln`) in `internal/resolver/resolver.go`.

📊 **Coverage:** What scenarios are now tested
The new `TestFprintfWrappers` function covers two main scenarios:
1. **Success**: Verifies that the wrappers accurately write string formats and arguments to a `bytes.Buffer` exactly like their standard library `fmt` counterparts.
2. **Error discarding**: Utilizes an `errorWriter` mock to simulate an `io.Writer` failure and ensure that the wrappers silently discard the resulting errors without returning or panicking, as described by their purpose comment.

✨ **Result:** The improvement in test coverage
The overall line and statement coverage for `internal/resolver` increases by explicitly executing the helper lines that discard unactionable I/O errors. All `go test ./...` test suites pass properly with this change.

---
*PR created automatically by Jules for task [12083817510976834856](https://jules.google.com/task/12083817510976834856) started by @ks1686*