### PR TITLE
🧪 Add test for ensureShell in shell.go

### DIFF
--- a/internal/commands/shell_test.go
+++ b/internal/commands/shell_test.go
@@ -7,6 +7,40 @@ import (
 	"github.com/ks1686/genv/internal/schema"
 )
 
+// ─── ensureShell ─────────────────────────────────────────────────────────────
+
+func TestEnsureShell(t *testing.T) {
+	t.Run("nil shell", func(t *testing.T) {
+		f := &schema.GenvFile{SchemaVersion: schema.Version}
+		ensureShell(f)
+		if f.Shell == nil {
+			t.Fatal("expected Shell to be initialized")
+		}
+		if f.SchemaVersion != schema.Version3 {
+			t.Errorf("expected schemaVersion %q, got %q", schema.Version3, f.SchemaVersion)
+		}
+	})
+
+	t.Run("existing shell", func(t *testing.T) {
+		f := &schema.GenvFile{
+			SchemaVersion: schema.Version,
+			Shell: &schema.ShellConfig{
+				Aliases: map[string]schema.ShellAlias{"ll": {Value: "ls -la"}},
+			},
+		}
+		ensureShell(f)
+		if f.Shell == nil {
+			t.Fatal("expected Shell to remain initialized")
+		}
+		if _, ok := f.Shell.Aliases["ll"]; !ok {
+			t.Error("expected existing shell config to be preserved")
+		}
+		if f.SchemaVersion != schema.Version3 {
+			t.Errorf("expected schemaVersion %q, got %q", schema.Version3, f.SchemaVersion)
+		}
+	})
+}
+
 // ─── ShellAliasSet ───────────────────────────────────────────────────────────
 
 func TestShellAliasSet_New(t *testing.T) {


### PR DESCRIPTION
🎯 **What:** Added tests for the `ensureShell` function in `internal/commands/shell.go` to cover its initialization and upgrade behavior.

📊 **Coverage:**
- Covered the scenario where `f.Shell` is initially `nil`, verifying it gets initialized and schema is upgraded to Version3.
- Covered the scenario where `f.Shell` already contains data, verifying the existing aliases/config are preserved while schema is still upgraded to Version3.

✨ **Result:** Improved test coverage for `internal/commands/shell.go`, ensuring regressions aren't introduced to this utility function.

---
*PR created automatically by Jules for task [11417263664583398750](https://jules.google.com/task/11417263664583398750) started by @ks1686*