### PR TITLE
🔒 Fix path traversal in systemd and launchd service generation

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -15,10 +15,10 @@ import (
 )
 
 // systemdUnitName returns the systemd unit name for a genv-managed service.
-func systemdUnitName(name string) string { return "genv-" + name + ".service" }
+func systemdUnitName(name string) string { return "genv-" + filepath.Base(name) + ".service" }
 
 // launchdPlistName returns the launchd plist filename for a genv-managed service.
-func launchdPlistName(name string) string { return "genv." + name + ".plist" }
+func launchdPlistName(name string) string { return "genv." + filepath.Base(name) + ".plist" }
 
 // SystemdLogsHint returns the journalctl command users should run to view logs for name.
 func SystemdLogsHint(name string) string {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -259,3 +259,16 @@ func TestLaunchdPlistContent(t *testing.T) {
 		}
 	}
 }
+
+func TestSystemdUnitName_PathTraversal(t *testing.T) {
+	name := "../../../evil"
+	unitName := systemdUnitName(name)
+	if strings.Contains(unitName, "/") || strings.Contains(unitName, "..") {
+		t.Errorf("systemdUnitName(%q) = %q; want no directory traversal characters", name, unitName)
+	}
+
+	plistName := launchdPlistName(name)
+	if strings.Contains(plistName, "/") || strings.Contains(plistName, "..") {
+		t.Errorf("launchdPlistName(%q) = %q; want no directory traversal characters", name, plistName)
+	}
+}


### PR DESCRIPTION
🎯 **What:** 
Fixed a path traversal vulnerability in `systemdUnitName` and `launchdPlistName` within `internal/service/service.go`. By explicitly using `filepath.Base` on the user-provided `name` argument, we ensure that the resulting file names (`genv-*.service` or `genv.*.plist`) do not contain directory separators or escape sequences like `../`. 

⚠️ **Risk:** 
If an attacker provides a service name like `../../../evil`, the previous code would directly concatenate it into the file path. This would result in files being written or overwritten outside the designated user service directories (`~/.config/systemd/user` and `~/Library/LaunchAgents`), leading to an unauthenticated arbitrary file write vulnerability within the user's home directory. This could potentially allow arbitrary command execution or privilege escalation if placed in sensitive configuration locations.

🛡️ **Solution:**
Wrapped the `name` argument with `filepath.Base()` in both functions. This strips away all directory components and ensures only the final base name is utilized to form the unit name. A unit test `TestSystemdUnitName_PathTraversal` was added to verify the robustness of this solution against directory traversal attempts.

---
*PR created automatically by Jules for task [12250353173802021573](https://jules.google.com/task/12250353173802021573) started by @ks1686*