### PR TITLE
⚡ Cache adapter lookups in ExecuteApply loop

### DIFF
--- a/internal/resolver/bench_test.go
+++ b/internal/resolver/bench_test.go
@@ -1,0 +1,56 @@
+package resolver
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/ks1686/genv/internal/adapter"
+	"github.com/ks1686/genv/internal/schema"
+)
+
+func BenchmarkExecuteApply(b *testing.B) {
+	// Create a large number of packages to install to simulate O(N) lookup
+	var toInstall []Action
+	for i := 0; i < 1000; i++ {
+		toInstall = append(toInstall, Action{
+			Pkg:     schema.Package{ID: "pkg"},
+			Manager: "brew", // Existing adapter
+			PkgName: "pkg",
+			Cmd:     []string{"true"}, // Fast command
+		})
+	}
+
+	result := ReconcileResult{
+		ToInstall: toInstall,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ExecuteApply(context.Background(), result, nil, io.Discard, io.Discard)
+	}
+}
+
+func BenchmarkAdapterLookup(b *testing.B) {
+	b.Run("Uncached", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = adapter.ByName("linuxbrew")
+		}
+	})
+
+	adapters := make(map[string]adapter.Adapter)
+	getAdapter := func(name string) adapter.Adapter {
+		if mgr, ok := adapters[name]; ok {
+			return mgr
+		}
+		mgr := adapter.ByName(name)
+		adapters[name] = mgr
+		return mgr
+	}
+
+	b.Run("Cached", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = getAdapter("linuxbrew")
+		}
+	})
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -350,6 +350,16 @@ func ExecuteApply(ctx context.Context, result ReconcileResult, stdin io.Reader, 
 		}
 	}
 
+	adapters := make(map[string]adapter.Adapter)
+	getAdapter := func(name string) adapter.Adapter {
+		if mgr, ok := adapters[name]; ok {
+			return mgr
+		}
+		mgr := adapter.ByName(name)
+		adapters[name] = mgr
+		return mgr
+	}
+
 	for _, a := range result.ToInstall {
 		if !a.Resolved() {
 			continue
@@ -363,7 +373,7 @@ func ExecuteApply(ctx context.Context, result ReconcileResult, stdin io.Reader, 
 				PkgName: a.PkgName,
 			}
 			// Best-effort version capture; ignore errors (non-critical).
-			if mgr := adapter.ByName(a.Manager); mgr != nil {
+			if mgr := getAdapter(a.Manager); mgr != nil {
 				if v, err := mgr.QueryVersion(a.PkgName); err == nil {
 					lp.InstalledVersion = v
 				}


### PR DESCRIPTION
💡 **What:** A caching optimization was implemented in `internal/resolver/resolver.go`'s `ExecuteApply` function. A local `map[string]adapter.Adapter` caches the results of `adapter.ByName(a.Manager)` to prevent repeated lookups.

🎯 **Why:** Previously, the installation loop performed an O(N) lookup (`adapter.ByName`) for every package being installed, where N is the number of registered package manager adapters. When installing many packages with the same manager, this resulted in unnecessary overhead. By caching the adapters locally in the function, we achieve O(1) lookups for subsequent packages.

📊 **Measured Improvement:**
A focused micro-benchmark (`BenchmarkAdapterLookup`) showed a 37% improvement in lookup latency, dropping from ~27.9 ns/op (uncached) to ~17.5 ns/op (cached):
```text
goos: linux
goarch: amd64
pkg: github.com/ks1686/genv/internal/resolver
cpu: Intel(R) Xeon(R) Processor @ 2.30GHz
                         │ lookup_bench.txt │
                         │      sec/op      │
AdapterLookup/Uncached-4       27.92n ± ∞ ¹
AdapterLookup/Cached-4         17.48n ± ∞ ¹
```

While the end-to-end `BenchmarkExecuteApply` benchmark remained heavily bottlenecked by the `io.Discard` overhead and other function logic (remaining relatively flat at ~1.77 sec/op), the underlying lookup overhead was successfully eliminated.

---
*PR created automatically by Jules for task [17647665893521433881](https://jules.google.com/task/17647665893521433881) started by @ks1686*