### PR TITLE
🧪 test: Add test for FragmentPath in shellcfg.go

### DIFF
--- a/internal/shellcfg/shellcfg_test.go
+++ b/internal/shellcfg/shellcfg_test.go
@@ -29,6 +29,49 @@ func TestSingleQuote(t *testing.T) {
 	}
 }
 
+// ─── FragmentPath ────────────────────────────────────────────────────────────
+
+func TestFragmentPath(t *testing.T) {
+	t.Run("XDG_CONFIG_HOME set", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "/custom/xdg")
+		got, err := FragmentPath()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join("/custom/xdg", "genv", "shell.sh")
+		if got != want {
+			t.Errorf("FragmentPath() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("Fallback to HOME", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "")
+		homeDir := "/custom/home"
+		t.Setenv("HOME", homeDir)
+		t.Setenv("USERPROFILE", homeDir)
+
+		got, err := FragmentPath()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join(homeDir, ".config", "genv", "shell.sh")
+		if got != want {
+			t.Errorf("FragmentPath() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("Error no home dir", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "")
+		t.Setenv("HOME", "")
+		t.Setenv("USERPROFILE", "")
+
+		_, err := FragmentPath()
+		if err == nil {
+			t.Error("expected error when HOME is not set, got nil")
+		}
+	})
+}
+
 // ─── WriteFragment ────────────────────────────────────────────────────────────
 
 func TestWriteFragment_Aliases(t *testing.T) {


### PR DESCRIPTION
🎯 **What:** This PR adds missing test coverage for the `FragmentPath` function in `internal/shellcfg/shellcfg.go`.
📊 **Coverage:** The new test covers three scenarios: 
  1. `XDG_CONFIG_HOME` is set.
  2. `XDG_CONFIG_HOME` is not set, falling back to `HOME` (or `USERPROFILE` on Windows).
  3. Error condition where no relevant environment variable is set.
✨ **Result:** Increased test coverage for configuration directory resolution and ensured the robustness of `FragmentPath`.

---
*PR created automatically by Jules for task [4128794590490322957](https://jules.google.com/task/4128794590490322957) started by @ks1686*