### PR TITLE
🧪 test(env): Add tests for FragmentPath in env.go

### DIFF
--- a/internal/env/fragment_test.go
+++ b/internal/env/fragment_test.go
@@ -1,0 +1,42 @@
+package env_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ks1686/genv/internal/env"
+)
+
+func TestFragmentPath(t *testing.T) {
+	t.Run("with XDG_CONFIG_HOME", func(t *testing.T) {
+		xdgDir := "/tmp/myxdg"
+		t.Setenv("XDG_CONFIG_HOME", xdgDir)
+
+		got, err := env.FragmentPath()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join(xdgDir, "genv", "env.sh")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without XDG_CONFIG_HOME", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "")
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skipf("skipping test: os.UserHomeDir failed: %v", err)
+		}
+
+		got, err := env.FragmentPath()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join(home, ".config", "genv", "env.sh")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
🎯 **What:** Added tests to cover the `FragmentPath` function in `internal/env/env.go`, which is responsible for returning the correct path to the managed shell fragment.
📊 **Coverage:** Two scenarios are now tested:
  - When `XDG_CONFIG_HOME` is set, it properly paths to `$XDG_CONFIG_HOME/genv/env.sh`.
  - When `XDG_CONFIG_HOME` is absent, it properly falls back to `<UserHomeDir>/.config/genv/env.sh`.
✨ **Result:** Enhanced test coverage and ensured predictable behavior for shell fragment resolution logic.

---
*PR created automatically by Jules for task [273581601916093874](https://jules.google.com/task/273581601916093874) started by @ks1686*