### PR TITLE
🔒 Fix path traversal in launchd plist creation

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -18,6 +18,7 @@ import (
 func systemdUnitName(name string) string {
 	name = strings.ReplaceAll(name, "/", "-")
 	name = strings.ReplaceAll(name, "\\", "-")
+	name = strings.ReplaceAll(name, "..", "")
 	return "genv-" + name + ".service"
 }
 
@@ -25,6 +26,7 @@ func systemdUnitName(name string) string {
 func launchdPlistName(name string) string {
 	name = strings.ReplaceAll(name, "/", "-")
 	name = strings.ReplaceAll(name, "\\", "-")
+	name = strings.ReplaceAll(name, "..", "")
 	return "genv." + name + ".plist"
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -279,7 +279,7 @@ func TestSanitizeUnitName(t *testing.T) {
 		want string
 	}{
 		{"normal", "normal"},
-		{"../../foo", "..-..-foo"},
+		{"../../foo", "--foo"},
 		{"foo/bar\\baz", "foo-bar-baz"},
 		{"C:\\windows\\path", "C:-windows-path"},
 	}


### PR DESCRIPTION
🎯 **What:** Added explicit sanitization for ".." in service names for both systemd and launchd.
⚠️ **Risk:** An attacker or malicious configuration could construct names containing "..", potentially causing files to be written outside the intended LaunchAgents or systemd user directories.
🛡️ **Solution:** Updated `launchdPlistName` and `systemdUnitName` functions to strip out any ".." characters, preventing recursive directory traversal while retaining the hyphen replacement logic for path separators so that sub-services like `frontend/app` cleanly become `frontend-app` instead of truncating.

---
*PR created automatically by Jules for task [5489820551304973507](https://jules.google.com/task/5489820551304973507) started by @ks1686*