### PR TITLE
Scheduler and platform correctness for managed updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Automatic manager discovery is now platform-native: macOS search, scan, and implicit resolution use `brew` without duplicate `linuxbrew` suggestions, while Linux uses `linuxbrew`. Explicit `prefer` and `managers` configuration remains authoritative when the selected manager is available.
+- Managed update jobs now receive a deterministic package-manager `PATH` under launchd and systemd, and `genv updates status` distinguishes registration, active execution, successful runs, and failed runs using real supervisor state.
+- `genv upgrade` and managed updates conservatively skip version-constrained packages when an adapter cannot guarantee a compatible target instead of issuing an unsafe latest-version upgrade.
+- Scheduled auto-apply now fails closed when its audit log cannot be opened, records each failed action with its tracked package IDs, and retains bounded, credential-redacted manager diagnostics.
+
 ## v3.0.1 - 2026-07-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -440,7 +440,9 @@ When you run `genv apply`:
 
 `genv updates start` registers a user-level scheduled job using `systemd --user` on Linux or `launchd` on macOS. The scheduled command is a one-shot `genv updates __run-once` inside the genv binary; the platform supervisor owns the interval and restart lifecycle. Unsupported platforms report a clear message instead of crashing.
 
-The managed checker logs to `~/.config/genv/updates.log` (respecting `$XDG_CONFIG_HOME`) and rotates that file to `updates.log.1` after roughly 1 MiB. On each interval it runs the shared upgrade planner against tracked packages only, logs the result, and sends a best-effort notification when `updates.notify:true` and a notifier binary is available.
+The generated job carries a deterministic `PATH` built from the invoking shell plus platform defaults, including Homebrew locations on macOS and Linuxbrew locations on Linux. Rerun `genv updates start` after upgrading genv to regenerate an existing unit or plist with the current command and environment.
+
+The managed checker logs to `~/.config/genv/updates.log` (respecting `$XDG_CONFIG_HOME`) and rotates that file to `updates.log.1` after roughly 1 MiB. On each interval it runs the shared upgrade planner against tracked packages only, logs the result, and sends a best-effort notification when `updates.notify:true` and a notifier binary is available. Auto-apply refuses to run if the audit log cannot be opened. Failed actions include their tracked package IDs, and manager diagnostics are bounded and credential-redacted before logging.
 
 The default background behavior is **check/log/notify only**. It does not apply package upgrades unless the spec explicitly sets:
 
@@ -455,7 +457,7 @@ The default background behavior is **check/log/notify only**. It does not apply 
 }
 ```
 
-`genv updates start` refuses a missing, disabled, or invalid `updates` block with a corrective hint. Use `genv updates status` to inspect the registered checker and `genv updates stop` to remove it.
+`genv updates start` refuses a missing, disabled, or invalid `updates` block with a corrective hint. Use `genv updates status` to distinguish an unregistered checker, an executing job, an idle checker, and the last known success or failure. Use `genv updates stop` to remove it.
 
 `genv updates start` flags:
 
@@ -539,6 +541,8 @@ Unresolved packages (no compatible manager found) produce a warning. Use `--stri
 ## How upgrades work
 
 `genv upgrade` updates the packages recorded in `genv.lock.json` without touching packages that are installed but not tracked by genv.
+
+Packages with a non-empty `version` constraint are skipped unless their adapter can guarantee an explicit compatible upgrade target. Current adapters do not expose that capability, so genv reports `version-constrained package requires an explicit compatible target` and continues with eligible unconstrained packages instead of upgrading the constrained package to an unsafe latest version. The same rule protects `genv updates` because both commands use the shared planner.
 
 To minimize the number of subprocesses, genv groups tracked packages by their recorded package manager and issues one batched upgrade command per manager when the underlying tool supports it:
 

--- a/docs/handoffs/2026-07-13-scheduler-platform-correctness.md
+++ b/docs/handoffs/2026-07-13-scheduler-platform-correctness.md
@@ -1,0 +1,292 @@
+# Scheduler and Platform Correctness Handoff
+
+Date: 2026-07-13  
+Repository: `/Users/ks1686/Documents/Repos/genv`  
+Branch: `codex/scheduler-platform-correctness`  
+Starting commit: `dc31d11`  
+Status: implementation is nearly complete, uncommitted, with one validated correctness blocker remaining
+
+## Read this first
+
+The approved design and execution plan are:
+
+- `docs/superpowers/specs/2026-07-12-scheduler-platform-correctness-design.md`
+- `docs/superpowers/plans/2026-07-12-scheduler-platform-correctness.md`
+
+Task evidence is under `.superpowers/sdd/task-{1..5}-report.md`. The durable progress ledger is `.superpowers/sdd/progress.md`.
+
+Do not stage, commit, push, install the development binary, or replace the live scheduler job unless the user explicitly authorizes that action. Developer ID signing/notarization is intentionally out of scope.
+
+## Original objective and decisions
+
+The user wanted every genv-supported tracked package covered by managed updates and asked to fix the core defects discovered while enabling that workflow.
+
+Binding decisions:
+
+- macOS automatic search, scan, and implicit resolution use `brew`, not `linuxbrew`;
+- Linux automatic paths use `linuxbrew`, not `brew`;
+- explicit `prefer` or `managers` configuration can still select either identity when the shared `brew` executable is available;
+- scheduled jobs inherit a sanitized, augmented package-manager `PATH`;
+- scheduler status must distinguish unsupported, unregistered, idle, executing, last success, and last failure;
+- a constrained package must not receive an unsafe broad latest-version upgrade;
+- scheduled auto-apply must fail closed without an audit log and retain bounded, credential-safe diagnostics;
+- no real package upgrades may run during tests or QA.
+
+## Completed implementation
+
+### Platform-native automatic managers
+
+- New policy: `internal/adapter/platform.go`
+- Search filter: `internal/search/search.go`
+- Implicit resolver filter: `internal/resolver/resolver.go`
+- Scan filter and test seam: `main.go`
+- Tests cover Darwin/Linux automatic behavior, explicit cross-platform selection, and a real `scan` command no-call regression.
+
+The physical availability map remains deliberately unfiltered so explicit configuration still works.
+
+### Scheduled environment
+
+- New PATH construction/rendering: `internal/service/scheduled_environment.go`
+- `ScheduledJob` now carries `Environment map[string]string`.
+- Both launchd and systemd render deterministic environment data.
+- `updates start` captures the invoking PATH, removes empty/relative/duplicate entries, and appends platform defaults.
+
+### Scheduler status
+
+- New typed parser/status boundary: `internal/service/scheduled_status.go`
+- CLI formatting: `main_updates_daemon.go`
+- Launchd parsing already handles:
+  - top-level state without nested coalition-state overwrite;
+  - `last exit code = 78: EX_CONFIG`;
+  - `last exit code = (never exited)`;
+  - missing job versus inspection failure.
+- Systemd timer and service queries already use different property sets.
+
+One systemd ambiguity remains and is described below.
+
+### Constraint-safe upgrades
+
+- Shared planner change: `internal/upgrade/planner.go`
+- Non-empty package constraints are skipped with the exact reason:
+
+  `version-constrained package requires an explicit compatible target`
+
+- Filters retain their existing precedence.
+- Constrained entries are removed before batch construction, while unconstrained packages continue.
+- Both `genv upgrade` and `genv updates` use this planner.
+
+### Scheduled audit logging and diagnostics
+
+- New bounded/redacted diagnostics: `main_updates_diagnostics.go`
+- Logger initialization errors now stop the hidden worker before planning or execution.
+- Typed `UpgradeFailure` data preserves tracked IDs through resolver and upgrade layers.
+- Each failure is logged individually; unmatched legacy errors still get a fallback event.
+- Raw capture and post-redaction output are both capped at 64 KiB with a visible truncation marker.
+- Credential-bearing lines and IDs are redacted; stdin and environment are never captured.
+- Interactive upgrade stream behavior is unchanged.
+
+### Documentation
+
+- `README.md` documents scheduler PATH/status, fail-closed audit logging, and conservative constraint behavior.
+- `CHANGELOG.md` has Unreleased fixes for all four areas.
+
+## Remaining correctness blocker
+
+The final goal review found that systemd status can falsely report a never-executed oneshot service as a successful completed run.
+
+Current logic in `internal/service/scheduled_status.go` treats:
+
+```text
+Result=success
+ExecMainStatus=0
+```
+
+as proof of a completed success. systemd can expose those zero/success defaults before the service has ever executed, so this violates the required distinction between “registered and idle; no completed run is known” and “last run succeeded.”
+
+### Recommended fix
+
+Use a stable service execution marker, preferably `ExecMainStartTimestampMonotonic`:
+
+1. Add `ExecMainStartTimestampMonotonic` to the service `systemctl --user show` property list in `systemdScheduledStatus`.
+2. Require it in the service completeness check in `parseSystemdScheduledStatus`.
+3. Parse it as an unsigned integer.
+4. If it is empty or zero, keep `LastRun=ScheduledRunUnknown` regardless of default `Result=success` and `ExecMainStatus=0`.
+5. If the service is currently executing, report `Executing=true` and do not claim a completed outcome for the active invocation; `LastRun=unknown` is the conservative value because the current start has replaced the service execution fields.
+6. Only interpret `Result` and `ExecMainStatus` when the start timestamp is non-zero and the service is no longer executing.
+7. Malformed timestamp text should produce conservative registered/unknown status with a malformed-output detail.
+
+Verify the property contract against official systemd documentation if network access is available. Previous web/HTTP attempts failed because the Codex session exhausted process descriptors; no documentation result was obtained.
+
+### Required RED tests
+
+Add realistic fixtures in `internal/service/scheduled_status_test.go`:
+
+- never run: inactive/dead, `Result=success`, `ExecMainStatus=0`, `ExecMainStartTimestampMonotonic=0` -> registered, idle, last run unknown;
+- completed success: inactive/dead, success/0, positive start timestamp -> last run success;
+- completed failure: failed/failed, non-zero status, positive timestamp -> last run failure;
+- first execution in progress: active/running, positive timestamp, default success/0 -> executing, last run unknown;
+- malformed timestamp -> registered/unknown with explanatory detail;
+- command assertion verifies the service query requests `--property=ExecMainStartTimestampMonotonic`, while the timer query does not.
+
+Run before production changes and capture the expected failure:
+
+```bash
+go test ./internal/service . -run 'Scheduled.*Status|UpdatesStatus' -count=1
+```
+
+Then implement minimally, format, and rerun:
+
+```bash
+gofmt -w internal/service/scheduled_status.go internal/service/scheduled_status_test.go
+go test ./internal/service . -run 'Scheduled.*Status|UpdatesStatus' -count=1
+go test -race -shuffle=on -count=1 ./internal/service .
+```
+
+Append RED/GREEN evidence to `.superpowers/sdd/task-3-report.md`.
+
+## Verification already completed
+
+Successful gates on the current diff before the remaining systemd fix:
+
+```text
+go test -count=1 ./internal/adapter ./internal/search ./internal/resolver ./internal/service ./internal/upgrade .
+PASS
+
+go test -race -shuffle=on -count=1 ./...
+PASS, all packages
+
+go vet ./...
+PASS
+
+go build -o .omo/session-work/genv-qa .
+PASS
+
+make ci
+PASS, total statement coverage 68.1%
+
+git diff --check
+PASS
+```
+
+Relevant resolver benchmarks passed:
+
+```text
+BenchmarkPlanUpgradeAdapterLookup-14    84000 ns/op
+BenchmarkDetect-14                  114711542 ns/op
+BenchmarkResolve-14                     16875 ns/op
+```
+
+Command:
+
+```bash
+go test -run '^$' -bench 'Benchmark(Detect|Resolve|PlanUpgradeAdapterLookup)$' -benchtime=1x ./internal/resolver
+```
+
+`make bench` is not a useful bounded gate in this repository: it also runs `BenchmarkExecuteApply`, which spawns `true` 1,000 times. It was stopped after 78.235 seconds with no result. Use the relevant benchmark selection above unless intentionally waiting for the subprocess benchmark.
+
+### Known pre-existing lint failures
+
+`make lint` fails on 12 findings outside this change. Do not silently fold these into this fix:
+
+- unchecked errors and one ineffectual assignment in `main_profile_test.go`;
+- unchecked `in.Close()` in `main_pull.go`;
+- an ST1005 test sentinel in `internal/files/links_test.go`;
+- SA4006 and an unused helper in pre-existing `main.go` apply code.
+
+All changed files passed formatting and the compiler/race suite. If Claude chooses to repair lint, treat that as a separate scope decision and report it clearly.
+
+## Manual QA evidence
+
+A fresh binary under `.omo/session-work/genv-qa` was used; no install or upgrade executed.
+
+- Automatic macOS apply dry-run resolved `jq` through `brew`.
+- Explicit `prefer: linuxbrew` apply dry-run resolved `jq` through `linuxbrew`.
+- Constrained `upgrade --dry-run` printed no upgrade plan and the exact skip reason.
+- `updates check --json` returned zero batches and the constraint skip.
+- Live launchd status printed:
+
+  `updates checker is registered and idle; last run succeeded (status 0) (genv.updates).`
+
+- Bad `updates status` flag exited 1 with `flag provided but not defined`.
+- Check-only hidden worker exited 0 and wrote `updates.check.planned ... auto_apply=false`.
+- With `XDG_CONFIG_HOME` pointing to a regular file, the hidden worker exited 2 and printed only:
+
+  `genv updates: audit log unavailable`
+
+- Real macOS `scan` completed against scratch files:
+  - 283 packages added;
+  - brew=211, bun=3, gem=48, mas=19, npm=2;
+  - linuxbrew=0.
+- The real config `/Users/ks1686/.config/genv/genv.json` validates and has:
+
+  ```json
+  {"enabled":true,"interval":"24h","autoApply":true}
+  ```
+
+- A read-only `updates check --json` against the real config/lock planned 91 unfiltered tracked batches. No upgrade was executed.
+
+The final goal review noted that the plan literally asked for a search/add candidate-selection QA flow. The automatic and explicit resolution paths were exercised through `apply --dry-run`, and the real scan path was exercised, but no interactive `add` search was run. If practical, add a bounded non-mutating `add` search QA scenario; do not permit it to install anything. If the CLI cannot search without proceeding to installation, document why the apply/scan coverage is the safe equivalent.
+
+## Live system state
+
+- Installed binary: `/opt/homebrew/bin/genv`
+- Installed version: `genv 3.0.1`, commit `f428c0f147e2de0065af168ff9723624daefcfef`
+- The installed binary is not this development build.
+- Live plist: `~/Library/LaunchAgents/genv.updates.plist`
+- Current plist already contains a PATH with Homebrew/system directories, runs every 86,400 seconds, and points at `/opt/homebrew/bin/genv`.
+- The live job was only inspected, not replaced or stopped.
+
+Do not install the development build or rerun `updates start` without explicit authorization. Once a fixed genv binary is installed, rerunning `genv updates start` will regenerate the supervisor artifact using the corrected environment renderer.
+
+## Final verification and review checklist
+
+After fixing the systemd execution marker:
+
+1. Run the focused Task 3 tests and touched-package race tests above.
+2. Run:
+
+   ```bash
+   gofmt -w <all changed Go files>
+   git diff --check
+   go test -race -shuffle=on -count=1 ./...
+   go vet ./...
+   make ci
+   go build -o .omo/session-work/genv-qa .
+   go test -run '^$' -bench 'Benchmark(Detect|Resolve|PlanUpgradeAdapterLookup)$' -benchtime=1x ./internal/resolver
+   ```
+
+3. Repeat the relevant manual status scenario with the fresh binary.
+4. Rerun final goal, QA, code-quality, security, and context/history reviews. The previous five-lane review produced one substantive FAIL (the systemd issue) and four infrastructure failures (`Bad file descriptor` / disconnected streams); those four failures were not counted as passes.
+5. Address every validated blocking finding and rerun the affected review lane.
+6. Update `.superpowers/sdd/progress.md` to mark Task 6 complete and create `.superpowers/sdd/task-6-report.md` with final evidence.
+7. Confirm no test, benchmark, debugger, or QA process remains.
+
+## Cleanup before handoff completion
+
+Current scratch artifacts intentionally remain because the work is not finished:
+
+- `.omo/session-work/` contains the QA binary, fixture specs/locks, generated scan results, logs, and captured error output;
+- `coverage.out` was generated by `make ci`;
+- `.debug-journal.md` contains the runtime hypotheses and cleanup ledger;
+- `.superpowers/sdd/` contains task briefs/reports/progress.
+
+After final verification, use the recoverable `trash` command on macOS for disposable scratch artifacts rather than `rm`:
+
+```bash
+trash .omo/session-work
+trash coverage.out
+trash .debug-journal.md
+```
+
+Decide whether `.superpowers/sdd/` is retained as implementation evidence or trashed as workflow scratch. Keep the approved design, implementation plan, and this handoff unless the user asks for them removed.
+
+Finish with:
+
+```bash
+git status --short
+git diff --check
+git diff --stat
+pgrep -af 'go test|genv-qa|dlv|lldb' || true
+```
+
+The final diff should contain only the requested implementation, direct tests, README/CHANGELOG updates, approved design/plan, and this handoff. Report the pre-existing lint failures separately. Do not claim the branch is complete while the systemd never-run case or any required review lane remains unresolved.

--- a/docs/superpowers/plans/2026-07-12-scheduler-platform-correctness.md
+++ b/docs/superpowers/plans/2026-07-12-scheduler-platform-correctness.md
@@ -1,0 +1,159 @@
+# Scheduler and Platform Correctness Implementation Plan
+
+> **Execution:** Follow this plan task by task with strict RED-GREEN-REFACTOR cycles. Do not implement or test Developer ID signing/notarization.
+
+**Goal:** Make automatic manager suggestions platform-native, make scheduled updates run in a reliable environment with truthful status, prevent unsafe constrained upgrades, and preserve actionable scheduled-run diagnostics.
+
+**Architecture:** Add a reusable automatic-manager policy in `internal/adapter` and call it only from search, scan, and implicit resolver fallback. Extend scheduled jobs with deterministic environment rendering and parse supervisor state into a typed status. Keep version-constraint safety in the shared upgrade planner. Make the hidden updates worker require an audit logger and capture bounded, redacted diagnostics.
+
+**Tech stack:** Go 1.24, standard library, launchd, systemd user units, existing manual CLI/test seams.
+
+---
+
+## Task 1: Platform-native automatic package managers
+
+**Files:**
+
+- Create: `internal/adapter/platform.go`
+- Create: `internal/adapter/platform_test.go`
+- Modify: `internal/search/search.go`
+- Modify: `internal/search/search_test.go`
+- Modify: `internal/resolver/resolver.go`
+- Modify: `internal/resolver/resolver_test.go`
+- Modify: `main.go`
+- Modify: `main_test.go`
+
+1. Add table-driven tests for `AutomaticOnGOOS(manager, goos)` proving Darwin accepts `brew` and rejects `linuxbrew`, Linux does the inverse, and unrelated managers are unchanged.
+2. Add search tests through an OS-parameterized helper proving only the native Homebrew identity is queried.
+3. Add resolver tests proving implicit fallback uses the native identity while explicit `prefer` and `managers` can still choose either available identity.
+4. Extract the scan adapter selection loop into a helper that accepts GOOS and add a CLI-level test proving a Darwin scan does not call Linuxbrew when both identities are detected.
+5. Run the focused tests and confirm they fail for the missing policy:
+
+   ```bash
+   go test ./internal/adapter ./internal/search ./internal/resolver . -run 'AutomaticOnGOOS|Platform|Scan.*Homebrew'
+   ```
+
+6. Implement the minimal policy and thread `runtime.GOOS` through public production entry points while keeping test-only helpers parameterized.
+7. Rerun the focused tests to green, then run the complete touched-package tests.
+
+## Task 2: Deterministic scheduled-job PATH
+
+**Files:**
+
+- Create: `internal/service/scheduled_environment.go`
+- Create: `internal/service/scheduled_environment_test.go`
+- Modify: `internal/service/scheduled.go`
+- Modify: `internal/service/service_test.go`
+- Modify: `main_updates_daemon.go`
+- Modify: `main_test.go`
+
+1. Add table-driven tests for PATH construction: retain only non-empty absolute paths, de-duplicate in first-seen order, and append Darwin/Linux defaults.
+2. Extend scheduled content tests to require systemd `Environment=` and launchd `EnvironmentVariables` output with correctly escaped values.
+3. Extend `TestUpdatesStart_valid_config_registers_scheduler_without_auto_apply` to assert the scheduled job receives the sanitized augmented PATH captured from the invoking process.
+4. Run the focused tests and record RED:
+
+   ```bash
+   go test ./internal/service . -run 'Scheduled.*(Path|Environment)|UpdatesStart_valid'
+   ```
+
+5. Add `Environment map[string]string` to `ScheduledJob`, deterministic environment renderers, and `ScheduledPath(pathValue, goos)`.
+6. Pass the constructed PATH from `updates start` to the backend and render it in both supervisor formats.
+7. Rerun focused and complete service/main tests to green.
+
+## Task 3: Truthful scheduled-job status
+
+**Files:**
+
+- Create: `internal/service/scheduled_status.go`
+- Create: `internal/service/scheduled_status_test.go`
+- Modify: `internal/service/scheduled.go`
+- Modify: `main_updates_daemon.go`
+- Modify: `main_test.go`
+
+1. Define expected typed status fixtures for unsupported, unregistered, registered idle, executing, last-run success, last-run failure, and unknown/malformed supervisor output.
+2. Add launchd parser fixtures for `state`, `last exit code`, and `last exit reason`.
+3. Add systemd parser fixtures using stable `LoadState`, `ActiveState`, `SubState`, `Result`, and `ExecMainStatus` properties.
+4. Expand the fake supervisor and CLI tests so `updates status` prints explicit messages for each shared state.
+5. Run focused tests and confirm RED:
+
+   ```bash
+   go test ./internal/service . -run 'Scheduled.*Status|UpdatesStatus'
+   ```
+
+6. Extend `ScheduledJobStatus` with registration, activity, last-run outcome, exit code, and detail fields. Add backend command helpers that capture supervisor output and distinguish not-found from inspection errors.
+7. Parse backend output conservatively: never equate a loaded idle one-shot job with active execution, and never hide a recorded failure.
+8. Update CLI formatting to consume only the shared typed fields and rerun focused tests to green.
+
+## Task 4: Version-constraint-safe upgrade planning
+
+**Files:**
+
+- Modify: `internal/upgrade/planner.go`
+- Modify: `internal/upgrade/planner_test.go`
+- Modify: `main_test.go` if output coverage is not already exercised through the planner result
+
+1. Add planner tests proving an unconstrained package still plans normally, a constrained package is skipped with `version-constrained package requires an explicit compatible target`, and a mixed batch excludes only constrained packages.
+2. Add filter-composition cases proving current `--only`/`--skip` precedence remains deterministic.
+3. Run focused tests and confirm RED:
+
+   ```bash
+   go test ./internal/upgrade -run 'Constraint|BuildPlan'
+   ```
+
+4. Replace the allowed-ID set with a package-by-ID index. Apply existing filters first, then separate constrained packages before `resolver.PlanUpgrade`.
+5. Append constraint skips in stable lock order, preserve existing warnings, and rerun focused tests to green.
+6. Run upgrade and updates command tests to prove the shared planner protects both interactive and scheduled flows.
+
+## Task 5: Scheduled update audit logging and bounded diagnostics
+
+**Files:**
+
+- Create: `main_updates_diagnostics.go`
+- Create: `main_updates_diagnostics_test.go`
+- Modify: `main_updates_worker.go`
+- Modify: `main_test.go`
+
+1. Add tests for a bounded diagnostic writer that caps retained bytes, includes an explicit truncation marker, and redacts synthetic credential assignments.
+2. Add a worker test where logger directory creation/opening fails; assert an IO exit and zero calls to `updatesRunUpgrade`.
+3. Add a worker test returning multiple execution errors and synthetic stderr; assert each failure is logged separately with affected IDs/error and the bounded diagnostics are recorded.
+4. Run focused tests and confirm RED:
+
+   ```bash
+   go test . -run 'Updates(Diagnostic|Logger|RunOnce.*Failure)'
+   ```
+
+5. Change logger initialization to return an error. Emit a minimal stderr message when no audit log can be opened and stop before planning/execution that could auto-apply.
+6. Pass a bounded diagnostic writer as scheduled stderr, sanitize its rendered output, and log it once after execution only when non-empty.
+7. Log each `UpgradeRunResult.Errors` entry separately. Derive affected IDs from the plan/action ordering without logging environment state or command credentials.
+8. Rerun focused tests to green and confirm existing check-only/notification tests remain green.
+
+## Task 6: Documentation, regression suite, and manual QA
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-07-12-scheduler-platform-correctness-design.md`
+- Modify: `README.md` if scheduler status/PATH or constrained-upgrade behavior is user-facing there
+- Modify: `CHANGELOG.md` if the repository records unreleased fixes there
+
+1. Mark the approved design status accurately and document user-visible behavior where the repository currently documents updates/upgrades.
+2. Format and inspect the diff:
+
+   ```bash
+   gofmt -w <changed-go-files>
+   git diff --check
+   ```
+
+3. Run focused touched-package suites, then the repository gates:
+
+   ```bash
+   go test ./internal/adapter ./internal/search ./internal/resolver ./internal/service ./internal/upgrade .
+   go test -race -shuffle=on -count=1 ./...
+   make lint
+   make build
+   make bench
+   ```
+
+4. Build a fresh binary and manually exercise non-mutating surfaces with fixture specs under `.omo/session-work/`: `search`/`add` candidate selection, `updates check --json`, and `updates status`. Do not execute a real upgrade or register/replace a real scheduler job during QA.
+5. Inspect generated launchd/systemd content using pure rendering tests or a small Go test fixture, confirming only the expected PATH and status fields appear.
+6. Review the complete diff against every approved requirement, run the post-implementation review workflow, fix validated findings, rerun affected gates, and ensure no test processes or scratch artifacts remain.
+

--- a/docs/superpowers/specs/2026-07-12-scheduler-platform-correctness-design.md
+++ b/docs/superpowers/specs/2026-07-12-scheduler-platform-correctness-design.md
@@ -1,0 +1,123 @@
+# Scheduler and Platform Correctness Design
+
+Date: 2026-07-12
+Status: Approved
+
+## Goal
+
+Fix the correctness and observability defects exposed while enabling unattended genv updates, and prevent macOS from suggesting Linuxbrew alongside native Homebrew. Developer ID signing and notarization are explicitly out of scope.
+
+## Required behavior
+
+### Platform-aware manager suggestions
+
+- On macOS, automatic search, scan, and resolution suggestions include `brew` and exclude `linuxbrew`.
+- On Linux, automatic suggestions include `linuxbrew` and exclude `brew` when presenting the two Homebrew identities.
+- Explicit configuration remains authoritative: a package may still name or prefer either manager when that manager is available on the current host.
+- Platform filtering applies only to automatic candidate generation. It must not make an explicitly configured manager invalid.
+- The platform-policy seam must accept an OS value in tests rather than requiring tests to run on multiple operating systems.
+
+### Scheduled-job environment
+
+- Scheduled jobs receive a deterministic PATH that can resolve supported user-level package managers.
+- PATH construction starts with the invoking process PATH, retains only non-empty absolute directories, removes duplicates, and appends missing platform defaults.
+- macOS defaults include Apple Silicon Homebrew, Intel Homebrew/local, and system binary directories.
+- Linux defaults include Linuxbrew, local, and system binary directories.
+- Both launchd and systemd render the scheduled environment so behavior does not depend on a supervisor's restricted default PATH.
+- Generated environment values are escaped using the target supervisor's existing escaping rules.
+
+### Truthful scheduler status
+
+- Status distinguishes unsupported, unregistered, registered/idle, executing, last-run success, and last-run failure.
+- An idle one-shot timer remains healthy and registered; it is not reported as currently executing.
+- A loaded job whose last execution failed reports that failure instead of the generic `running` message.
+- launchd parsing recognizes state, last exit code, and last exit reason from `launchctl print` output.
+- systemd obtains equivalent timer/service state through stable `systemctl show` properties.
+- Human output is explicit, while structured internal status remains typed and testable.
+
+### Version-constrained upgrades
+
+- The upgrade planner must never schedule a broad latest-version upgrade for a package with a non-empty version constraint unless the selected adapter can guarantee the target satisfies that constraint.
+- In the current adapter model, constrained packages are skipped with a stable, actionable reason rather than upgraded unsafely.
+- Unconstrained packages retain current behavior.
+- Filters continue to compose with constraint skips, and JSON/human output exposes the skip reason.
+- This conservative behavior applies to both `genv upgrade` and `genv updates` because they share the planner.
+- A future version-aware adapter capability can replace the conservative skip without changing the planner contract.
+
+### Scheduled update observability
+
+- Failure to create, rotate, or open `updates.log` is an explicit worker error and prevents auto-apply from running without an audit trail.
+- Every failed upgrade action is logged with its affected tracked IDs and error.
+- Package-manager diagnostics are captured with a bounded buffer and logged without unbounded memory or log growth.
+- Successful scheduled runs retain the existing aggregate completion record.
+- Logging changes must not expose environment variables or credentials, and tests use synthetic non-sensitive diagnostics.
+
+## Architecture
+
+### Platform policy
+
+A small internal policy function decides whether a manager may appear as an automatic suggestion for a supplied GOOS. Search, scan, and implicit resolver candidate construction call this function. Explicit `prefer` and `managers` paths bypass automatic-suggestion filtering after normal availability checks.
+
+This targeted seam avoids adding a platform method to every adapter while remaining extensible for future platform-specific manager pairs.
+
+### Scheduled environment and status
+
+`ScheduledJob` gains a typed environment map. The updates lifecycle constructs the sanitized augmented PATH once and passes it to the scheduled backend. launchd emits `EnvironmentVariables`; systemd emits `Environment=` entries.
+
+`ScheduledJobStatus` grows explicit registration, activity, and last-run fields. Backend-specific parsers translate supervisor output into that shared type. CLI formatting consumes the typed status instead of inferring health from command success.
+
+### Constraint policy
+
+`BuildUpgradePlan` indexes complete `schema.Package` values by ID instead of storing only allowed IDs. Before creating upgrade actions, it separates non-empty constraints into skipped packages with the stable reason `version-constrained package requires an explicit compatible target`. Existing manager/package filters run consistently and preserve their current precedence.
+
+### Diagnostic capture
+
+The scheduled worker opens its logger through a function returning an error. Auto-apply uses a bounded writer for manager stderr and records each structured execution error after `RunUpgrade`. The normal interactive `genv upgrade` output path is unchanged.
+
+## Error handling
+
+- Malformed supervisor output returns a conservative registered/unknown-health status plus detail rather than claiming success.
+- Failure to inspect status returns the existing IO exit category.
+- Invalid or unusable PATH entries are omitted; if the resulting PATH is empty, platform defaults remain.
+- Constrained packages are skips, not planner failures, so unconstrained tracked packages may still upgrade.
+- Logger initialization failure returns an IO exit code before any upgrade command executes.
+
+## Test strategy
+
+Every behavior follows RED to GREEN.
+
+1. Platform suggestions:
+   - macOS automatic candidates contain `brew` and not `linuxbrew`.
+   - Linux automatic candidates contain `linuxbrew` and not `brew`.
+   - Explicit cross-platform manager selection remains accepted when available.
+2. Scheduled environment:
+   - PATH sanitizer removes relative, empty, and duplicate entries.
+   - launchd plist contains escaped `EnvironmentVariables`.
+   - systemd unit contains the equivalent PATH.
+3. Scheduler status:
+   - fixtures cover unregistered, idle successful, executing, and failed launchd/systemd states.
+   - CLI output names each state truthfully.
+4. Constraints:
+   - unconstrained packages still plan upgrades.
+   - constrained packages are skipped with the stable reason.
+   - filters and constraint skips compose deterministically.
+5. Observability:
+   - logger-open failure prevents the executor call.
+   - multiple action failures are individually logged.
+   - diagnostics are bounded and truncation is visible.
+
+Verification includes targeted tests, `go test -race -shuffle=on -count=1 ./...`, formatting/lint gates available in the repository, and CLI manual QA using a freshly built binary with fixture specs. Manual QA must not execute real package upgrades.
+
+## Compatibility and migration
+
+- Existing genv schema remains version 6; no configuration migration is required.
+- Existing update filters and unconstrained upgrade behavior remain compatible.
+- Human `updates status` wording becomes more precise but command and exit-code contracts remain stable.
+- Rerunning `genv updates start` regenerates the current user's scheduler artifact with the corrected environment, removing the need for manual plist edits.
+
+## Out of scope
+
+- Developer ID signing, Apple notarization, or acquiring an Apple developer account.
+- Redesigning every adapter around generalized platform metadata.
+- Implementing manager-specific compatible-version discovery in this change.
+- Executing real upgrades as part of tests or manual QA.

--- a/internal/adapter/platform.go
+++ b/internal/adapter/platform.go
@@ -1,0 +1,14 @@
+package adapter
+
+// AutomaticOnGOOS reports whether manager is eligible for automatic candidate
+// generation on goos. Explicit manager selection does not use this policy.
+func AutomaticOnGOOS(manager, goos string) bool {
+	switch manager {
+	case "brew":
+		return goos == "darwin"
+	case "linuxbrew":
+		return goos == "linux"
+	default:
+		return true
+	}
+}

--- a/internal/adapter/platform_test.go
+++ b/internal/adapter/platform_test.go
@@ -1,0 +1,27 @@
+package adapter
+
+import "testing"
+
+func TestAutomaticOnGOOS(t *testing.T) {
+	tests := []struct {
+		name    string
+		manager string
+		goos    string
+		want    bool
+	}{
+		{name: "Darwin accepts Homebrew", manager: "brew", goos: "darwin", want: true},
+		{name: "Darwin rejects Linuxbrew", manager: "linuxbrew", goos: "darwin", want: false},
+		{name: "Linux rejects Homebrew", manager: "brew", goos: "linux", want: false},
+		{name: "Linux accepts Linuxbrew", manager: "linuxbrew", goos: "linux", want: true},
+		{name: "unrelated manager on Darwin", manager: "pacman", goos: "darwin", want: true},
+		{name: "unrelated manager on Linux", manager: "pacman", goos: "linux", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AutomaticOnGOOS(tt.manager, tt.goos); got != tt.want {
+				t.Errorf("AutomaticOnGOOS(%q, %q) = %v, want %v", tt.manager, tt.goos, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/files/links_test.go
+++ b/internal/files/links_test.go
@@ -14,6 +14,8 @@ import (
 
 // sentinelSymlinkErr stands in for the Windows os.Symlink privilege error
 // (Developer Mode off, unelevated); tests assert errors.Is reaches it.
+//
+//nolint:staticcheck // ST1005: intentional verbatim replica of the real Windows os.Symlink error string, which ends with a period.
 var sentinelSymlinkErr = errors.New("A required privilege is not held by the client.")
 
 func TestWindowsSymlinkHint_wrapsOnWindows(t *testing.T) {

--- a/internal/genvfile/genvfile_test.go
+++ b/internal/genvfile/genvfile_test.go
@@ -50,6 +50,7 @@ func TestWriteAndRead_Roundtrip(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("Read returned nil")
+		return
 	}
 
 	if got.SchemaVersion != original.SchemaVersion {
@@ -113,6 +114,7 @@ func TestReadOrNew_CreatesNew(t *testing.T) {
 	}
 	if f == nil {
 		t.Fatal("expected non-nil GenvFile")
+		return
 	}
 	if f.SchemaVersion != schema.Version {
 		t.Errorf("SchemaVersion = %q", f.SchemaVersion)
@@ -260,6 +262,7 @@ func TestWrite_OverwritesExistingFile(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("Read returned nil")
+		return
 	}
 	if len(got.Packages) != 1 || got.Packages[0].ID != "git" {
 		t.Errorf("expected 1 package 'git' after overwrite, got: %+v", got.Packages)
@@ -342,6 +345,7 @@ func TestReadLock_MissingFile_ReturnsEmpty(t *testing.T) {
 	}
 	if lf == nil {
 		t.Fatal("ReadLock on missing file: expected non-nil LockFile")
+		return
 	}
 	if lf.SchemaVersion != schema.Version {
 		t.Errorf("SchemaVersion: got %q, want %q", lf.SchemaVersion, schema.Version)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -58,9 +58,13 @@ func ResolveOne(pkg schema.Package, available map[string]bool) Action {
 // Plan resolves every package in f into an Action, using the provided set of
 // available manager names. Call Detect() to build the available map.
 func Plan(f *schema.GenvFile, available map[string]bool) []Action {
+	return planOnGOOS(f, available, runtime.GOOS)
+}
+
+func planOnGOOS(f *schema.GenvFile, available map[string]bool, goos string) []Action {
 	actions := make([]Action, 0, len(f.Packages))
 	for _, pkg := range f.Packages {
-		actions = append(actions, resolveOnGOOS(pkg, available, runtime.GOOS))
+		actions = append(actions, resolveOnGOOS(pkg, available, goos))
 	}
 	return actions
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"os/exec"
+	"runtime"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -51,7 +52,7 @@ func (a Action) Resolved() bool { return a.Manager != "" }
 // ResolveOne resolves a single package into an Action using the provided set of
 // available manager names. Used by addCmd to install one package immediately.
 func ResolveOne(pkg schema.Package, available map[string]bool) Action {
-	return resolve(pkg, available)
+	return resolveOnGOOS(pkg, available, runtime.GOOS)
 }
 
 // Plan resolves every package in f into an Action, using the provided set of
@@ -59,12 +60,12 @@ func ResolveOne(pkg schema.Package, available map[string]bool) Action {
 func Plan(f *schema.GenvFile, available map[string]bool) []Action {
 	actions := make([]Action, 0, len(f.Packages))
 	for _, pkg := range f.Packages {
-		actions = append(actions, resolve(pkg, available))
+		actions = append(actions, resolveOnGOOS(pkg, available, runtime.GOOS))
 	}
 	return actions
 }
 
-func resolve(pkg schema.Package, available map[string]bool) Action {
+func resolveOnGOOS(pkg schema.Package, available map[string]bool, goos string) Action {
 	// 1. Honor the prefer hint if that manager is available.
 	// ByName is guaranteed non-nil here: available is built from adapter.All
 	// in Detect(), so any name present in available has a registered adapter.
@@ -91,7 +92,7 @@ func resolve(pkg schema.Package, available map[string]bool) Action {
 	//    never silently resolves to npm/cargo/go just because one happens to be
 	//    installed.
 	for _, a := range adapter.All {
-		if available[a.Name()] && adapter.IsDefaultFallbackEligible(a) {
+		if available[a.Name()] && adapter.IsDefaultFallbackEligible(a) && adapter.AutomaticOnGOOS(a.Name(), goos) {
 			name, _ := a.NormalizeID(pkg.ID, pkg.Managers)
 			return Action{Pkg: pkg, Manager: a.Name(), PkgName: name, Cmd: a.PlanInstall(name), UninstallCmd: a.PlanUninstall(name)}
 		}
@@ -255,6 +256,13 @@ func PlanUpgrade(packages []genvfile.LockedPackage) (plan []UpgradeAction, skipp
 type UpgradeExecution struct {
 	Upgraded []genvfile.LockedPackage
 	Errors   []error
+	Failures []UpgradeFailure
+}
+
+// UpgradeFailure identifies the tracked packages affected by one failed action.
+type UpgradeFailure struct {
+	IDs []string
+	Err error
 }
 
 // ExecuteUpgrade runs each resolved upgrade action sequentially, updating the
@@ -270,7 +278,9 @@ func ExecuteUpgrade(ctx context.Context, plan []UpgradeAction, stdin io.Reader, 
 
 		cmdErr := runSubcmd(ctx, a.Cmd, stdin, stdout, stderr)
 		if cmdErr != nil {
-			out.Errors = append(out.Errors, fmt.Errorf("upgrade %q: %w", ids, cmdErr))
+			wrappedErr := fmt.Errorf("upgrade %q: %w", ids, cmdErr)
+			out.Errors = append(out.Errors, wrappedErr)
+			out.Failures = append(out.Failures, UpgradeFailure{IDs: ids, Err: wrappedErr})
 		}
 
 		// Collect current versions for every package in the action. Use a single
@@ -364,14 +374,14 @@ func Reconcile(desired []schema.Package, managed []genvfile.LockedPackage, avail
 	for _, pkg := range desired {
 		lp, alreadyManaged := managedByID[pkg.ID]
 		if !alreadyManaged {
-			toInstall = append(toInstall, resolve(pkg, available))
+			toInstall = append(toInstall, resolveOnGOOS(pkg, available, runtime.GOOS))
 			continue
 		}
 		// Package is already in the lock. Check version constraint: if the lock
 		// recorded an InstalledVersion and it no longer satisfies the spec
 		// constraint, queue for reinstallation.
 		if versionDrifted(pkg, lp) {
-			toInstall = append(toInstall, resolve(pkg, available))
+			toInstall = append(toInstall, resolveOnGOOS(pkg, available, runtime.GOOS))
 		}
 	}
 

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"bytes"
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -360,8 +361,7 @@ func TestExecuteUpgrade_BatchUsesVersionLister(t *testing.T) {
 }
 
 func TestExecuteUpgrade_PartialFailureStillUpdatesChangedVersions(t *testing.T) {
-	// The command fails, but ListInstalledVersions reports that one package
-	// did upgrade anyway.
+	// Given: a failed batch command whose version query shows one package changed anyway.
 	mgr := &testBatchVersionListerMgr{versions: map[string]string{"git": "2.45.0", "neovim": "0.9.0"}}
 	plan := []UpgradeAction{
 		{
@@ -374,9 +374,21 @@ func TestExecuteUpgrade_PartialFailureStillUpdatesChangedVersions(t *testing.T) 
 		},
 	}
 
+	// When: the batch executes.
 	out := ExecuteUpgrade(context.Background(), plan, nil, &bytes.Buffer{}, &bytes.Buffer{})
+
+	// Then: the legacy error and typed action failure are both retained.
 	if len(out.Errors) != 1 {
 		t.Fatalf("expected 1 error, got %d", len(out.Errors))
+	}
+	if len(out.Failures) != 1 {
+		t.Fatalf("expected 1 typed failure, got %d", len(out.Failures))
+	}
+	if !slices.Equal(out.Failures[0].IDs, []string{"git", "neovim"}) {
+		t.Fatalf("failure IDs = %v, want [git neovim]", out.Failures[0].IDs)
+	}
+	if out.Failures[0].Err == nil || out.Failures[0].Err.Error() != out.Errors[0].Error() {
+		t.Fatalf("typed failure error = %v, legacy error = %v", out.Failures[0].Err, out.Errors[0])
 	}
 	if len(out.Upgraded) != 1 {
 		t.Fatalf("expected 1 upgraded package (git), got %d", len(out.Upgraded))
@@ -1172,6 +1184,63 @@ func TestResolveOne_DefaultFallbackStillUsesSystemManagers(t *testing.T) {
 	}
 	if action.Manager != "paru" {
 		t.Errorf("Manager: got %q, want %q", action.Manager, "paru")
+	}
+}
+
+func TestResolveOneOnGOOS_PlatformFallbackUsesNativeHomebrew(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		want string
+	}{
+		{name: "Darwin uses Homebrew", goos: "darwin", want: "brew"},
+		{name: "Linux uses Linuxbrew", goos: "linux", want: "linuxbrew"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := resolveOnGOOS(
+				schema.Package{ID: "git"},
+				map[string]bool{"brew": true, "linuxbrew": true},
+				tt.goos,
+			)
+
+			if action.Manager != tt.want {
+				t.Errorf("manager = %q, want %q", action.Manager, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveOneOnGOOS_PlatformExplicitHomebrewSelectionRemainsAuthoritative(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		pkg  schema.Package
+		want string
+	}{
+		{
+			name: "Darwin prefer can select Linuxbrew",
+			goos: "darwin",
+			pkg:  schema.Package{ID: "git", Prefer: "linuxbrew"},
+			want: "linuxbrew",
+		},
+		{
+			name: "Linux managers map can select Homebrew",
+			goos: "linux",
+			pkg:  schema.Package{ID: "git", Managers: map[string]string{"brew": "git"}},
+			want: "brew",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := resolveOnGOOS(tt.pkg, map[string]bool{"brew": true, "linuxbrew": true}, tt.goos)
+
+			if action.Manager != tt.want {
+				t.Errorf("manager = %q, want %q", action.Manager, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -179,7 +179,7 @@ func TestPrintPlan_ShowsInstallCommand(t *testing.T) {
 			{ID: "git"},
 		},
 	}
-	actions := Plan(f, map[string]bool{"brew": true})
+	actions := planOnGOOS(f, map[string]bool{"brew": true}, "darwin")
 	var sb strings.Builder
 	PrintPlan(actions, &sb)
 	out := sb.String()
@@ -635,7 +635,7 @@ func TestPrintPlan_ReturnsCorrectCounts(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &schema.GenvFile{Packages: tc.pkgs}
-			actions := Plan(f, tc.available)
+			actions := planOnGOOS(f, tc.available, "darwin")
 			var sb strings.Builder
 			resolved, unresolved := PrintPlan(actions, &sb)
 			if resolved != tc.wantResolved {
@@ -672,7 +672,7 @@ func TestPlan_MultiplePackagesMixed(t *testing.T) {
 	// prefer is snap (unavailable) and its managers map has only snap
 	// (unavailable), so it falls back to the generic fallback at step 3 (brew).
 	available := map[string]bool{"brew": true}
-	actions := Plan(f, available)
+	actions := planOnGOOS(f, available, "darwin")
 	if len(actions) != 3 {
 		t.Fatalf("expected 3 actions, got %d", len(actions))
 	}
@@ -1156,7 +1156,7 @@ func TestExecuteApply_SkipsUnresolvedInstall(t *testing.T) {
 // TestResolveOne verifies that ResolveOne resolves a single package correctly.
 func TestResolveOne(t *testing.T) {
 	pkg := schema.Package{ID: "git"}
-	action := ResolveOne(pkg, map[string]bool{"brew": true})
+	action := resolveOnGOOS(pkg, map[string]bool{"brew": true}, "darwin")
 	if !action.Resolved() {
 		t.Fatal("ResolveOne: expected resolved action")
 	}

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -472,6 +472,7 @@ func TestParseAndValidate_MultipleValidPackages(t *testing.T) {
 	}
 	if f == nil {
 		t.Fatal("ParseAndValidate returned nil")
+		return
 	}
 	if len(f.Packages) != 3 {
 		t.Fatalf("expected 3 packages, got %d", len(f.Packages))
@@ -1024,6 +1025,7 @@ func TestParseAndValidate_UpdatesInvalidInterval(t *testing.T) {
 	}
 	if found == nil {
 		t.Fatalf("expected updates.interval validation error, got: %v", errs)
+		return
 	}
 	if !strings.Contains(found.Message, "24h") {
 		t.Errorf("expected corrective hint mentioning a valid duration, got: %q", found.Message)

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -4,6 +4,7 @@
 package search
 
 import (
+	"runtime"
 	"sync"
 
 	"github.com/ks1686/genv/internal/adapter"
@@ -34,10 +35,14 @@ type searchResult struct {
 // priority (brew → pacman → paru → …). Adapters that are unavailable or do
 // not implement adapter.Searchable are silently skipped, as are search errors.
 func All(query string, available map[string]bool) []Candidate {
+	return allOnGOOS(query, available, runtime.GOOS)
+}
+
+func allOnGOOS(query string, available map[string]bool, goos string) []Candidate {
 	jobs := make([]searchJob, 0, len(adapter.All))
 	for _, a := range adapter.All {
 		manager := a.Name()
-		if !available[manager] {
+		if !available[manager] || !adapter.AutomaticOnGOOS(manager, goos) {
 			continue
 		}
 		s, ok := a.(adapter.Searchable)

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -3,11 +3,78 @@ package search
 import (
 	"errors"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/ks1686/genv/internal/adapter"
 )
+
+func TestAllOnGOOS_PlatformHomebrew(t *testing.T) {
+	originalAll := adapter.All
+	t.Cleanup(func() {
+		adapter.All = originalAll
+	})
+
+	var brewCalls atomic.Int32
+	var linuxbrewCalls atomic.Int32
+	adapter.All = []adapter.Adapter{
+		mockSearchableAdapter{
+			mockAdapter: mockAdapter{name: "brew"},
+			searchFunc: func(string) ([]string, error) {
+				brewCalls.Add(1)
+				return []string{"brew-result"}, nil
+			},
+		},
+		mockSearchableAdapter{
+			mockAdapter: mockAdapter{name: "linuxbrew"},
+			searchFunc: func(string) ([]string, error) {
+				linuxbrewCalls.Add(1)
+				return []string{"linuxbrew-result"}, nil
+			},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		goos               string
+		want               []Candidate
+		wantBrewCalls      int32
+		wantLinuxbrewCalls int32
+	}{
+		{
+			name:          "Darwin queries Homebrew only",
+			goos:          "darwin",
+			want:          []Candidate{{Manager: "brew", PkgName: "brew-result"}},
+			wantBrewCalls: 1,
+		},
+		{
+			name:               "Linux queries Linuxbrew only",
+			goos:               "linux",
+			want:               []Candidate{{Manager: "linuxbrew", PkgName: "linuxbrew-result"}},
+			wantLinuxbrewCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			brewCalls.Store(0)
+			linuxbrewCalls.Store(0)
+
+			got := allOnGOOS("pkg", map[string]bool{"brew": true, "linuxbrew": true}, tt.goos)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("candidates = %#v, want %#v", got, tt.want)
+			}
+			if got := brewCalls.Load(); got != tt.wantBrewCalls {
+				t.Errorf("brew search calls = %d, want %d", got, tt.wantBrewCalls)
+			}
+			if got := linuxbrewCalls.Load(); got != tt.wantLinuxbrewCalls {
+				t.Errorf("linuxbrew search calls = %d, want %d", got, tt.wantLinuxbrewCalls)
+			}
+		})
+	}
+}
 
 // mockAdapter implements adapter.Adapter but NOT adapter.Searchable
 type mockAdapter struct {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -193,7 +193,7 @@ func TestAll(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := All(tc.query, tc.available)
+			got := allOnGOOS(tc.query, tc.available, "darwin")
 
 			if len(got) != len(tc.want) {
 				t.Fatalf("got %d candidates, want %d", len(got), len(tc.want))
@@ -241,7 +241,7 @@ func TestAll_preservesRegistryOrderAndDedupeWhenSearchesCompleteOutOfOrder(t *te
 
 	done := make(chan []Candidate, 1)
 	go func() {
-		done <- All("pkg", map[string]bool{"brew": true, "apt": true})
+		done <- allOnGOOS("pkg", map[string]bool{"brew": true, "apt": true}, "darwin")
 	}()
 
 	var got []Candidate

--- a/internal/service/scheduled.go
+++ b/internal/service/scheduled.go
@@ -6,23 +6,27 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 )
 
 // ScheduledJob is a one-shot command managed by the host user supervisor on a fixed interval.
 type ScheduledJob struct {
-	Name     string
-	Command  []string
-	Interval time.Duration
+	Name        string
+	Command     []string
+	Interval    time.Duration
+	Environment map[string]string
 }
 
-// ScheduledJobStatus reports whether a managed scheduled job is supported and running.
+// ScheduledJobStatus reports supervisor registration, current activity, and the last known completed run.
 type ScheduledJobStatus struct {
-	Supported bool
-	Running   bool
-	Detail    string
+	Supported     bool
+	Registered    bool
+	Executing     bool
+	LastRun       ScheduledRunOutcome
+	ExitCode      *int
+	LastRunDetail string
+	Detail        string
 }
 
 // ScheduledBackend manages one-shot scheduled jobs via systemd --user or launchd.
@@ -69,27 +73,23 @@ func (hostScheduledBackend) Stop(ctx context.Context, name string) error {
 func (hostScheduledBackend) Status(ctx context.Context, name string) (ScheduledJobStatus, error) {
 	switch {
 	case IsSystemdAvailable():
-		timerName := systemdTimerName(name)
-		running := exec.CommandContext(ctx, "systemctl", "--user", "is-active", "--quiet", timerName).Run() == nil
-		return ScheduledJobStatus{Supported: true, Running: running, Detail: timerName}, nil
+		return systemdScheduledStatus(ctx, systemdTimerName(name), systemdScheduledUnitName(name))
 	case IsLaunchdAvailable():
-		label := launchdScheduledLabel(name)
-		running := exec.CommandContext(ctx, "launchctl", "print", "gui/"+strconv.Itoa(os.Getuid())+"/"+label).Run() == nil
-		return ScheduledJobStatus{Supported: true, Running: running, Detail: label}, nil
+		return launchdScheduledStatus(ctx, launchdScheduledLabel(name))
 	default:
-		return ScheduledJobStatus{Supported: false, Running: false, Detail: "systemd --user or launchd is required"}, nil
+		return ScheduledJobStatus{Supported: false, LastRun: ScheduledRunUnknown, Detail: "systemd --user or launchd is required"}, nil
 	}
 }
 
-func SystemdScheduledUnitContent(name string, command []string) string {
+func SystemdScheduledUnitContent(name string, command []string, environment map[string]string) string {
 	name = stripLineBreaks(name)
 	return fmt.Sprintf(`[Unit]
 Description=genv scheduled job: %s
 
 [Service]
 Type=oneshot
-ExecStart=%s
-`, name, renderSystemdCommand(command))
+%sExecStart=%s
+`, name, renderSystemdEnvironment(environment), renderSystemdCommand(command))
 }
 
 func SystemdScheduledTimerContent(name string, interval time.Duration) string {
@@ -108,7 +108,7 @@ WantedBy=timers.target
 `, name, seconds, systemdScheduledUnitName(name))
 }
 
-func LaunchdScheduledPlistContent(name string, command []string, interval time.Duration) string {
+func LaunchdScheduledPlistContent(name string, command []string, interval time.Duration, environment map[string]string) string {
 	name = stripLineBreaks(name)
 	seconds := max(int(interval.Seconds()), 1)
 	var b strings.Builder
@@ -124,13 +124,13 @@ func LaunchdScheduledPlistContent(name string, command []string, interval time.D
     <key>ProgramArguments</key>
     <array>
 %s    </array>
-    <key>RunAtLoad</key>
+%s    <key>RunAtLoad</key>
     <true/>
     <key>StartInterval</key>
     <integer>%d</integer>
 </dict>
 </plist>
-`, xmlEscape(launchdScheduledLabel(name)), b.String(), seconds)
+`, xmlEscape(launchdScheduledLabel(name)), b.String(), renderLaunchdEnvironment(environment), seconds)
 }
 
 func systemdScheduledUnitName(name string) string {
@@ -159,7 +159,7 @@ func startSystemdScheduledJob(ctx context.Context, job ScheduledJob) error {
 	timerName := systemdTimerName(job.Name)
 	unitPath := filepath.Join(unitDir, unitName)
 	timerPath := filepath.Join(unitDir, timerName)
-	if err := os.WriteFile(unitPath, []byte(SystemdScheduledUnitContent(job.Name, job.Command)), 0o644); err != nil {
+	if err := os.WriteFile(unitPath, []byte(SystemdScheduledUnitContent(job.Name, job.Command, job.Environment)), 0o644); err != nil {
 		return fmt.Errorf("writing systemd unit file %q: %w", unitPath, err)
 	}
 	if err := os.WriteFile(timerPath, []byte(SystemdScheduledTimerContent(job.Name, job.Interval)), 0o644); err != nil {
@@ -201,7 +201,7 @@ func startLaunchdScheduledJob(ctx context.Context, job ScheduledJob) error {
 		return fmt.Errorf("creating launchd agent directory: %w", err)
 	}
 	plistPath := filepath.Join(agentDir, launchdPlistName(job.Name))
-	if err := os.WriteFile(plistPath, []byte(LaunchdScheduledPlistContent(job.Name, job.Command, job.Interval)), 0o644); err != nil {
+	if err := os.WriteFile(plistPath, []byte(LaunchdScheduledPlistContent(job.Name, job.Command, job.Interval, job.Environment)), 0o644); err != nil {
 		return fmt.Errorf("writing launchd plist file %q: %w", plistPath, err)
 	}
 	_ = exec.CommandContext(ctx, "launchctl", "unload", plistPath).Run()

--- a/internal/service/scheduled_environment.go
+++ b/internal/service/scheduled_environment.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+)
+
+var scheduledPathDefaults = map[string][]string{
+	"darwin": {
+		"/opt/homebrew/bin",
+		"/opt/homebrew/sbin",
+		"/usr/local/bin",
+		"/usr/local/sbin",
+		"/usr/bin",
+		"/bin",
+		"/usr/sbin",
+		"/sbin",
+	},
+	"linux": {
+		"/home/linuxbrew/.linuxbrew/bin",
+		"/home/linuxbrew/.linuxbrew/sbin",
+		"/usr/local/bin",
+		"/usr/local/sbin",
+		"/usr/bin",
+		"/bin",
+		"/usr/sbin",
+		"/sbin",
+	},
+}
+
+// ScheduledPath returns a sanitized PATH augmented with defaults for goos.
+func ScheduledPath(pathValue, goos string) string {
+	entries := make([]string, 0)
+	seen := make(map[string]struct{})
+	appendEntry := func(entry string) {
+		if entry == "" || !path.IsAbs(entry) {
+			return
+		}
+		if _, ok := seen[entry]; ok {
+			return
+		}
+		seen[entry] = struct{}{}
+		entries = append(entries, entry)
+	}
+
+	for _, entry := range strings.Split(pathValue, ":") {
+		appendEntry(entry)
+	}
+	for _, entry := range scheduledPathDefaults[goos] {
+		appendEntry(entry)
+	}
+
+	return strings.Join(entries, ":")
+}
+
+func renderSystemdEnvironment(environment map[string]string) string {
+	var b strings.Builder
+	for _, name := range sortedEnvironmentNames(environment) {
+		fmt.Fprintf(&b, "Environment=%s\n", systemdQuoteArg(stripLineBreaks(name+"="+environment[name])))
+	}
+	return b.String()
+}
+
+func renderLaunchdEnvironment(environment map[string]string) string {
+	if len(environment) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("    <key>EnvironmentVariables</key>\n    <dict>\n")
+	for _, name := range sortedEnvironmentNames(environment) {
+		fmt.Fprintf(&b, "        <key>%s</key>\n", xmlEscape(stripLineBreaks(name)))
+		fmt.Fprintf(&b, "        <string>%s</string>\n", xmlEscape(stripLineBreaks(environment[name])))
+	}
+	b.WriteString("    </dict>\n")
+	return b.String()
+}
+
+func sortedEnvironmentNames(environment map[string]string) []string {
+	names := make([]string, 0, len(environment))
+	for name := range environment {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/service/scheduled_environment_test.go
+++ b/internal/service/scheduled_environment_test.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScheduledPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		pathValue string
+		goos      string
+		want      []string
+	}{
+		{
+			name:      "darwin retains absolute entries and appends defaults",
+			pathValue: "/custom/bin::relative:/usr/bin:/custom/bin:/another/bin",
+			goos:      "darwin",
+			want: []string{
+				"/custom/bin", "/usr/bin", "/another/bin",
+				"/opt/homebrew/bin", "/opt/homebrew/sbin", "/usr/local/bin", "/usr/local/sbin",
+				"/bin", "/usr/sbin", "/sbin",
+			},
+		},
+		{
+			name:      "linux falls back to platform defaults",
+			pathValue: "relative::also-relative",
+			goos:      "linux",
+			want: []string{
+				"/home/linuxbrew/.linuxbrew/bin", "/home/linuxbrew/.linuxbrew/sbin",
+				"/usr/local/bin", "/usr/local/sbin", "/usr/bin", "/bin", "/usr/sbin", "/sbin",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := strings.Split(ScheduledPath(tt.pathValue, tt.goos), ":"); !equalStrings(got, tt.want) {
+				t.Fatalf("ScheduledPath(%q, %q) = %v, want %v", tt.pathValue, tt.goos, got, tt.want)
+			}
+		})
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/service/scheduled_status.go
+++ b/internal/service/scheduled_status.go
@@ -1,0 +1,236 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// ScheduledRunOutcome describes the most recent completed execution known to the supervisor.
+type ScheduledRunOutcome string
+
+const (
+	ScheduledRunUnknown ScheduledRunOutcome = "unknown"
+	ScheduledRunSuccess ScheduledRunOutcome = "success"
+	ScheduledRunFailure ScheduledRunOutcome = "failure"
+)
+
+var scheduledCommandOutput = func(ctx context.Context, command string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, command, args...).CombinedOutput()
+}
+
+func launchdScheduledStatus(ctx context.Context, label string) (ScheduledJobStatus, error) {
+	target := "gui/" + strconv.Itoa(os.Getuid()) + "/" + label
+	output, err := scheduledCommandOutput(ctx, "launchctl", "print", target)
+	if err != nil {
+		if supervisorUnitMissing(string(output)) {
+			return unregisteredScheduledStatus(label), nil
+		}
+		return ScheduledJobStatus{}, fmt.Errorf("inspect launchd scheduled job %q: %w", label, err)
+	}
+	return parseLaunchdScheduledStatus(label, string(output)), nil
+}
+
+func parseLaunchdScheduledStatus(label, output string) ScheduledJobStatus {
+	status := registeredScheduledStatus(label)
+	fields := parseLaunchdFields(output)
+	state, hasState := fields["state"]
+	if hasState {
+		status.Executing = strings.EqualFold(state, "running")
+	}
+
+	exitCodeText, hasExitCode := fields["last exit code"]
+	if hasExitCode {
+		exitCode, reason, known, err := parseLaunchdExitCode(exitCodeText)
+		if err == nil && known {
+			status.ExitCode = &exitCode
+			status.LastRunDetail = reason
+			if exitCode == 0 {
+				status.LastRun = ScheduledRunSuccess
+			} else {
+				status.LastRun = ScheduledRunFailure
+			}
+		} else if err != nil {
+			status.Detail = malformedStatusDetail(label, "launchctl", "invalid last exit code")
+		}
+	}
+	if reason := fields["last exit reason"]; reason != "" {
+		status.LastRunDetail = reason
+		if !hasExitCode {
+			status.LastRun = ScheduledRunFailure
+		}
+	}
+	if !hasState {
+		status.Detail = malformedStatusDetail(label, "launchctl", "missing state")
+	}
+	return status
+}
+
+func parseLaunchdFields(output string) map[string]string {
+	fields := make(map[string]string)
+	fieldDepths := make(map[string]int)
+	depth := 0
+	for line := range strings.SplitSeq(output, "\n") {
+		trimmedLine := strings.TrimSpace(line)
+		key, value, ok := strings.Cut(trimmedLine, "=")
+		if !ok {
+			depth += strings.Count(trimmedLine, "{") - strings.Count(trimmedLine, "}")
+			continue
+		}
+		key = strings.ToLower(strings.TrimSpace(key))
+		switch key {
+		case "state", "last exit code", "last exit reason":
+			previousDepth, exists := fieldDepths[key]
+			if !exists || depth < previousDepth {
+				fields[key] = strings.TrimSpace(value)
+				fieldDepths[key] = depth
+			}
+		}
+		depth += strings.Count(trimmedLine, "{") - strings.Count(trimmedLine, "}")
+	}
+	return fields
+}
+
+func parseLaunchdExitCode(value string) (int, string, bool, error) {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, "(never exited)") {
+		return 0, "", false, nil
+	}
+	codeText, reason, _ := strings.Cut(value, ":")
+	exitCode, err := strconv.Atoi(strings.TrimSpace(codeText))
+	if err != nil {
+		return 0, "", false, err
+	}
+	return exitCode, strings.TrimSpace(reason), true, nil
+}
+
+func systemdScheduledStatus(ctx context.Context, timerName, serviceName string) (ScheduledJobStatus, error) {
+	timerOutput, err := systemdShow(ctx, timerName, "LoadState", "ActiveState", "SubState")
+	if err != nil {
+		if supervisorUnitMissing(string(timerOutput)) {
+			return unregisteredScheduledStatus(timerName), nil
+		}
+		return ScheduledJobStatus{}, fmt.Errorf("inspect systemd timer %q: %w", timerName, err)
+	}
+	timerFields, _ := parseSystemdProperties(string(timerOutput), "LoadState", "ActiveState", "SubState")
+	if timerFields["LoadState"] == "not-found" {
+		return unregisteredScheduledStatus(timerName), nil
+	}
+
+	serviceOutput, err := systemdShow(ctx, serviceName, "LoadState", "ActiveState", "SubState", "Result", "ExecMainStatus", "ExecMainStartTimestampMonotonic")
+	if err != nil {
+		if supervisorUnitMissing(string(serviceOutput)) {
+			status := registeredScheduledStatus(timerName)
+			status.Detail = malformedStatusDetail(timerName, "systemctl", "service unit not found")
+			return status, nil
+		}
+		return ScheduledJobStatus{}, fmt.Errorf("inspect systemd service %q: %w", serviceName, err)
+	}
+	return parseSystemdScheduledStatus(timerName, string(timerOutput), string(serviceOutput)), nil
+}
+
+func systemdShow(ctx context.Context, unit string, properties ...string) ([]byte, error) {
+	args := []string{"--user", "show", unit}
+	for _, property := range properties {
+		args = append(args, "--property="+property)
+	}
+	args = append(args, "--no-pager")
+	return scheduledCommandOutput(ctx, "systemctl", args...)
+}
+
+func parseSystemdScheduledStatus(timerName, timerOutput, serviceOutput string) ScheduledJobStatus {
+	timerFields, timerComplete := parseSystemdProperties(timerOutput, "LoadState", "ActiveState", "SubState")
+	if timerFields["LoadState"] == "not-found" {
+		return unregisteredScheduledStatus(timerName)
+	}
+	status := registeredScheduledStatus(timerName)
+	serviceFields, serviceComplete := parseSystemdProperties(serviceOutput, "LoadState", "ActiveState", "SubState", "Result", "ExecMainStatus", "ExecMainStartTimestampMonotonic")
+	if timerFields["LoadState"] != "loaded" || serviceFields["LoadState"] != "loaded" || !timerComplete || !serviceComplete {
+		status.Detail = malformedStatusDetail(timerName, "systemctl", "missing or unexpected properties")
+		return status
+	}
+
+	activeState := serviceFields["ActiveState"]
+	subState := serviceFields["SubState"]
+	status.Executing = activeState == "activating" || (activeState == "active" && subState == "running")
+
+	// A never-executed oneshot service exposes default Result=success and
+	// ExecMainStatus=0, so a real invocation is only proven by a non-zero start
+	// marker. Parse it as an unsigned integer and stay conservative otherwise.
+	startTimestamp, err := strconv.ParseUint(serviceFields["ExecMainStartTimestampMonotonic"], 10, 64)
+	if err != nil {
+		status.Detail = malformedStatusDetail(timerName, "systemctl", "invalid ExecMainStartTimestampMonotonic")
+		return status
+	}
+	if startTimestamp == 0 {
+		return status
+	}
+
+	// While the service is executing, its execution fields describe the in-flight
+	// invocation rather than a completed outcome, so report executing with an
+	// unknown last run instead of the active run's provisional Result/status.
+	if status.Executing {
+		return status
+	}
+
+	result := serviceFields["Result"]
+	exitCodeText := serviceFields["ExecMainStatus"]
+	if result == "" && exitCodeText == "" {
+		return status
+	}
+	status.LastRunDetail = result
+	if exitCodeText != "" {
+		exitCode, err := strconv.Atoi(exitCodeText)
+		if err != nil {
+			status.Detail = malformedStatusDetail(timerName, "systemctl", "invalid ExecMainStatus")
+			return status
+		}
+		status.ExitCode = &exitCode
+	}
+	if result == "success" && status.ExitCode != nil && *status.ExitCode == 0 {
+		status.LastRun = ScheduledRunSuccess
+		status.LastRunDetail = ""
+		return status
+	}
+	status.LastRun = ScheduledRunFailure
+	return status
+}
+
+func parseSystemdProperties(output string, requiredProperties ...string) (map[string]string, bool) {
+	fields := make(map[string]string)
+	for line := range strings.SplitSeq(output, "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if ok {
+			fields[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	}
+	for _, key := range requiredProperties {
+		if _, ok := fields[key]; !ok {
+			return fields, false
+		}
+	}
+	return fields, true
+}
+
+func supervisorUnitMissing(output string) bool {
+	message := strings.ToLower(output)
+	return strings.Contains(message, "could not find service") ||
+		strings.Contains(message, "could not be found") ||
+		strings.Contains(message, "service not found") ||
+		strings.Contains(message, "unit not found")
+}
+
+func registeredScheduledStatus(detail string) ScheduledJobStatus {
+	return ScheduledJobStatus{Supported: true, Registered: true, LastRun: ScheduledRunUnknown, Detail: detail}
+}
+
+func unregisteredScheduledStatus(detail string) ScheduledJobStatus {
+	return ScheduledJobStatus{Supported: true, LastRun: ScheduledRunUnknown, Detail: detail}
+}
+
+func malformedStatusDetail(detail, supervisor, reason string) string {
+	return fmt.Sprintf("%s: malformed %s output (%s)", detail, supervisor, reason)
+}

--- a/internal/service/scheduled_status_test.go
+++ b/internal/service/scheduled_status_test.go
@@ -1,0 +1,259 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func intPointer(value int) *int {
+	return &value
+}
+
+const launchdRunningNeverExited = `com.ks1686.genv.updates = {
+	active count = 1
+	state = running
+	last exit code = (never exited)
+
+	jetsam coalition = {
+		ID = 1441
+		state = active
+	}
+}
+`
+
+const launchdIdleConfigFailure = `com.ks1686.genv.updates = {
+	active count = 0
+	state = not running
+	last exit code = 78: EX_CONFIG
+
+	jetsam coalition = {
+		ID = 1441
+		state = active
+	}
+}
+`
+
+func TestScheduledLaunchdStatus_parses_supervisor_output(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   ScheduledJobStatus
+	}{
+		{
+			name:   "registered idle with no known run",
+			output: "state = waiting\n",
+			want:   ScheduledJobStatus{Supported: true, Registered: true, LastRun: ScheduledRunUnknown, Detail: "com.ks1686.genv.updates"},
+		},
+		{
+			name:   "currently executing before first exit despite nested coalition state",
+			output: launchdRunningNeverExited,
+			want:   ScheduledJobStatus{Supported: true, Registered: true, Executing: true, LastRun: ScheduledRunUnknown, Detail: "com.ks1686.genv.updates"},
+		},
+		{
+			name:   "last run succeeded with zero exit code",
+			output: "state = waiting\nlast exit code = 0\n",
+			want:   ScheduledJobStatus{Supported: true, Registered: true, LastRun: ScheduledRunSuccess, ExitCode: intPointer(0), Detail: "com.ks1686.genv.updates"},
+		},
+		{
+			name:   "last run failed with annotated exit reason and nested coalition state",
+			output: launchdIdleConfigFailure,
+			want: ScheduledJobStatus{
+				Supported: true, Registered: true, LastRun: ScheduledRunFailure,
+				ExitCode: intPointer(78), LastRunDetail: "EX_CONFIG", Detail: "com.ks1686.genv.updates",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseLaunchdScheduledStatus("com.ks1686.genv.updates", tt.output)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("status = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScheduledLaunchdStatus_is_conservative_when_loaded_output_is_malformed(t *testing.T) {
+	got := parseLaunchdScheduledStatus("com.ks1686.genv.updates", "com.ks1686.genv.updates = {\n}\n")
+
+	if !got.Supported || !got.Registered || got.Executing || got.LastRun != ScheduledRunUnknown {
+		t.Fatalf("status = %#v, want registered unknown state", got)
+	}
+	if !strings.Contains(got.Detail, "malformed launchctl output") {
+		t.Fatalf("detail = %q, want malformed-output explanation", got.Detail)
+	}
+}
+
+func TestScheduledSystemdStatus_parses_stable_show_properties(t *testing.T) {
+	timer := "LoadState=loaded\nActiveState=active\nSubState=waiting\n"
+	tests := []struct {
+		name    string
+		service string
+		want    ScheduledJobStatus
+	}{
+		{
+			name:    "registered idle with empty execution fields",
+			service: "LoadState=loaded\nActiveState=inactive\nSubState=dead\nResult=\nExecMainStatus=\nExecMainStartTimestampMonotonic=0\n",
+			want:    ScheduledJobStatus{Supported: true, Registered: true, LastRun: ScheduledRunUnknown, Detail: "genv-updates.timer"},
+		},
+		{
+			name:    "never executed oneshot exposes default success without a start marker",
+			service: "LoadState=loaded\nActiveState=inactive\nSubState=dead\nResult=success\nExecMainStatus=0\nExecMainStartTimestampMonotonic=0\n",
+			want:    ScheduledJobStatus{Supported: true, Registered: true, LastRun: ScheduledRunUnknown, Detail: "genv-updates.timer"},
+		},
+		{
+			name:    "first execution in progress does not claim a completed outcome",
+			service: "LoadState=loaded\nActiveState=active\nSubState=running\nResult=success\nExecMainStatus=0\nExecMainStartTimestampMonotonic=987654321\n",
+			want:    ScheduledJobStatus{Supported: true, Registered: true, Executing: true, LastRun: ScheduledRunUnknown, Detail: "genv-updates.timer"},
+		},
+		{
+			name:    "last run succeeded",
+			service: "LoadState=loaded\nActiveState=inactive\nSubState=dead\nResult=success\nExecMainStatus=0\nExecMainStartTimestampMonotonic=987654321\n",
+			want:    ScheduledJobStatus{Supported: true, Registered: true, LastRun: ScheduledRunSuccess, ExitCode: intPointer(0), Detail: "genv-updates.timer"},
+		},
+		{
+			name:    "last run failed",
+			service: "LoadState=loaded\nActiveState=failed\nSubState=failed\nResult=exit-code\nExecMainStatus=9\nExecMainStartTimestampMonotonic=987654321\n",
+			want: ScheduledJobStatus{
+				Supported: true, Registered: true, LastRun: ScheduledRunFailure,
+				ExitCode: intPointer(9), LastRunDetail: "exit-code", Detail: "genv-updates.timer",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSystemdScheduledStatus("genv-updates.timer", timer, tt.service)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("status = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScheduledSystemdStatus_is_conservative_when_start_marker_is_malformed(t *testing.T) {
+	timer := "LoadState=loaded\nActiveState=active\nSubState=waiting\n"
+	service := "LoadState=loaded\nActiveState=inactive\nSubState=dead\nResult=success\nExecMainStatus=0\nExecMainStartTimestampMonotonic=not-a-number\n"
+
+	got := parseSystemdScheduledStatus("genv-updates.timer", timer, service)
+
+	if !got.Supported || !got.Registered || got.Executing || got.LastRun != ScheduledRunUnknown {
+		t.Fatalf("status = %#v, want registered unknown state", got)
+	}
+	if got.ExitCode != nil {
+		t.Fatalf("exit code = %v, want no completed outcome", *got.ExitCode)
+	}
+	if !strings.Contains(got.Detail, "malformed systemctl output") {
+		t.Fatalf("detail = %q, want malformed-output explanation", got.Detail)
+	}
+}
+
+func TestScheduledSystemdStatus_reports_unregistered_timer(t *testing.T) {
+	timer := "LoadState=not-found\nActiveState=inactive\nSubState=dead\n"
+
+	got := parseSystemdScheduledStatus("genv-updates.timer", timer, "")
+
+	want := ScheduledJobStatus{Supported: true, LastRun: ScheduledRunUnknown, Detail: "genv-updates.timer"}
+	if got != want {
+		t.Fatalf("status = %#v, want %#v", got, want)
+	}
+}
+
+func TestScheduledSystemdStatus_is_conservative_when_loaded_output_is_malformed(t *testing.T) {
+	got := parseSystemdScheduledStatus("genv-updates.timer", "LoadState=loaded\n", "LoadState=loaded\n")
+
+	if !got.Supported || !got.Registered || got.Executing || got.LastRun != ScheduledRunUnknown {
+		t.Fatalf("status = %#v, want registered unknown state", got)
+	}
+	if !strings.Contains(got.Detail, "malformed systemctl output") {
+		t.Fatalf("detail = %q, want malformed-output explanation", got.Detail)
+	}
+}
+
+func TestScheduledLaunchdStatus_distinguishes_missing_job_from_inspection_failure(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		commandErr error
+		wantStatus ScheduledJobStatus
+		wantErr    bool
+	}{
+		{
+			name: "missing job", output: "Could not find service \"com.ks1686.genv.updates\" in domain for user gui: 501",
+			commandErr: errors.New("exit status 113"),
+			wantStatus: ScheduledJobStatus{Supported: true, LastRun: ScheduledRunUnknown, Detail: "com.ks1686.genv.updates"},
+		},
+		{name: "inspection failure", output: "Operation not permitted", commandErr: errors.New("exit status 1"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := scheduledCommandOutput
+			scheduledCommandOutput = func(context.Context, string, ...string) ([]byte, error) {
+				return []byte(tt.output), tt.commandErr
+			}
+			t.Cleanup(func() { scheduledCommandOutput = original })
+
+			got, err := launchdScheduledStatus(context.Background(), "com.ks1686.genv.updates")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.wantStatus) {
+				t.Fatalf("status = %#v, want %#v", got, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestScheduledSystemdStatus_uses_stable_properties_without_real_supervisor(t *testing.T) {
+	var calls [][]string
+	original := scheduledCommandOutput
+	scheduledCommandOutput = func(_ context.Context, command string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string{command}, args...))
+		if strings.HasSuffix(args[2], ".timer") {
+			return []byte("LoadState=loaded\nActiveState=active\nSubState=waiting\n"), nil
+		}
+		return []byte("LoadState=loaded\nActiveState=inactive\nSubState=dead\nResult=success\nExecMainStatus=0\nExecMainStartTimestampMonotonic=987654321\n"), nil
+	}
+	t.Cleanup(func() { scheduledCommandOutput = original })
+
+	got, err := systemdScheduledStatus(context.Background(), "genv-updates.timer", "genv-updates.service")
+	if err != nil {
+		t.Fatalf("status error: %v", err)
+	}
+	if got.LastRun != ScheduledRunSuccess || got.ExitCode == nil || *got.ExitCode != 0 {
+		t.Fatalf("status = %#v, want successful zero exit status", got)
+	}
+	timerProperties := []string{
+		"--property=LoadState", "--property=ActiveState", "--property=SubState",
+	}
+	serviceProperties := []string{
+		"--property=LoadState", "--property=ActiveState", "--property=SubState",
+		"--property=Result", "--property=ExecMainStatus", "--property=ExecMainStartTimestampMonotonic",
+	}
+	if len(calls) != 2 {
+		t.Fatalf("calls = %#v, want timer and service show calls", calls)
+	}
+	for index, call := range calls {
+		if len(call) < 4 || call[0] != "systemctl" || call[1] != "--user" || call[2] != "show" {
+			t.Fatalf("call = %v, want systemctl --user show", call)
+		}
+		wantProperties := serviceProperties
+		if index == 0 {
+			wantProperties = timerProperties
+		}
+		for _, property := range wantProperties {
+			if !slices.Contains(call, property) {
+				t.Fatalf("call = %v, want %s", call, property)
+			}
+		}
+		if index == 0 && (slices.Contains(call, "--property=Result") || slices.Contains(call, "--property=ExecMainStatus") || slices.Contains(call, "--property=ExecMainStartTimestampMonotonic")) {
+			t.Fatalf("timer call = %v, want timer-only properties", call)
+		}
+	}
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -296,11 +296,15 @@ func TestLaunchdPlistContent_EscapesXML(t *testing.T) {
 func TestScheduledJobContent_uses_interval_and_one_shot_command(t *testing.T) {
 	// Given: the managed updates checker command and cadence.
 	command := []string{"/usr/local/bin/genv", "updates", "__run-once", "--file", "/tmp/genv.json"}
+	environment := map[string]string{
+		"Z_VAR": "last",
+		"PATH":  `/custom/bin:/path with spaces:/quoted"path`,
+	}
 
 	// When: supervisor metadata is rendered for systemd and launchd.
-	unit := SystemdScheduledUnitContent("updates", command)
+	unit := SystemdScheduledUnitContent("updates", command, environment)
 	timer := SystemdScheduledTimerContent("updates", 2*time.Hour)
-	plist := LaunchdScheduledPlistContent("updates", command, 2*time.Hour)
+	plist := LaunchdScheduledPlistContent("updates", command, 2*time.Hour, environment)
 
 	// Then: both backends run the one-shot command on the configured interval.
 	if !strings.Contains(unit, "Type=oneshot") || !strings.Contains(unit, `ExecStart="/usr/local/bin/genv" "updates" "__run-once"`) {
@@ -311,6 +315,26 @@ func TestScheduledJobContent_uses_interval_and_one_shot_command(t *testing.T) {
 	}
 	if !strings.Contains(plist, "<key>StartInterval</key>") || !strings.Contains(plist, "<integer>7200</integer>") || !strings.Contains(plist, "<string>genv.updates</string>") {
 		t.Fatalf("launchd plist = %q, want StartInterval cadence for updates label", plist)
+	}
+}
+
+func TestScheduledJobContent_Environment_is_deterministic_and_escaped(t *testing.T) {
+	command := []string{"/usr/local/bin/genv", "updates", "__run-once"}
+	environment := map[string]string{
+		"Z_VAR": "last",
+		"PATH":  "/custom&bin:/quoted\"path",
+	}
+
+	unit := SystemdScheduledUnitContent("updates", command, environment)
+	wantSystemd := "Environment=\"PATH=/custom&bin:/quoted\\\"path\"\nEnvironment=\"Z_VAR=last\""
+	if !strings.Contains(unit, wantSystemd) {
+		t.Fatalf("systemd unit = %q, want sorted escaped environment %q", unit, wantSystemd)
+	}
+
+	plist := LaunchdScheduledPlistContent("updates", command, time.Hour, environment)
+	wantLaunchd := "<key>EnvironmentVariables</key>\n    <dict>\n        <key>PATH</key>\n        <string>/custom&amp;bin:/quoted&#34;path</string>\n        <key>Z_VAR</key>\n        <string>last</string>\n    </dict>"
+	if !strings.Contains(plist, wantLaunchd) {
+		t.Fatalf("launchd plist = %q, want sorted escaped environment %q", plist, wantLaunchd)
 	}
 }
 

--- a/internal/shellcfg/shellcfg_test.go
+++ b/internal/shellcfg/shellcfg_test.go
@@ -314,6 +314,7 @@ func TestSpecToLock_Roundtrip(t *testing.T) {
 	lsc := SpecToLock(spec)
 	if lsc == nil {
 		t.Fatal("expected non-nil LockedShellConfig")
+		return
 	}
 	if len(lsc.Aliases) != 1 || lsc.Aliases[0].Name != "ll" || lsc.Aliases[0].Value != "ls -la" {
 		t.Errorf("alias roundtrip failed: %+v", lsc.Aliases)

--- a/internal/upgrade/planner.go
+++ b/internal/upgrade/planner.go
@@ -39,6 +39,7 @@ type UpgradeRunResult struct {
 	Plan           UpgradePlan
 	Upgraded       []genvfile.LockedPackage
 	Errors         []error
+	Failures       []resolver.UpgradeFailure
 	LockWriteError error
 }
 
@@ -60,14 +61,14 @@ func BuildUpgradePlan(opts UpgradeOptions) (UpgradePlan, error) {
 		}
 	}
 
-	allowedIDs := make(map[string]bool, len(opts.Spec.Packages))
+	packagesByID := make(map[string]schema.Package, len(opts.Spec.Packages))
 	for _, p := range opts.Spec.Packages {
-		allowedIDs[p.ID] = true
+		packagesByID[p.ID] = p
 	}
 
 	var allowedPackages []genvfile.LockedPackage
 	for _, lp := range opts.Lock.Packages {
-		if allowedIDs[lp.ID] {
+		if _, ok := packagesByID[lp.ID]; ok {
 			allowedPackages = append(allowedPackages, lp)
 		}
 	}
@@ -164,9 +165,24 @@ func BuildUpgradePlan(opts UpgradeOptions) (UpgradePlan, error) {
 		}
 	}
 
-	actions, skipped := resolver.PlanUpgrade(filteredPackages)
+	var upgradeablePackages []genvfile.LockedPackage
+	var skippedByConstraint []resolver.SkippedPackage
+	for _, lp := range filteredPackages {
+		if packagesByID[lp.ID].Version != "" {
+			skippedByConstraint = append(skippedByConstraint, resolver.SkippedPackage{
+				ID:      lp.ID,
+				Manager: lp.Manager,
+				Reason:  "version-constrained package requires an explicit compatible target",
+			})
+			continue
+		}
+		upgradeablePackages = append(upgradeablePackages, lp)
+	}
+
+	actions, skipped := resolver.PlanUpgrade(upgradeablePackages)
 	plan.Actions = actions
 	plan.Skipped = append(skipped, skippedByFilter...)
+	plan.Skipped = append(plan.Skipped, skippedByConstraint...)
 
 	return plan, nil
 }
@@ -179,6 +195,7 @@ func RunUpgrade(ctx context.Context, opts UpgradeRunOptions) UpgradeRunResult {
 		Plan:     opts.Plan,
 		Upgraded: execResult.Upgraded,
 		Errors:   append([]error(nil), execResult.Errors...),
+		Failures: append([]resolver.UpgradeFailure(nil), execResult.Failures...),
 	}
 	if opts.LockPath != "" {
 		if err := genvfile.WriteLock(opts.LockPath, opts.Lock); err != nil {

--- a/internal/upgrade/planner_test.go
+++ b/internal/upgrade/planner_test.go
@@ -1,12 +1,152 @@
 package upgrade
 
 import (
+	"bytes"
+	"context"
+	"slices"
 	"testing"
 
 	"github.com/ks1686/genv/internal/genvfile"
 	"github.com/ks1686/genv/internal/output"
+	"github.com/ks1686/genv/internal/resolver"
 	"github.com/ks1686/genv/internal/schema"
 )
+
+func TestBuildUpgradePlan_Constraint_unconstrained_package_plans_normally(t *testing.T) {
+	// Given: an unconstrained package tracked by a registered manager.
+	spec := &schema.GenvFile{Packages: []schema.Package{{ID: "git"}}}
+	lock := &genvfile.LockFile{Packages: []genvfile.LockedPackage{{ID: "git", Manager: "brew", PkgName: "git"}}}
+
+	// When: the shared upgrade plan is built.
+	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock})
+
+	// Then: the package retains the existing upgrade behavior.
+	if err != nil {
+		t.Fatalf("BuildUpgradePlan: %v", err)
+	}
+	if len(plan.Actions) != 1 || !slices.Equal([]string{plan.Actions[0].LPs[0].ID}, []string{"git"}) {
+		t.Fatalf("actions = %#v, want one action for git", plan.Actions)
+	}
+	if len(plan.Skipped) != 0 {
+		t.Fatalf("skipped = %#v, want none", plan.Skipped)
+	}
+}
+
+func TestBuildUpgradePlan_Constraint_constrained_packages_are_skipped_in_lock_order(t *testing.T) {
+	// Given: two constrained packages separated by an unconstrained package in lock order.
+	spec := &schema.GenvFile{Packages: []schema.Package{
+		{ID: "ripgrep", Version: "14.1.0"},
+		{ID: "git"},
+		{ID: "jq", Version: "1.7.x"},
+	}}
+	lock := &genvfile.LockFile{Packages: []genvfile.LockedPackage{
+		{ID: "jq", Manager: "brew", PkgName: "jq"},
+		{ID: "git", Manager: "brew", PkgName: "git"},
+		{ID: "ripgrep", Manager: "brew", PkgName: "ripgrep"},
+	}}
+
+	// When: the shared upgrade plan is built.
+	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock})
+
+	// Then: only the unconstrained package is planned and constraint skips retain lock order and identity.
+	if err != nil {
+		t.Fatalf("BuildUpgradePlan: %v", err)
+	}
+	if len(plan.Actions) != 1 || len(plan.Actions[0].LPs) != 1 || plan.Actions[0].LPs[0].ID != "git" {
+		t.Fatalf("actions = %#v, want one action for git", plan.Actions)
+	}
+	wantSkipped := []struct {
+		id      string
+		manager string
+	}{
+		{id: "jq", manager: "brew"},
+		{id: "ripgrep", manager: "brew"},
+	}
+	if len(plan.Skipped) != len(wantSkipped) {
+		t.Fatalf("skipped = %#v, want %d constraint skips", plan.Skipped, len(wantSkipped))
+	}
+	for i, want := range wantSkipped {
+		got := plan.Skipped[i]
+		if got.ID != want.id || got.Manager != want.manager || got.Reason != "version-constrained package requires an explicit compatible target" {
+			t.Errorf("skipped[%d] = %#v, want ID %q, manager %q, stable constraint reason", i, got, want.id, want.manager)
+		}
+	}
+}
+
+func TestBuildUpgradePlan_Constraint_mixed_batch_excludes_only_constrained_packages(t *testing.T) {
+	// Given: a batch-capable manager tracks constrained and unconstrained packages together.
+	spec := &schema.GenvFile{Packages: []schema.Package{
+		{ID: "git"},
+		{ID: "jq", Version: "1.7.1"},
+		{ID: "ripgrep"},
+	}}
+	lock := &genvfile.LockFile{Packages: []genvfile.LockedPackage{
+		{ID: "git", Manager: "brew", PkgName: "git"},
+		{ID: "jq", Manager: "brew", PkgName: "jq"},
+		{ID: "ripgrep", Manager: "brew", PkgName: "ripgrep"},
+	}}
+
+	// When: the shared upgrade plan is built.
+	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock})
+
+	// Then: the remaining unconstrained packages still form one batch.
+	if err != nil {
+		t.Fatalf("BuildUpgradePlan: %v", err)
+	}
+	if len(plan.Actions) != 1 {
+		t.Fatalf("actions = %#v, want one brew batch", plan.Actions)
+	}
+	gotIDs := make([]string, len(plan.Actions[0].LPs))
+	for i, lp := range plan.Actions[0].LPs {
+		gotIDs[i] = lp.ID
+	}
+	if !slices.Equal(gotIDs, []string{"git", "ripgrep"}) {
+		t.Fatalf("batch IDs = %v, want [git ripgrep]", gotIDs)
+	}
+	if len(plan.Skipped) != 1 || plan.Skipped[0].ID != "jq" {
+		t.Fatalf("skipped = %#v, want only jq", plan.Skipped)
+	}
+}
+
+func TestBuildUpgradePlan_Constraint_existing_package_filters_run_first(t *testing.T) {
+	// Given: a constrained package selected by overlapping package filters.
+	spec := &schema.GenvFile{Packages: []schema.Package{{ID: "jq", Version: "1.7.1"}}}
+	lock := &genvfile.LockFile{Packages: []genvfile.LockedPackage{{ID: "jq", Manager: "brew", PkgName: "jq"}}}
+	tests := []struct {
+		name       string
+		filters    output.UpgradeFilters
+		wantReason string
+	}{
+		{
+			name:       "skip excludes before constraint evaluation",
+			filters:    output.UpgradeFilters{Skip: []string{"jq"}},
+			wantReason: "excluded by --skip",
+		},
+		{
+			name:       "only takes precedence over skip before constraint evaluation",
+			filters:    output.UpgradeFilters{Only: []string{"jq"}, Skip: []string{"jq"}},
+			wantReason: "version-constrained package requires an explicit compatible target",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// When: the shared upgrade plan is built with the overlapping filters.
+			plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock, Filters: tt.filters})
+
+			// Then: existing filter precedence determines which skip reason is reported.
+			if err != nil {
+				t.Fatalf("BuildUpgradePlan: %v", err)
+			}
+			if len(plan.Actions) != 0 {
+				t.Fatalf("actions = %#v, want none", plan.Actions)
+			}
+			if len(plan.Skipped) != 1 || plan.Skipped[0].Reason != tt.wantReason {
+				t.Fatalf("skipped = %#v, want reason %q", plan.Skipped, tt.wantReason)
+			}
+		})
+	}
+}
 
 func TestBuildPlan(t *testing.T) {
 	spec := &schema.GenvFile{
@@ -125,4 +265,49 @@ func TestBuildUpgradePlan_is_callable_without_cli_side_effects(t *testing.T) {
 	if lock.Packages[0].InstalledVersion != "1.0.0" {
 		t.Fatalf("planner mutated lock version to %q", lock.Packages[0].InstalledVersion)
 	}
+}
+
+func TestRunUpgrade_propagates_typed_action_failures(t *testing.T) {
+	// Given: one synthetic failed upgrade action.
+	mgr := upgradeFailureTestAdapter{}
+	plan := UpgradePlan{Actions: []resolver.UpgradeAction{{
+		LPs: []genvfile.LockedPackage{{ID: "alpha", Manager: "brew", PkgName: "alpha"}},
+		Mgr: mgr,
+		Cmd: []string{"false"},
+	}}}
+
+	// When: the shared upgrade executor runs it.
+	result := RunUpgrade(context.Background(), UpgradeRunOptions{
+		Plan:   plan,
+		Lock:   &genvfile.LockFile{},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	})
+
+	// Then: callers receive both the existing error slice and structured action identity.
+	if len(result.Errors) != 1 {
+		t.Fatalf("Errors = %v, want one", result.Errors)
+	}
+	if len(result.Failures) != 1 || !slices.Equal(result.Failures[0].IDs, []string{"alpha"}) {
+		t.Fatalf("Failures = %#v, want alpha action failure", result.Failures)
+	}
+}
+
+type upgradeFailureTestAdapter struct{}
+
+func (upgradeFailureTestAdapter) Name() string { return "test-failure" }
+func (upgradeFailureTestAdapter) Available() bool {
+	return true
+}
+func (upgradeFailureTestAdapter) NormalizeID(id string, managers map[string]string) (string, bool) {
+	return id, false
+}
+func (upgradeFailureTestAdapter) PlanInstall(pkgName string) []string   { return nil }
+func (upgradeFailureTestAdapter) PlanUninstall(pkgName string) []string { return nil }
+func (upgradeFailureTestAdapter) PlanUpgrade(pkgName string) []string   { return nil }
+func (upgradeFailureTestAdapter) PlanClean() [][]string                 { return nil }
+func (upgradeFailureTestAdapter) Query(pkgName string) (bool, error)    { return true, nil }
+func (upgradeFailureTestAdapter) ListInstalled() ([]string, error)      { return nil, nil }
+func (upgradeFailureTestAdapter) QueryVersion(pkgName string) (string, error) {
+	return "", nil
 }

--- a/main.go
+++ b/main.go
@@ -989,16 +989,6 @@ func runApply(opts applyOptions) int {
 	return runApplyWithSpecAndLock(ctx, opts, f, lf, lockPath)
 }
 
-func runApplyWithSpec(ctx context.Context, opts applyOptions, f *schema.GenvFile) int {
-	lockPath := lockPathForSpec(opts.File, opts.LockFile)
-	lf, err := genvfile.ReadLock(lockPath)
-	if err != nil {
-		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
-		return exitIO
-	}
-	return runApplyWithSpecAndLock(ctx, opts, f, lf, lockPath)
-}
-
 func runApplyWithSpecAndLock(ctx context.Context, opts applyOptions, f *schema.GenvFile, lf *genvfile.LockFile, lockPath string) int {
 	f = host.FilterForHost(f, hostForCommand(opts.Host))
 
@@ -1208,7 +1198,7 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	_, _, svcErrs := applyServices(ctx, f, lf, !opts.Quiet)
 	var fileErrs []error
 	if len(execResult.Errors) == 0 {
-		filePlan, filePlanErr = applyFiles(ctx, opts, f, lf)
+		_, filePlanErr = applyFiles(ctx, opts, f, lf)
 		if filePlanErr != nil {
 			fileErrs = append(fileErrs, filePlanErr)
 		}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -2215,6 +2216,8 @@ func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (app
 // bulk-adopts them into genv.json and the lock file. Packages already tracked
 // are skipped. Duplicate names discovered across multiple managers are
 // deduplicated — the first adapter in registry order wins.
+var scanGOOS = runtime.GOOS
+
 func scanCmd(args []string) int {
 	fs := flag.NewFlagSet("scan", flag.ContinueOnError)
 	fs.Usage = func() {
@@ -2279,10 +2282,7 @@ func scanCmd(args []string) int {
 	var added int
 	var skipped int
 
-	for _, a := range adapter.All {
-		if !available[a.Name()] {
-			continue
-		}
+	for _, a := range scanAdaptersOnGOOS(available, scanGOOS) {
 		versions := map[string]string(nil)
 		var pkgs []string
 		if versionLister, ok := a.(adapter.VersionLister); ok {
@@ -2366,6 +2366,16 @@ func scanCmd(args []string) int {
 	}
 	fprintf(os.Stdout, "scan complete: %d added, %d already tracked\n", added, skipped)
 	return exitOK
+}
+
+func scanAdaptersOnGOOS(available map[string]bool, goos string) []adapter.Adapter {
+	selected := make([]adapter.Adapter, 0, len(adapter.All))
+	for _, a := range adapter.All {
+		if available[a.Name()] && adapter.AutomaticOnGOOS(a.Name(), goos) {
+			selected = append(selected, a)
+		}
+	}
+	return selected
 }
 
 // statusCmd implements `genv status [--json] [--debug]`.

--- a/main_profile_test.go
+++ b/main_profile_test.go
@@ -110,17 +110,21 @@ func TestProfileSwitch(t *testing.T) {
 	}
 	profA, _ := profile.Load(specPath, "A")
 	profA.Packages = append(profA.Packages, schema.Package{ID: "pkg-A"})
-	genvfile.Write(profile.Path(specPath, "A"), profA)
+	if err := genvfile.Write(profile.Path(specPath, "A"), profA); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := profile.Create(specPath, "B"); err != nil {
 		t.Fatal(err)
 	}
 	profB, _ := profile.Load(specPath, "B")
 	profB.Packages = append(profB.Packages, schema.Package{ID: "pkg-B"})
-	genvfile.Write(profile.Path(specPath, "B"), profB)
+	if err := genvfile.Write(profile.Path(specPath, "B"), profB); err != nil {
+		t.Fatal(err)
+	}
 
 	// Switch to A
-	out := captureStdout(t, func() {
+	_ = captureStdout(t, func() {
 		code := run([]string{"profile", "switch", "A", "-file", specPath, "-lock-file", lockPath, "-yes"})
 		if code != exitOK {
 			t.Errorf("expected exitOK, got %d", code)
@@ -136,7 +140,7 @@ func TestProfileSwitch(t *testing.T) {
 	}
 
 	// Switch to B
-	out = captureStdout(t, func() {
+	_ = captureStdout(t, func() {
 		code := run([]string{"profile", "switch", "B", "-file", specPath, "-lock-file", lockPath, "-yes"})
 		if code != exitOK {
 			t.Errorf("expected exitOK, got %d", code)
@@ -162,8 +166,6 @@ func TestProfileSwitch(t *testing.T) {
 	if pkgMap["pkg-A"] {
 		t.Error("pkg-A was not removed")
 	}
-
-	_ = out
 }
 
 func TestStatusJSONActiveProfile(t *testing.T) {
@@ -198,7 +200,9 @@ func TestStatusJSONActiveProfile(t *testing.T) {
 
 	dataBytes, _ := json.Marshal(env.Data)
 	var res output.StatusResult
-	json.Unmarshal(dataBytes, &res)
+	if err := json.Unmarshal(dataBytes, &res); err != nil {
+		t.Fatal(err)
+	}
 
 	if res.ActiveProfile != "work" {
 		t.Errorf("expected active profile 'work', got %q", res.ActiveProfile)
@@ -224,23 +228,31 @@ func TestProfileSwitchFailure(t *testing.T) {
 	}
 	profA, _ := profile.LoadMerged(specPath, "A")
 	profA.Packages = append(profA.Packages, schema.Package{ID: "pkg-A"})
-	genvfile.Write(profile.Path(specPath, "A"), profA)
+	if err := genvfile.Write(profile.Path(specPath, "A"), profA); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := profile.Create(specPath, "B"); err != nil {
 		t.Fatal(err)
 	}
 	profB, _ := profile.LoadMerged(specPath, "B")
 	profB.Packages = append(profB.Packages, schema.Package{ID: "pkg-B"})
-	genvfile.Write(profile.Path(specPath, "B"), profB)
+	if err := genvfile.Write(profile.Path(specPath, "B"), profB); err != nil {
+		t.Fatal(err)
+	}
 
 	// Switch to A successfully
 	run([]string{"profile", "switch", "A", "-file", specPath, "-lock-file", lockPath, "-yes"})
 
 	// Now mock a failure for pkg-B
 	fakeBin := filepath.Join(dir, "bin")
-	os.MkdirAll(fakeBin, 0755)
+	if err := os.MkdirAll(fakeBin, 0755); err != nil {
+		t.Fatal(err)
+	}
 	fakeBrew := filepath.Join(fakeBin, "brew")
-	os.WriteFile(fakeBrew, []byte("#!/bin/sh\nif [ \"$2\" = \"pkg-B\" ]; then echo 'mock install failure'; exit 1; fi\nexit 0\n"), 0755)
+	if err := os.WriteFile(fakeBrew, []byte("#!/bin/sh\nif [ \"$2\" = \"pkg-B\" ]; then echo 'mock install failure'; exit 1; fi\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
 
 	// Switch to B should fail
@@ -308,7 +320,9 @@ func TestProfileSwitchInvalidJSON(t *testing.T) {
 	if err := profile.Create(specPath, "bad"); err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(profile.Path(specPath, "bad"), []byte("{bad json"), 0644)
+	if err := os.WriteFile(profile.Path(specPath, "bad"), []byte("{bad json"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	out := captureStderr(t, func() {
 		code := run([]string{"profile", "switch", "bad", "-file", specPath, "-lock-file", lockPath, "-yes"})

--- a/main_profile_test.go
+++ b/main_profile_test.go
@@ -217,34 +217,10 @@ func TestProfileSwitchFailure(t *testing.T) {
 	specPath := filepath.Join(dir, "genv.json")
 	lockPath := filepath.Join(dir, "genv.lock.json")
 
-	base := genvfile.New()
-	base.Packages = append(base.Packages, schema.Package{ID: "base-pkg"})
-	if err := genvfile.Write(specPath, base); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := profile.Create(specPath, "A"); err != nil {
-		t.Fatal(err)
-	}
-	profA, _ := profile.LoadMerged(specPath, "A")
-	profA.Packages = append(profA.Packages, schema.Package{ID: "pkg-A"})
-	if err := genvfile.Write(profile.Path(specPath, "A"), profA); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := profile.Create(specPath, "B"); err != nil {
-		t.Fatal(err)
-	}
-	profB, _ := profile.LoadMerged(specPath, "B")
-	profB.Packages = append(profB.Packages, schema.Package{ID: "pkg-B"})
-	if err := genvfile.Write(profile.Path(specPath, "B"), profB); err != nil {
-		t.Fatal(err)
-	}
-
-	// Switch to A successfully
-	run([]string{"profile", "switch", "A", "-file", specPath, "-lock-file", lockPath, "-yes"})
-
-	// Now mock a failure for pkg-B
+	// Install a fake brew that succeeds for every package except pkg-B, and put
+	// it first on PATH before any switch. Packages explicitly prefer brew so
+	// resolution is deterministic on every platform (the automatic brew/linuxbrew
+	// suggestion is platform-specific, but explicit selection is not).
 	fakeBin := filepath.Join(dir, "bin")
 	if err := os.MkdirAll(fakeBin, 0755); err != nil {
 		t.Fatal(err)
@@ -255,7 +231,34 @@ func TestProfileSwitchFailure(t *testing.T) {
 	}
 	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
 
-	// Switch to B should fail
+	base := genvfile.New()
+	base.Packages = append(base.Packages, schema.Package{ID: "base-pkg", Prefer: "brew"})
+	if err := genvfile.Write(specPath, base); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := profile.Create(specPath, "A"); err != nil {
+		t.Fatal(err)
+	}
+	profA, _ := profile.LoadMerged(specPath, "A")
+	profA.Packages = append(profA.Packages, schema.Package{ID: "pkg-A", Prefer: "brew"})
+	if err := genvfile.Write(profile.Path(specPath, "A"), profA); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := profile.Create(specPath, "B"); err != nil {
+		t.Fatal(err)
+	}
+	profB, _ := profile.LoadMerged(specPath, "B")
+	profB.Packages = append(profB.Packages, schema.Package{ID: "pkg-B", Prefer: "brew"})
+	if err := genvfile.Write(profile.Path(specPath, "B"), profB); err != nil {
+		t.Fatal(err)
+	}
+
+	// Switch to A successfully
+	run([]string{"profile", "switch", "A", "-file", specPath, "-lock-file", lockPath, "-yes"})
+
+	// Switch to B should fail because installing pkg-B via the fake brew exits 1
 	out := captureStderr(t, func() {
 		code := run([]string{"profile", "switch", "B", "-file", specPath, "-lock-file", lockPath, "-yes"})
 		if code == exitOK {

--- a/main_pull.go
+++ b/main_pull.go
@@ -181,7 +181,7 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", src, err)
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
 		return fmt.Errorf("creating parent directory: %w", err)

--- a/main_test.go
+++ b/main_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -1047,6 +1049,89 @@ func TestScanCmd_Debug_NoCrash(t *testing.T) {
 	}
 }
 
+func TestScanAdapters_HomebrewPlatform(t *testing.T) {
+	available := map[string]bool{"brew": true, "linuxbrew": true}
+
+	tests := []struct {
+		name    string
+		goos    string
+		include string
+		exclude string
+	}{
+		{name: "Darwin scans Homebrew only", goos: "darwin", include: "brew", exclude: "linuxbrew"},
+		{name: "Linux scans Linuxbrew only", goos: "linux", include: "linuxbrew", exclude: "brew"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selected := scanAdaptersOnGOOS(available, tt.goos)
+			names := make([]string, 0, len(selected))
+			for _, a := range selected {
+				names = append(names, a.Name())
+			}
+
+			if !slices.Contains(names, tt.include) {
+				t.Errorf("selected managers %v do not include %q", names, tt.include)
+			}
+			if slices.Contains(names, tt.exclude) {
+				t.Errorf("selected managers %v include non-native %q", names, tt.exclude)
+			}
+		})
+	}
+}
+
+type scanCountingAdapter struct {
+	name      string
+	listCalls int
+}
+
+func (a *scanCountingAdapter) Name() string { return a.name }
+func (a *scanCountingAdapter) Available() bool {
+	return true
+}
+
+func (a *scanCountingAdapter) NormalizeID(id string, managers map[string]string) (string, bool) {
+	return id, false
+}
+func (a *scanCountingAdapter) PlanInstall(pkgName string) []string   { return []string{"true"} }
+func (a *scanCountingAdapter) PlanUninstall(pkgName string) []string { return []string{"true"} }
+func (a *scanCountingAdapter) PlanUpgrade(pkgName string) []string   { return []string{"true"} }
+func (a *scanCountingAdapter) PlanClean() [][]string                 { return nil }
+func (a *scanCountingAdapter) Query(pkgName string) (bool, error)    { return true, nil }
+func (a *scanCountingAdapter) ListInstalled() ([]string, error) {
+	a.listCalls++
+	return nil, nil
+}
+func (a *scanCountingAdapter) QueryVersion(pkgName string) (string, error) { return "", nil }
+
+func TestScanCmd_DarwinDoesNotListLinuxbrew(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "genv.json")
+	brew := &scanCountingAdapter{name: "brew"}
+	linuxbrew := &scanCountingAdapter{name: "linuxbrew"}
+
+	originalAll := adapter.All
+	originalGOOS := scanGOOS
+	adapter.All = []adapter.Adapter{brew, linuxbrew}
+	scanGOOS = "darwin"
+	t.Cleanup(func() {
+		adapter.All = originalAll
+		scanGOOS = originalGOOS
+	})
+
+	code := run([]string{"scan", "--file", path})
+
+	if code != exitOK {
+		t.Fatalf("scan: expected exitOK (%d), got %d", exitOK, code)
+	}
+	if brew.listCalls != 1 {
+		t.Errorf("Homebrew ListInstalled calls = %d, want 1", brew.listCalls)
+	}
+	if linuxbrew.listCalls != 0 {
+		t.Errorf("Linuxbrew ListInstalled calls = %d, want 0", linuxbrew.listCalls)
+	}
+}
+
 type scanVersionListerAdapter struct {
 	listCalls         int
 	versionListCalls  int
@@ -1057,22 +1142,28 @@ func (a *scanVersionListerAdapter) Name() string { return "batch" }
 func (a *scanVersionListerAdapter) Available() bool {
 	return true
 }
+
 func (a *scanVersionListerAdapter) NormalizeID(id string, managers map[string]string) (string, bool) {
 	return id, false
 }
-func (a *scanVersionListerAdapter) PlanInstall(pkgName string) []string   { return []string{"true"} }
+
+func (a *scanVersionListerAdapter) PlanInstall(pkgName string) []string { return []string{"true"} }
+
 func (a *scanVersionListerAdapter) PlanUninstall(pkgName string) []string { return []string{"true"} }
-func (a *scanVersionListerAdapter) PlanUpgrade(pkgName string) []string   { return []string{"true"} }
-func (a *scanVersionListerAdapter) PlanClean() [][]string                 { return nil }
-func (a *scanVersionListerAdapter) Query(pkgName string) (bool, error)    { return true, nil }
+
+func (a *scanVersionListerAdapter) PlanUpgrade(pkgName string) []string { return []string{"true"} }
+func (a *scanVersionListerAdapter) PlanClean() [][]string               { return nil }
+func (a *scanVersionListerAdapter) Query(pkgName string) (bool, error)  { return true, nil }
 func (a *scanVersionListerAdapter) ListInstalled() ([]string, error) {
 	a.listCalls++
 	return []string{"alpha", "beta"}, nil
 }
+
 func (a *scanVersionListerAdapter) QueryVersion(pkgName string) (string, error) {
 	a.queryVersionCalls++
 	return "fallback", nil
 }
+
 func (a *scanVersionListerAdapter) ListInstalledVersions() (map[string]string, error) {
 	a.versionListCalls++
 	return map[string]string{"beta": "2.0.0", "alpha": "1.0.0"}, nil
@@ -1356,6 +1447,7 @@ func (a upgradeNoHooksAdapter) Name() string { return "test-upgrade-no-hooks" }
 func (a upgradeNoHooksAdapter) Available() bool {
 	return true
 }
+
 func (a upgradeNoHooksAdapter) NormalizeID(id string, managers map[string]string) (string, bool) {
 	return id, false
 }
@@ -1363,6 +1455,7 @@ func (a upgradeNoHooksAdapter) PlanInstall(pkgName string) []string { return []s
 func (a upgradeNoHooksAdapter) PlanUninstall(pkgName string) []string {
 	return []string{"true"}
 }
+
 func (a upgradeNoHooksAdapter) PlanUpgrade(pkgName string) []string {
 	return []string{"sh", "-c", "printf upgrade >> " + a.marker}
 }
@@ -1371,6 +1464,7 @@ func (a upgradeNoHooksAdapter) Query(pkgName string) (bool, error) { return true
 func (a upgradeNoHooksAdapter) ListInstalled() ([]string, error) {
 	return []string{pkgNameForTest}, nil
 }
+
 func (a upgradeNoHooksAdapter) QueryVersion(pkgName string) (string, error) {
 	return "2.0.0", nil
 }
@@ -1388,18 +1482,22 @@ func (a lifecycleHookAdapter) Available() bool { return true }
 func (a lifecycleHookAdapter) NormalizeID(id string, managers map[string]string) (string, bool) {
 	return id, false
 }
+
 func (a lifecycleHookAdapter) PlanInstall(pkgName string) []string {
 	return []string{"sh", "-c", "printf install >> " + a.installMarker}
 }
+
 func (a lifecycleHookAdapter) PlanUninstall(pkgName string) []string {
 	return []string{"sh", "-c", "printf uninstall >> " + a.uninstallMarker}
 }
+
 func (a lifecycleHookAdapter) PlanUpgrade(pkgName string) []string {
 	return []string{"sh", "-c", "printf upgrade >> " + a.upgradeMarker}
 }
 func (a lifecycleHookAdapter) PlanClean() [][]string              { return nil }
 func (a lifecycleHookAdapter) Query(pkgName string) (bool, error) { return true, nil }
 func (a lifecycleHookAdapter) ListInstalled() ([]string, error)   { return []string{pkgNameForTest}, nil }
+
 func (a lifecycleHookAdapter) QueryVersion(pkgName string) (string, error) {
 	return "2.0.0", nil
 }
@@ -1980,7 +2078,8 @@ func TestUpdates_UsageErrors_are_actionable(t *testing.T) {
 
 type fakeUpdatesSupervisor struct {
 	supported bool
-	running   bool
+	status    service.ScheduledJobStatus
+	statusErr error
 	started   []service.ScheduledJob
 	stopped   []string
 }
@@ -1998,7 +2097,12 @@ func (f *fakeUpdatesSupervisor) Stop(ctx context.Context, name string) error {
 }
 
 func (f *fakeUpdatesSupervisor) Status(ctx context.Context, name string) (service.ScheduledJobStatus, error) {
-	return service.ScheduledJobStatus{Supported: f.supported, Running: f.running, Detail: name}, nil
+	status := f.status
+	status.Supported = f.supported
+	if status.Detail == "" {
+		status.Detail = name
+	}
+	return status, f.statusErr
 }
 
 func withUpdatesSupervisor(t *testing.T, supervisor *fakeUpdatesSupervisor) {
@@ -2062,6 +2166,8 @@ func TestUpdatesStart_valid_config_registers_scheduler_without_auto_apply(t *tes
 	originalExecutable := updatesExecutable
 	updatesExecutable = func() (string, error) { return "/tmp/genv-test-bin", nil }
 	t.Cleanup(func() { updatesExecutable = originalExecutable })
+	invokingPath := "/custom/bin:relative:/usr/bin:/custom/bin"
+	t.Setenv("PATH", invokingPath)
 
 	// When: updates start is invoked.
 	var code int
@@ -2083,6 +2189,10 @@ func TestUpdatesStart_valid_config_registers_scheduler_without_auto_apply(t *tes
 	wantCommand := []string{"/tmp/genv-test-bin", "updates", "__run-once", "--file", specPath, "--lock-file", lockPath, "--host", "qa-host"}
 	if !slices.Equal(job.Command, wantCommand) {
 		t.Fatalf("job command = %v, want %v", job.Command, wantCommand)
+	}
+	wantPath := service.ScheduledPath(invokingPath, runtime.GOOS)
+	if got := job.Environment["PATH"]; got != wantPath {
+		t.Fatalf("job PATH = %q, want sanitized augmented PATH %q", got, wantPath)
 	}
 	if !strings.Contains(out, "check/log/notify only") || strings.Contains(out, "auto-apply enabled") {
 		t.Fatalf("stdout = %q, want explicit default check-only mode", out)
@@ -2109,6 +2219,62 @@ func TestUpdatesStatusAndStop_unsupported_platform_do_not_crash(t *testing.T) {
 	}
 	if !strings.Contains(stopOut, "not supported") || !strings.Contains(stopOut, "nothing to stop") {
 		t.Fatalf("stop output = %q, want unsupported nothing to stop", stopOut)
+	}
+}
+
+func TestUpdatesStatus_prints_typed_scheduler_state(t *testing.T) {
+	exitZero := 0
+	exitSeven := 7
+	tests := []struct {
+		name     string
+		status   service.ScheduledJobStatus
+		want     []string
+		dontWant []string
+	}{
+		{name: "not registered", status: service.ScheduledJobStatus{Supported: true}, want: []string{"not registered"}},
+		{name: "registered and executing", status: service.ScheduledJobStatus{Supported: true, Registered: true, Executing: true}, want: []string{"registered and executing"}, dontWant: []string{"idle", "last run", "no completed run"}},
+		{name: "registered idle no known run", status: service.ScheduledJobStatus{Supported: true, Registered: true, LastRun: service.ScheduledRunUnknown}, want: []string{"registered and idle", "no completed run is known"}},
+		{name: "registered idle last run succeeded", status: service.ScheduledJobStatus{Supported: true, Registered: true, LastRun: service.ScheduledRunSuccess, ExitCode: &exitZero}, want: []string{"registered and idle", "last run succeeded", "status 0"}},
+		{name: "registered idle last run failed", status: service.ScheduledJobStatus{Supported: true, Registered: true, LastRun: service.ScheduledRunFailure, ExitCode: &exitSeven, LastRunDetail: "exit-code"}, want: []string{"registered and idle", "last run failed", "status 7", "exit-code"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			supervisor := &fakeUpdatesSupervisor{supported: true, status: tt.status}
+			withUpdatesSupervisor(t, supervisor)
+
+			var code int
+			out := captureStdout(t, func() { code = run([]string{"updates", "status"}) })
+
+			if code != exitOK {
+				t.Fatalf("updates status code = %d, want %d", code, exitOK)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(out, want) {
+					t.Fatalf("stdout = %q, want %q", out, want)
+				}
+			}
+			for _, dontWant := range tt.dontWant {
+				if strings.Contains(out, dontWant) {
+					t.Fatalf("stdout = %q, do not want contradictory %q wording", out, dontWant)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdatesStatus_returns_io_error_when_inspection_fails(t *testing.T) {
+	supervisor := &fakeUpdatesSupervisor{supported: true, statusErr: errors.New("supervisor unavailable")}
+	withUpdatesSupervisor(t, supervisor)
+
+	var code int
+	errOut := captureStderr(t, func() { code = run([]string{"updates", "status"}) })
+
+	if code != exitIO {
+		t.Fatalf("updates status code = %d, want %d", code, exitIO)
+	}
+	if !strings.Contains(errOut, "supervisor unavailable") {
+		t.Fatalf("stderr = %q, want inspection error", errOut)
 	}
 }
 
@@ -2155,6 +2321,222 @@ func TestUpdatesRunOnce_auto_apply_only_when_explicit(t *testing.T) {
 				t.Fatalf("RunUpgrade calls = %d, want %d", runCalls, tt.wantRuns)
 			}
 		})
+	}
+}
+
+func TestUpdatesLogger_returns_error_for_unusable_log_path(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, xdg string)
+	}{
+		{
+			name: "directory creation failure",
+			setup: func(t *testing.T, xdg string) {
+				t.Helper()
+				if err := os.WriteFile(xdg, []byte("not a directory"), 0o600); err != nil {
+					t.Fatalf("write XDG_CONFIG_HOME file: %v", err)
+				}
+			},
+		},
+		{
+			name: "log open failure",
+			setup: func(t *testing.T, xdg string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(xdg, "genv", "updates.log"), 0o700); err != nil {
+					t.Fatalf("mkdir updates.log directory: %v", err)
+				}
+			},
+		},
+		{
+			name: "log rotation failure",
+			setup: func(t *testing.T, xdg string) {
+				t.Helper()
+				dir := filepath.Join(xdg, "genv")
+				if err := os.MkdirAll(filepath.Join(dir, "updates.log.1", "occupied"), 0o700); err != nil {
+					t.Fatalf("mkdir rotation target: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "updates.log"), make([]byte, (1<<20)+1), 0o600); err != nil {
+					t.Fatalf("write oversized updates.log: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: the audit log path cannot be prepared for the named reason.
+			xdg := filepath.Join(t.TempDir(), "xdg")
+			tt.setup(t, xdg)
+			t.Setenv("XDG_CONFIG_HOME", xdg)
+
+			// When: the scheduled audit logger is initialized.
+			logger, closeLog, err := updatesLogger()
+
+			// Then: initialization reports the I/O failure instead of discarding logs.
+			if err == nil {
+				if closeLog != nil {
+					closeLog()
+				}
+				t.Fatalf("updatesLogger returned logger %v without an error", logger)
+			}
+		})
+	}
+}
+
+func TestUpdatesRunOnce_LoggerFailure_stops_before_executor(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, xdg string)
+	}{
+		{
+			name: "directory creation failure",
+			setup: func(t *testing.T, xdg string) {
+				t.Helper()
+				if err := os.WriteFile(xdg, []byte("not a directory"), 0o600); err != nil {
+					t.Fatalf("write XDG_CONFIG_HOME file: %v", err)
+				}
+			},
+		},
+		{
+			name: "log open failure",
+			setup: func(t *testing.T, xdg string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(xdg, "genv", "updates.log"), 0o700); err != nil {
+					t.Fatalf("mkdir updates.log directory: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: audit logger initialization fails and the executor is observable.
+			xdg := filepath.Join(t.TempDir(), "xdg")
+			tt.setup(t, xdg)
+			t.Setenv("XDG_CONFIG_HOME", xdg)
+			originalRun := updatesRunUpgrade
+			runCalls := 0
+			updatesRunUpgrade = func(ctx context.Context, opts upgrade.UpgradeRunOptions) upgrade.UpgradeRunResult {
+				runCalls++
+				return upgrade.UpgradeRunResult{}
+			}
+			t.Cleanup(func() { updatesRunUpgrade = originalRun })
+
+			// When: the one-shot worker starts.
+			var code int
+			errOut := captureStderr(t, func() {
+				code = run([]string{"updates", "__run-once", "--file", "unused.json", "--lock-file", "unused.lock.json"})
+			})
+
+			// Then: it exits as I/O failure before any auto-apply execution.
+			if code != exitIO {
+				t.Fatalf("updates __run-once code = %d, want %d", code, exitIO)
+			}
+			if runCalls != 0 {
+				t.Fatalf("RunUpgrade calls = %d, want zero", runCalls)
+			}
+			if errOut != "genv updates: audit log unavailable\n" {
+				t.Fatalf("stderr = %q, want minimal audit log error", errOut)
+			}
+		})
+	}
+}
+
+func TestUpdatesRunOnce_UpgradeFailure_logs_typed_failures_and_unmatched_legacy_errors(t *testing.T) {
+	// Given: auto-apply has typed failures, one unmatched legacy error, and oversized diagnostics.
+	dir := t.TempDir()
+	xdg := filepath.Join(dir, "xdg")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	if err := os.WriteFile(specPath, []byte(`{"schemaVersion":"6","packages":[{"id":"alpha"},{"id":"beta"},{"id":"gamma"}],"updates":{"enabled":true,"interval":"1h","autoApply":true}}`), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	writeLock(t, lockPath, nil)
+	plan := upgrade.UpgradePlan{Actions: []resolver.UpgradeAction{
+		{LPs: []genvfile.LockedPackage{{ID: "alpha"}, {ID: "beta"}}},
+		{LPs: []genvfile.LockedPackage{{ID: "gamma"}}},
+	}}
+	originalBuild := updatesBuildPlan
+	updatesBuildPlan = func(opts upgrade.UpgradeOptions) (upgrade.UpgradePlan, error) { return plan, nil }
+	t.Cleanup(func() { updatesBuildPlan = originalBuild })
+	originalRun := updatesRunUpgrade
+	updatesRunUpgrade = func(ctx context.Context, opts upgrade.UpgradeRunOptions) upgrade.UpgradeRunResult {
+		_, _ = io.WriteString(opts.Stderr, "TOKEN=synthetic-token\nAuthorization: Bearer synthetic-bearer\n"+strings.Repeat("diagnostic", 10_000))
+		firstErr := errors.New("first synthetic failure PASSWORD=synthetic-password")
+		secondErr := errors.New("second synthetic failure")
+		legacyErr := errors.New("legacy synthetic failure")
+		return upgrade.UpgradeRunResult{
+			Plan:   opts.Plan,
+			Errors: []error{secondErr, legacyErr, firstErr},
+			Failures: []resolver.UpgradeFailure{
+				{IDs: []string{"alpha", "beta", "pkg?auth=credential-id-secret"}, Err: firstErr},
+				{IDs: []string{"gamma"}, Err: secondErr},
+			},
+		}
+	}
+	t.Cleanup(func() { updatesRunUpgrade = originalRun })
+
+	// When: the scheduled worker executes the synthetic upgrade result.
+	code := run([]string{"updates", "__run-once", "--file", specPath, "--lock-file", lockPath})
+
+	// Then: each action failure and one bounded sanitized diagnostic event are audited.
+	if code != exitLogic {
+		t.Fatalf("updates __run-once code = %d, want %d", code, exitLogic)
+	}
+	logBytes, err := os.ReadFile(filepath.Join(xdg, "genv", "updates.log"))
+	if err != nil {
+		t.Fatalf("read updates log: %v", err)
+	}
+	logText := string(logBytes)
+	if strings.Count(logText, "updates.apply.failed") != 3 {
+		t.Fatalf("updates log has %d failure events, want 3: %q", strings.Count(logText, "updates.apply.failed"), logText)
+	}
+	for _, want := range []string{"alpha", "beta", "gamma", "second synthetic failure", "legacy synthetic failure"} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("updates log missing %q: %q", want, logText)
+		}
+	}
+	for _, want := range []struct {
+		err string
+		ids []string
+	}{
+		{err: "second synthetic failure", ids: []string{"gamma"}},
+	} {
+		for _, line := range strings.Split(logText, "\n") {
+			if strings.Contains(line, want.err) {
+				for _, id := range want.ids {
+					if !strings.Contains(line, id) {
+						t.Fatalf("failure line %q missing correlated ID %q", line, id)
+					}
+				}
+			}
+		}
+	}
+	for _, line := range strings.Split(logText, "\n") {
+		if strings.Contains(line, "alpha") && strings.Contains(line, "beta") && strings.Count(line, updatesDiagnosticRedactionMarker) < 2 {
+			t.Fatalf("credential-bearing failure line is not fully redacted: %q", line)
+		}
+	}
+	for _, secret := range []string{"synthetic-token", "synthetic-bearer", "synthetic-password"} {
+		if strings.Contains(logText, secret) {
+			t.Fatalf("updates log contains synthetic secret %q", secret)
+		}
+	}
+	if strings.Contains(logText, "credential-id-secret") {
+		t.Fatalf("updates log contains credential-bearing package ID: %q", logText)
+	}
+	if !strings.Contains(logText, updatesDiagnosticRedactionMarker) {
+		t.Fatalf("updates log missing package ID redaction marker: %q", logText)
+	}
+	if strings.Count(logText, "updates.apply.diagnostics") != 1 {
+		t.Fatalf("updates log has %d diagnostic events, want 1", strings.Count(logText, "updates.apply.diagnostics"))
+	}
+	if !strings.Contains(logText, updatesDiagnosticTruncationMarker) {
+		t.Fatalf("updates log missing truncation marker")
+	}
+	if !strings.Contains(logText, "updates.apply.completed") {
+		t.Fatalf("updates log missing updates.apply.completed: %q", logText)
 	}
 }
 

--- a/main_updates_daemon.go
+++ b/main_updates_daemon.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/ks1686/genv/internal/genvfile"
@@ -63,7 +65,10 @@ func updatesStartCmd(args []string) int {
 	}
 	lockPath := lockPathForSpec(*file, *lockFile)
 	command := []string{exe, "updates", "__run-once", "--file", absFile, "--lock-file", lockPath, "--host", hostForCommand(*hostFlag)}
-	if err := backend.Start(context.Background(), service.ScheduledJob{Name: updatesServiceName, Command: command, Interval: interval}); err != nil {
+	pathValue := os.Getenv("PATH")
+	goos := runtime.GOOS
+	environment := map[string]string{"PATH": service.ScheduledPath(pathValue, goos)}
+	if err := backend.Start(context.Background(), service.ScheduledJob{Name: updatesServiceName, Command: command, Interval: interval, Environment: environment}); err != nil {
 		fprintf(os.Stderr, "genv updates start: %v\n", err)
 		return exitIO
 	}
@@ -110,12 +115,39 @@ func updatesStatusCmd(args []string) int {
 		fPrintln(os.Stdout, "updates checker is not supported on this platform (requires systemd --user on Linux or launchd on macOS); not running.")
 		return exitOK
 	}
-	if status.Running {
-		fprintf(os.Stdout, "updates checker is running (%s).\n", status.Detail)
+	if !status.Registered {
+		fprintf(os.Stdout, "updates checker is not registered (%s).\n", status.Detail)
 		return exitOK
 	}
-	fprintf(os.Stdout, "updates checker is not running (%s).\n", status.Detail)
+	if status.Executing {
+		fprintf(os.Stdout, "updates checker is registered and executing (%s).\n", status.Detail)
+		return exitOK
+	}
+	switch status.LastRun {
+	case service.ScheduledRunSuccess:
+		fprintf(os.Stdout, "updates checker is registered and idle; last run succeeded%s (%s).\n", scheduledRunStatusDetail(status), status.Detail)
+	case service.ScheduledRunFailure:
+		fprintf(os.Stdout, "updates checker is registered and idle; last run failed%s (%s).\n", scheduledRunStatusDetail(status), status.Detail)
+	case service.ScheduledRunUnknown, "":
+		fprintf(os.Stdout, "updates checker is registered and idle; no completed run is known (%s).\n", status.Detail)
+	default:
+		fprintf(os.Stdout, "updates checker is registered and idle; last-run outcome is unknown (%s).\n", status.Detail)
+	}
 	return exitOK
+}
+
+func scheduledRunStatusDetail(status service.ScheduledJobStatus) string {
+	parts := make([]string, 0, 2)
+	if status.ExitCode != nil {
+		parts = append(parts, fmt.Sprintf("status %d", *status.ExitCode))
+	}
+	if status.LastRunDetail != "" {
+		parts = append(parts, "reason "+status.LastRunDetail)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, "; ") + ")"
 }
 
 func readUpdatesConfigForLifecycle(file string) (*schema.UpdatesConfig, time.Duration, int) {

--- a/main_updates_diagnostics.go
+++ b/main_updates_diagnostics.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+)
+
+const (
+	updatesDiagnosticLimit            = 64 << 10
+	updatesDiagnosticTruncationMarker = "[diagnostics truncated]"
+	updatesDiagnosticRedactionMarker  = "[REDACTED]"
+)
+
+var (
+	updatesCredentialAssignmentLinePattern = regexp.MustCompile(`(?i)[a-z0-9_-]*(?:token|secret|password|api[-_]?key|auth)[a-z0-9_-]*(?:\\?["'])?\s*[:=]`)
+	updatesCredentialFlagLinePattern       = regexp.MustCompile(`(?i)--(?:[a-z0-9]+[-_])*(?:token|secret|password|api[-_]?key|auth(?:orization)?)(?:[-_][a-z0-9]+)*(?:\s+|=)`)
+	updatesCredentialURLLinePattern        = regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^/@\s]+@`)
+)
+
+type updatesDiagnosticWriter struct {
+	limit   int
+	total   int
+	content bytes.Buffer
+}
+
+func newUpdatesDiagnosticWriter(limit int) *updatesDiagnosticWriter {
+	return &updatesDiagnosticWriter{limit: limit}
+}
+
+func (w *updatesDiagnosticWriter) Write(p []byte) (int, error) {
+	w.total += len(p)
+	remaining := w.limit - w.content.Len()
+	if remaining > 0 {
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		_, _ = w.content.Write(p[:remaining])
+	}
+	return len(p), nil
+}
+
+func (w *updatesDiagnosticWriter) String() string {
+	retained := w.content.Bytes()
+	if w.total <= w.limit {
+		return string(retained)
+	}
+	prefixLimit := w.limit - len(updatesDiagnosticTruncationMarker)
+	if prefixLimit < 0 {
+		prefixLimit = 0
+	}
+	return string(retained[:prefixLimit]) + updatesDiagnosticTruncationMarker
+}
+
+func sanitizeUpdatesDiagnostic(diagnostic string) string {
+	var sanitized strings.Builder
+	remaining := diagnostic
+	for len(remaining) > 0 {
+		line := remaining
+		separator := ""
+		if index := strings.IndexAny(remaining, "\r\n"); index >= 0 {
+			line = remaining[:index]
+			separator = remaining[index : index+1]
+			remaining = remaining[index+1:]
+			if separator == "\r" && strings.HasPrefix(remaining, "\n") {
+				separator = "\r\n"
+				remaining = remaining[1:]
+			}
+		} else {
+			remaining = ""
+		}
+		if updatesCredentialAssignmentLinePattern.MatchString(line) ||
+			updatesCredentialFlagLinePattern.MatchString(line) ||
+			updatesCredentialURLLinePattern.MatchString(line) {
+			sanitized.WriteString(updatesDiagnosticRedactionMarker)
+		} else {
+			sanitized.WriteString(line)
+		}
+		sanitized.WriteString(separator)
+	}
+	return sanitized.String()
+}
+
+func sanitizeAndBoundUpdatesDiagnostic(diagnostic string, limit int) string {
+	sanitized := sanitizeUpdatesDiagnostic(diagnostic)
+	if len(sanitized) <= limit {
+		return sanitized
+	}
+	prefixLimit := limit - len(updatesDiagnosticTruncationMarker)
+	if prefixLimit < 0 {
+		prefixLimit = 0
+	}
+	return sanitized[:prefixLimit] + updatesDiagnosticTruncationMarker
+}

--- a/main_updates_diagnostics_test.go
+++ b/main_updates_diagnostics_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUpdatesDiagnosticWriter_caps_output_with_truncation_marker(t *testing.T) {
+	// Given: a diagnostic writer with a deliberately small retention limit.
+	writer := newUpdatesDiagnosticWriter(64)
+
+	// When: diagnostics exceed that limit across multiple writes.
+	if _, err := writer.Write([]byte(strings.Repeat("a", 40))); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	if _, err := writer.Write([]byte(strings.Repeat("b", 40))); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	// Then: rendered diagnostics are capped and explicitly marked as truncated.
+	got := writer.String()
+	if len(got) > 64 {
+		t.Fatalf("diagnostic length = %d, want at most 64", len(got))
+	}
+	if !strings.Contains(got, updatesDiagnosticTruncationMarker) {
+		t.Fatalf("diagnostic = %q, want truncation marker", got)
+	}
+}
+
+func TestUpdatesDiagnosticWriter_is_deterministic_across_write_boundaries(t *testing.T) {
+	// Given: identical oversized diagnostics written with different chunking.
+	input := strings.Repeat("0123456789", 20)
+	oneWrite := newUpdatesDiagnosticWriter(96)
+	manyWrites := newUpdatesDiagnosticWriter(96)
+
+	// When: one writer receives one chunk and the other receives several.
+	if _, err := oneWrite.Write([]byte(input)); err != nil {
+		t.Fatalf("oneWrite.Write: %v", err)
+	}
+	for _, chunk := range []string{input[:17], input[17:81], input[81:]} {
+		if _, err := manyWrites.Write([]byte(chunk)); err != nil {
+			t.Fatalf("manyWrites.Write: %v", err)
+		}
+	}
+
+	// Then: retained diagnostics do not depend on subprocess write boundaries.
+	if oneWrite.String() != manyWrites.String() {
+		t.Fatalf("chunked output differs:\none=%q\nmany=%q", oneWrite.String(), manyWrites.String())
+	}
+}
+
+func TestUpdatesDiagnosticSanitizer_redacts_synthetic_credentials(t *testing.T) {
+	// Given: synthetic manager diagnostics containing common credential forms.
+	input := strings.Join([]string{
+		"APIKEY=apikey-value",
+		"API-KEY=api-hyphen-value",
+		"API_KEY=api-underscore-value",
+		`{"token":"json-token-value","secret": "json-secret-value", "password":"json-password-value"}`,
+		"//registry.example/:_auth=auth-value",
+		"Authorization: Bearer bearer-value",
+		"Authorization: Basic basic-value",
+		"fetch https://url-user:url-password@example.com/archive?token=url-token-value&mode=check",
+		"command --token flag-token-value --password=flag-password-value --verbose",
+		"ordinary=status-ok",
+	}, "\n")
+
+	// When: the scheduled diagnostic payload is sanitized.
+	got := sanitizeUpdatesDiagnostic(input)
+
+	// Then: credentials are absent while unrelated diagnostics remain useful.
+	for _, secret := range []string{
+		"apikey-value",
+		"api-hyphen-value",
+		"api-underscore-value",
+		"json-token-value",
+		"json-secret-value",
+		"json-password-value",
+		"auth-value",
+		"bearer-value",
+		"basic-value",
+		"url-user",
+		"url-password",
+		"url-token-value",
+		"flag-token-value",
+		"flag-password-value",
+	} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("sanitized diagnostic contains synthetic secret %q: %q", secret, got)
+		}
+	}
+	for _, diagnostic := range []string{"ordinary=status-ok"} {
+		if !strings.Contains(got, diagnostic) {
+			t.Fatalf("sanitized diagnostic = %q, want non-sensitive text %q retained", got, diagnostic)
+		}
+	}
+}
+
+func TestUpdatesDiagnosticSanitizer_redacts_entire_credential_lines(t *testing.T) {
+	// Given: credential syntax that defeats value-oriented quoted-value matching.
+	input := strings.Join([]string{
+		"fetch https://example.com/archive?auth=query-secret",
+		"command --access-token compound-token --verbose",
+		"command --client-secret=compound-secret --quiet",
+		`manager returned {\"client_secret\":\"escaped-json-secret\"}`,
+		`manager returned PASSWORD=\"escaped-assignment-secret\"`,
+	}, "\n")
+
+	// When: the scheduled diagnostic payload is sanitized.
+	got := sanitizeUpdatesDiagnostic(input)
+
+	// Then: every credential-bearing line is replaced by one stable marker.
+	want := strings.Join([]string{
+		updatesDiagnosticRedactionMarker,
+		updatesDiagnosticRedactionMarker,
+		updatesDiagnosticRedactionMarker,
+		updatesDiagnosticRedactionMarker,
+		updatesDiagnosticRedactionMarker,
+	}, "\n")
+	if got != want {
+		t.Fatalf("sanitized diagnostic = %q, want %q", got, want)
+	}
+}
+
+func TestUpdatesDiagnosticSanitizer_preserves_noncredential_authentication_failure(t *testing.T) {
+	// Given: an ordinary authentication error without credential-bearing syntax.
+	input := "authentication failed"
+
+	// When: the scheduled diagnostic payload is sanitized.
+	got := sanitizeUpdatesDiagnostic(input)
+
+	// Then: useful non-secret context remains unchanged.
+	if got != input {
+		t.Fatalf("sanitized diagnostic = %q, want %q", got, input)
+	}
+}
+
+func TestUpdatesDiagnosticSanitizer_bounds_after_redaction_expansion(t *testing.T) {
+	// Given: many short secrets whose redaction markers expand the payload.
+	input := strings.Repeat("TOKEN=x\n", updatesDiagnosticLimit/2)
+
+	// When: the payload crosses the final sanitize-and-bound boundary.
+	got := sanitizeAndBoundUpdatesDiagnostic(input, updatesDiagnosticLimit)
+
+	// Then: the final sanitized value remains bounded and visibly truncated.
+	if len(got) > updatesDiagnosticLimit {
+		t.Fatalf("sanitized diagnostic length = %d, want at most %d", len(got), updatesDiagnosticLimit)
+	}
+	if !strings.HasSuffix(got, updatesDiagnosticTruncationMarker) {
+		t.Fatalf("sanitized diagnostic missing truncation marker suffix")
+	}
+	if strings.Contains(got, "TOKEN=x") {
+		t.Fatalf("sanitized diagnostic retained a short secret")
+	}
+}

--- a/main_updates_worker.go
+++ b/main_updates_worker.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -32,7 +33,11 @@ func updatesRunOnceCmd(args []string) int {
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
 	}
-	logger, closeLog := updatesLogger()
+	logger, closeLog, err := updatesLogger()
+	if err != nil {
+		fPrintln(os.Stderr, "genv updates: audit log unavailable")
+		return exitIO
+	}
 	defer closeLog()
 	f, err := genvfile.Read(*file)
 	if err != nil {
@@ -62,7 +67,30 @@ func updatesRunOnceCmd(args []string) int {
 		notifyUpdates(cfg.Notify, "genv updates", fmt.Sprintf("%d tracked update batch(es) planned", len(plan.Actions)), logger)
 		return exitOK
 	}
-	runResult := updatesRunUpgrade(context.Background(), upgrade.UpgradeRunOptions{Plan: plan, Lock: lf, LockPath: lockPath, Stdin: strings.NewReader(""), Stdout: io.Discard, Stderr: io.Discard})
+	diagnostics := newUpdatesDiagnosticWriter(updatesDiagnosticLimit)
+	runResult := updatesRunUpgrade(context.Background(), upgrade.UpgradeRunOptions{Plan: plan, Lock: lf, LockPath: lockPath, Stdin: strings.NewReader(""), Stdout: io.Discard, Stderr: diagnostics})
+	matchedErrors := make([]bool, len(runResult.Errors))
+	for _, failure := range runResult.Failures {
+		sanitizedIDs := make([]string, len(failure.IDs))
+		for i, id := range failure.IDs {
+			sanitizedIDs[i] = sanitizeAndBoundUpdatesDiagnostic(id, updatesDiagnosticLimit)
+		}
+		logger.Warn("updates.apply.failed", slog.Any("ids", sanitizedIDs), slog.String("err", sanitizeAndBoundUpdatesDiagnostic(failure.Err.Error(), updatesDiagnosticLimit)))
+		for i, runErr := range runResult.Errors {
+			if !matchedErrors[i] && errors.Is(runErr, failure.Err) {
+				matchedErrors[i] = true
+				break
+			}
+		}
+	}
+	for i, runErr := range runResult.Errors {
+		if !matchedErrors[i] {
+			logger.Warn("updates.apply.failed", slog.Any("ids", []string(nil)), slog.String("err", sanitizeAndBoundUpdatesDiagnostic(runErr.Error(), updatesDiagnosticLimit)))
+		}
+	}
+	if rendered := strings.TrimSpace(sanitizeAndBoundUpdatesDiagnostic(diagnostics.String(), updatesDiagnosticLimit)); rendered != "" {
+		logger.Warn("updates.apply.diagnostics", slog.String("diagnostics", rendered))
+	}
 	logger.Info("updates.apply.completed", slog.Int("upgraded", len(runResult.Upgraded)), slog.Int("errors", len(runResult.Errors)), slog.Bool("auto_apply", true))
 	notifyUpdates(cfg.Notify, "genv updates", fmt.Sprintf("auto-apply completed: %d upgraded, %d error(s)", len(runResult.Upgraded), len(runResult.Errors)), logger)
 	if runResult.LockWriteError != nil {
@@ -75,24 +103,35 @@ func updatesRunOnceCmd(args []string) int {
 	return exitOK
 }
 
-func updatesLogger() (*slog.Logger, func()) {
-	path := updatesLogPathOrFallback()
+func updatesLogger() (*slog.Logger, func(), error) {
+	path, err := updatesLogPath()
+	if err != nil {
+		return nil, nil, err
+	}
 	if err := rotateUpdatesLog(path); err != nil {
-		return slog.New(slog.NewTextHandler(io.Discard, nil)), func() {}
+		return nil, nil, err
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
-		return slog.New(slog.NewTextHandler(io.Discard, nil)), func() {}
+		return nil, nil, fmt.Errorf("opening updates log: %w", err)
 	}
-	return slog.New(slog.NewTextHandler(f, nil)), func() { _ = f.Close() }
+	return slog.New(slog.NewTextHandler(f, nil)), func() { _ = f.Close() }, nil
+}
+
+func updatesLogPath() (string, error) {
+	dir, err := genvfile.DefaultDir()
+	if err != nil {
+		return "", fmt.Errorf("locating updates log directory: %w", err)
+	}
+	return filepath.Join(dir, "updates.log"), nil
 }
 
 func updatesLogPathOrFallback() string {
-	dir, err := genvfile.DefaultDir()
+	path, err := updatesLogPath()
 	if err != nil {
 		return "updates.log"
 	}
-	return filepath.Join(dir, "updates.log")
+	return path
 }
 
 func rotateUpdatesLog(path string) error {


### PR DESCRIPTION
## Summary

Enables managed updates across all genv-tracked packages and fixes the core correctness and observability defects found while enabling that workflow. Developer ID signing/notarization is intentionally out of scope.

## Changes

- **Platform-native automatic managers** — macOS automatic search/scan/implicit resolution use `brew` (not `linuxbrew`); Linux uses `linuxbrew`. Explicit `prefer`/`managers` configuration still selects either identity when the shared `brew` executable is available.
- **Scheduled environment** — scheduled jobs inherit a sanitized, augmented package-manager `PATH`, rendered deterministically under launchd and systemd; `updates start` captures the invoking PATH and drops empty/relative/duplicate entries.
- **Truthful scheduler status** — `updates status` distinguishes unsupported, unregistered, idle, executing, last-success, and last-failure from real supervisor state. systemd now requires `ExecMainStartTimestampMonotonic`, so a never-executed `Type=oneshot` service (which exposes default `Result=success`/`ExecMainStatus=0`) is reported as registered/idle rather than a false completed success; an in-progress first run reports executing/unknown; malformed markers stay conservative.
- **Constraint-safe upgrades** — version-constrained packages are skipped with an explicit reason instead of an unsafe latest-version upgrade, in the shared planner used by both `genv upgrade` and `genv updates`.
- **Fail-closed audit logging** — scheduled auto-apply fails closed when its audit log cannot be opened, logs each failed action with its tracked package IDs, and retains bounded (64 KiB), credential-redacted diagnostics; stdin/environment are never captured.
- **Docs** — README and CHANGELOG document the new scheduler PATH/status, fail-closed logging, and conservative constraint behavior; approved design/plan/handoff included.
- **Lint cleanup** (separate commit) — clears the pre-existing golangci-lint findings so the branch is lint-clean, no behavior change.

## Verification

- `go test -race -shuffle=on -count=1 ./...` — PASS, all packages
- `go vet ./...` — PASS
- `make lint` — 0 issues
- `make ci` — PASS (statement coverage 68.2%)
- `go build` — PASS
- systemd `ExecMainStartTimestampMonotonic` never-run/executing/malformed cases covered by new TDD fixtures in `internal/service/scheduled_status_test.go`; property contract verified against the systemd man pages.

Manual QA used a throwaway binary against scratch fixtures; **no real package upgrade ran and the live scheduler job was only inspected, never replaced.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)