### PR TITLE
🧪 Add test for ensureShell in shell.go

### DIFF
--- a/internal/commands/shell_test.go
+++ b/internal/commands/shell_test.go
@@ -7,6 +7,41 @@ import (
 	"github.com/ks1686/genv/internal/schema"
 )
 
+// ─── ensureShell ─────────────────────────────────────────────────────────────
+
+func TestEnsureShell_NilShell(t *testing.T) {
+	f := &schema.GenvFile{
+		SchemaVersion: schema.Version2,
+		Shell:         nil,
+	}
+	ensureShell(f)
+	if f.Shell == nil {
+		t.Fatal("expected Shell to be initialized, got nil")
+	}
+	if f.SchemaVersion != schema.Version3 {
+		t.Errorf("expected schemaVersion %q, got %q", schema.Version3, f.SchemaVersion)
+	}
+}
+
+func TestEnsureShell_ExistingShell(t *testing.T) {
+	existingShell := &schema.ShellConfig{
+		Aliases: map[string]schema.ShellAlias{
+			"ll": {Value: "ls -la"},
+		},
+	}
+	f := &schema.GenvFile{
+		SchemaVersion: schema.Version,
+		Shell:         existingShell,
+	}
+	ensureShell(f)
+	if f.Shell != existingShell {
+		t.Errorf("expected existing Shell %p to be preserved, got %p", existingShell, f.Shell)
+	}
+	if f.SchemaVersion != schema.Version3 {
+		t.Errorf("expected schemaVersion %q, got %q", schema.Version3, f.SchemaVersion)
+	}
+}
+
 // ─── ShellAliasSet ───────────────────────────────────────────────────────────
 
 func TestShellAliasSet_New(t *testing.T) {


### PR DESCRIPTION
🎯 **What:** This PR adds a testing gap by adding tests for the `ensureShell` function in `internal/commands/shell.go`. This function is responsible for ensuring the `Shell` block of the schema exists and correctly upgrades to schema v3.
📊 **Coverage:** The tests cover the two possible scenarios: when the `Shell` block is `nil` (ensuring it's correctly initialized and schema updated) and when the `Shell` block already exists (ensuring its existing contents are preserved while schema is still updated).
✨ **Result:** 100% test coverage for the `ensureShell` function.

---
*PR created automatically by Jules for task [7180789582108790669](https://jules.google.com/task/7180789582108790669) started by @ks1686*