### PR TITLE
🧪 Add test for FragmentPath in shellcfg.go

### DIFF
--- a/internal/shellcfg/shellcfg_test.go
+++ b/internal/shellcfg/shellcfg_test.go
@@ -333,7 +333,7 @@ func TestFragmentPath(t *testing.T) {
 
 	t.Run("Error Condition", func(t *testing.T) {
 		t.Setenv("XDG_CONFIG_HOME", "")
-		t.Setenv("HOME", "") // Without HOME, os.UserHomeDir fails on unix
+		t.Setenv("HOME", "")        // Without HOME, os.UserHomeDir fails on unix
 		t.Setenv("USERPROFILE", "") // For Windows compatibility in test logic
 
 		path, err := FragmentPath()

--- a/internal/shellcfg/shellcfg_test.go
+++ b/internal/shellcfg/shellcfg_test.go
@@ -301,3 +301,47 @@ func TestSpecToLock_Roundtrip(t *testing.T) {
 		t.Errorf("source roundtrip failed: %+v", lsc.Source)
 	}
 }
+
+// ─── FragmentPath ────────────────────────────────────────────────────────────
+
+func TestFragmentPath(t *testing.T) {
+	t.Run("XDG_CONFIG_HOME set", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "/custom/xdg")
+		path, err := FragmentPath()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join("/custom/xdg", "genv", "shell.sh")
+		if path != want {
+			t.Errorf("expected %q, got %q", want, path)
+		}
+	})
+
+	t.Run("Fallback to HOME", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "")
+		t.Setenv("HOME", "/custom/home")
+
+		path, err := FragmentPath()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join("/custom/home", ".config", "genv", "shell.sh")
+		if path != want {
+			t.Errorf("expected %q, got %q", want, path)
+		}
+	})
+
+	t.Run("Error Condition", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "")
+		t.Setenv("HOME", "") // Without HOME, os.UserHomeDir fails on unix
+		t.Setenv("USERPROFILE", "") // For Windows compatibility in test logic
+
+		path, err := FragmentPath()
+		if err == nil {
+			t.Fatal("expected error when HOME is not set, got nil")
+		}
+		if path != "" {
+			t.Errorf("expected empty path on error, got %q", path)
+		}
+	})
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for `FragmentPath()` in `internal/shellcfg/shellcfg.go`.
📊 **Coverage:** Added tests to cover scenarios where `XDG_CONFIG_HOME` is set, where it falls back to `$HOME/.config`, and where both are missing leading to an error.
✨ **Result:** Improved test coverage and reliability for path resolution functions related to shell fragment generation.

---
*PR created automatically by Jules for task [6864191306163124736](https://jules.google.com/task/6864191306163124736) started by @ks1686*