### PR TITLE
🔒 Fix Path Traversal in Systemd Unit File Removal

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -15,10 +15,18 @@ import (
 )
 
 // systemdUnitName returns the systemd unit name for a genv-managed service.
-func systemdUnitName(name string) string { return "genv-" + name + ".service" }
+func systemdUnitName(name string) string {
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, "\\", "-")
+	return "genv-" + name + ".service"
+}
 
 // launchdPlistName returns the launchd plist filename for a genv-managed service.
-func launchdPlistName(name string) string { return "genv." + name + ".plist" }
+func launchdPlistName(name string) string {
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, "\\", "-")
+	return "genv." + name + ".plist"
+}
 
 // SystemdLogsHint returns the journalctl command users should run to view logs for name.
 func SystemdLogsHint(name string) string {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -259,3 +259,31 @@ func TestLaunchdPlistContent(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizeUnitName(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"normal", "normal"},
+		{"../../foo", "..-..-foo"},
+		{"foo/bar\\baz", "foo-bar-baz"},
+		{"C:\\windows\\path", "C:-windows-path"},
+	}
+
+	for _, tc := range cases {
+		// systemd unit
+		gotSystemd := systemdUnitName(tc.name)
+		wantSystemd := "genv-" + tc.want + ".service"
+		if gotSystemd != wantSystemd {
+			t.Errorf("systemdUnitName(%q) = %q, want %q", tc.name, gotSystemd, wantSystemd)
+		}
+
+		// launchd plist
+		gotLaunchd := launchdPlistName(tc.name)
+		wantLaunchd := "genv." + tc.want + ".plist"
+		if gotLaunchd != wantLaunchd {
+			t.Errorf("launchdPlistName(%q) = %q, want %q", tc.name, gotLaunchd, wantLaunchd)
+		}
+	}
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `systemdUnitName` and `launchdPlistName` functions did not sanitize the `name` argument, allowing path traversal (e.g., `../../foo`). This could lead to malicious service names bypassing the intended unit directory and creating or deleting files elsewhere.

⚠️ **Risk:** The potential impact if left unfixed
A malicious `genv.json` file specifying a maliciously crafted service name could trigger the arbitrary deletion or creation of files on the host system within the context of the user running `genv`.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced all occurrences of `/` and `\` with `-` in `systemdUnitName` and `launchdPlistName`. This sanitizes the user input, ensuring the generated filenames cannot contain path separators and will safely remain within `~/.config/systemd/user` or `~/Library/LaunchAgents`. Tests were added to verify the sanitization.

---
*PR created automatically by Jules for task [3177672218832085971](https://jules.google.com/task/3177672218832085971) started by @ks1686*