### PR TITLE
🔒 Prevent Command Injection in editCmd

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,14 @@ var safeEditors = map[string]bool{
 	"code":  true,
 }
 
+var safeFlags = map[string]bool{
+	"--wait": true,
+	"-w":     true,
+	"-R":     true,
+	"-nw":    true,
+	"-n":     true,
+}
+
 func main() {
 	os.Exit(run(os.Args[1:]))
 }
@@ -2058,6 +2066,12 @@ func buildEditorCmd(editor, file string) (*exec.Cmd, error) {
 	base := filepath.Base(bin)
 	if !safeEditors[base] {
 		return nil, fmt.Errorf("editor %q is not allowed; must be one of: vi, vim, nano, emacs, code", bin)
+	}
+
+	for _, arg := range fields[1:] {
+		if !safeFlags[arg] {
+			return nil, fmt.Errorf("editor flag %q is not allowed; only safe flags are permitted", arg)
+		}
 	}
 
 	args := append(fields[1:], file)


### PR DESCRIPTION
🎯 What: Prevented command injection in editCmd when using EDITOR/VISUAL by whitelisting arguments to the editor binary.
⚠️ Risk: An attacker controlling the EDITOR or VISUAL environment variable could inject arbitrary arguments (e.g. -c '!sh') enabling them to execute arbitrary commands when genv edit was run.
🛡️ Solution: Updated buildEditorCmd to validate all provided flags against a predefined strict safeFlags map. Any unexpected arguments will prevent the editor from executing.

---
*PR created automatically by Jules for task [2444113978595055019](https://jules.google.com/task/2444113978595055019) started by @ks1686*