### PR TITLE
🧪 Add tests for fprint wrappers in resolver package

### DIFF
--- a/internal/resolver/fprint_test.go
+++ b/internal/resolver/fprint_test.go
@@ -1,0 +1,59 @@
+package resolver
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+type errorWriter struct{}
+
+func (w *errorWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("simulated error")
+}
+
+func TestFprintf(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var buf bytes.Buffer
+		fprintf(&buf, "hello %s", "world")
+		if got := buf.String(); got != "hello world" {
+			t.Errorf("fprintf() = %q, want %q", got, "hello world")
+		}
+	})
+
+	t.Run("error ignored", func(t *testing.T) {
+		ew := &errorWriter{}
+		// If this panicked, the test would fail. We just ensure it doesn't crash.
+		fprintf(ew, "hello %s", "world")
+	})
+}
+
+func TestFPrintln(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var buf bytes.Buffer
+		fPrintln(&buf, "hello", "world")
+		if got := buf.String(); got != "hello world\n" {
+			t.Errorf("fPrintln() = %q, want %q", got, "hello world\n")
+		}
+	})
+
+	t.Run("error ignored", func(t *testing.T) {
+		ew := &errorWriter{}
+		fPrintln(ew, "hello", "world")
+	})
+}
+
+func TestFprint(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var buf bytes.Buffer
+		fprint(&buf, "hello", " world")
+		if got := buf.String(); got != "hello world" {
+			t.Errorf("fprint() = %q, want %q", got, "hello world")
+		}
+	})
+
+	t.Run("error ignored", func(t *testing.T) {
+		ew := &errorWriter{}
+		fprint(ew, "hello", "world")
+	})
+}


### PR DESCRIPTION
🎯 **What:** The `internal/resolver/resolver.go` file contains three internal helper functions `fprintf`, `fPrintln`, and `fprint` to wrap `fmt` print functions, ignoring any errors. These functions were previously not covered by any tests.
📊 **Coverage:** A new file `internal/resolver/fprint_test.go` has been introduced. Tests verify two cases for each function: the success case using `bytes.Buffer` to confirm the accurate payload gets processed as strings; and an ignored error case utilizing an `errorWriter` mock to confidently assure that a simulated internal return error doesn't cause panics or get bubbled up.
✨ **Result:** Test coverage in the `resolver` package has improved and it's been confirmed that string format methods act exactly as they should (writing bytes appropriately while purposefully discarding I/O errors), bolstering codebase reliability against potential regression.

---
*PR created automatically by Jules for task [2907063560217288744](https://jules.google.com/task/2907063560217288744) started by @ks1686*