### PR TITLE
🧪 Add unit tests for ApplyEnv in env.go

### DIFF
--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -229,3 +229,112 @@ func TestEnvStatus_Modified(t *testing.T) {
 		t.Errorf("expected 1 modified entry, got %v", entries)
 	}
 }
+
+// ─── ApplyEnv ───────────────────────────────────────────────────────────────
+
+func TestApplyEnv_Basic(t *testing.T) {
+	dir := t.TempDir()
+	frag := filepath.Join(dir, "env.sh")
+	rc1 := filepath.Join(dir, ".bashrc")
+	rc2 := filepath.Join(dir, ".zshrc")
+
+	vars := map[string]schema.EnvVar{
+		"FOO": {Value: "bar"},
+	}
+
+	if err := ApplyEnv(frag, vars, []string{rc1, rc2}); err != nil {
+		t.Fatalf("ApplyEnv: %v", err)
+	}
+
+	// Verify fragment
+	got, err := ReadFragment(frag)
+	if err != nil {
+		t.Fatalf("ReadFragment: %v", err)
+	}
+	if got["FOO"] != "bar" {
+		t.Errorf("got %q, want %q", got["FOO"], "bar")
+	}
+
+	// Verify rc injection
+	for _, rc := range []string{rc1, rc2} {
+		data, err := os.ReadFile(rc)
+		if err != nil {
+			t.Fatalf("reading %s: %v", rc, err)
+		}
+		if !strings.Contains(string(data), frag) {
+			t.Errorf("expected fragment path in %s", rc)
+		}
+	}
+}
+
+func TestApplyEnv_EmptyVars(t *testing.T) {
+	dir := t.TempDir()
+	frag := filepath.Join(dir, "env.sh")
+	rc := filepath.Join(dir, ".bashrc")
+
+	// Pre-create fragment
+	if err := WriteFragment(frag, map[string]schema.EnvVar{"X": {Value: "1"}}); err != nil {
+		t.Fatalf("WriteFragment: %v", err)
+	}
+
+	if err := ApplyEnv(frag, nil, []string{rc}); err != nil {
+		t.Fatalf("ApplyEnv: %v", err)
+	}
+
+	// Fragment should be removed
+	if _, err := os.Stat(frag); !os.IsNotExist(err) {
+		t.Error("expected fragment to be removed")
+	}
+
+	// RC file should not be created/modified
+	if _, err := os.Stat(rc); !os.IsNotExist(err) {
+		t.Error("expected rc file to not be created")
+	}
+}
+
+func TestApplyEnv_WriteError(t *testing.T) {
+	dir := t.TempDir()
+	// Create a directory where the fragment should be, causing a write error
+	frag := filepath.Join(dir, "env.sh")
+	if err := os.MkdirAll(frag, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	vars := map[string]schema.EnvVar{
+		"FOO": {Value: "bar"},
+	}
+
+	err := ApplyEnv(frag, vars, nil)
+	if err == nil {
+		t.Error("expected error from WriteFragment, got nil")
+	}
+}
+
+func TestApplyEnv_InjectErrorNonFatal(t *testing.T) {
+	dir := t.TempDir()
+	frag := filepath.Join(dir, "env.sh")
+	rc := filepath.Join(dir, ".bashrc")
+
+	// Create a directory where the rc file should be, causing an inject error
+	if err := os.MkdirAll(rc, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	vars := map[string]schema.EnvVar{
+		"FOO": {Value: "bar"},
+	}
+
+	// Should not return an error despite inject failure
+	if err := ApplyEnv(frag, vars, []string{rc}); err != nil {
+		t.Fatalf("ApplyEnv: %v", err)
+	}
+
+	// Check fragment was still written
+	got, err := ReadFragment(frag)
+	if err != nil {
+		t.Fatalf("ReadFragment: %v", err)
+	}
+	if got["FOO"] != "bar" {
+		t.Errorf("got %q, want %q", got["FOO"], "bar")
+	}
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of test coverage for the `ApplyEnv` function in `internal/env/env.go`.

📊 **Coverage:** What scenarios are now tested
The following test scenarios have been implemented:
1. `TestApplyEnv_Basic`: Covers the happy path where environment variables are correctly written to the managed fragment and injected into shell rc files.
2. `TestApplyEnv_EmptyVars`: Verifies that `ApplyEnv` removes the fragment and skips rc file injection when the vars map is empty.
3. `TestApplyEnv_WriteError`: Ensures that errors from `WriteFragment` are properly propagated by attempting to write to a path that is actually a directory.
4. `TestApplyEnv_InjectErrorNonFatal`: Confirms that `InjectSourceLine` failures are treated as non-fatal warnings and do not block the application of the variables.

✨ **Result:** The improvement in test coverage
`ApplyEnv` logic is now fully covered, including correct propagation of expected errors and confirmation of its internal non-fatal failure handling loop.

---
*PR created automatically by Jules for task [10281493080161014212](https://jules.google.com/task/10281493080161014212) started by @ks1686*