### PR TITLE
fix(release): strip com.apple.quarantine on cask install

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,6 +68,16 @@ homebrew_casks:
     description: "Track, sync, and reproduce your software environment across Linux, macOS, Windows, and WSL2."
     license: MIT
     skip_upload: auto  # skips pre-releases automatically
+    # The release binaries are adhoc-signed, not Developer ID notarized, so macOS
+    # sets com.apple.quarantine on cask install. launchd (used by `genv updates
+    # start`) refuses to exec a quarantined adhoc binary (OS_REASON_EXEC), so
+    # strip the attribute on install to keep scheduled jobs working across upgrades.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/genv"]
+          end
 
 # ── Snap Store ────────────────────────────────────────────────────────────────
 # Publishes a snap to the Snap Store on every non-prerelease tag.


### PR DESCRIPTION
## Problem

Release binaries are adhoc-signed, not Developer ID notarized (notarization is intentionally out of scope). macOS therefore sets `com.apple.quarantine` on the binary when the Homebrew cask is installed. A quarantined adhoc-signed binary runs fine from an interactive shell, but **launchd refuses to exec it** — so `genv updates start` registers a job that immediately fails with `OS_REASON_EXEC` after every cask install/upgrade.

This surfaced right after releasing v3.0.2: the freshly-installed cask binary was quarantined and the scheduled updates job failed to exec until the attribute was cleared manually with `xattr -dr com.apple.quarantine`.

## Fix

Add a GoReleaser `homebrew_casks` post-install hook that strips the quarantine attribute on macOS, so scheduled jobs keep working across cask upgrades without manual intervention:

```yaml
hooks:
  post:
    install: |
      if OS.mac?
        system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/genv"]
      end
```

Takes effect from the next release; `goreleaser check` passes locally. No effect on Linux/Windows artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)