### PR TITLE
fix(adapter): upgrade bun globals with 'bun add --global'

### DIFF
--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -722,7 +722,7 @@ func TestPlanUpgrade_ContainsUpgradeVerb(t *testing.T) {
 		{"uv", "--upgrade"},
 		{"pacman", "-S"},
 		{"linuxbrew", "upgrade"},
-		{"bun", "update"},
+		{"bun", "add"},
 		{"npm", "install"},
 		{"pnpm", "add"},
 		{"yarn", "add"},

--- a/internal/adapter/bun.go
+++ b/internal/adapter/bun.go
@@ -30,7 +30,12 @@ func (Bun) PlanUninstall(pkgName string) []string {
 }
 
 func (Bun) PlanUpgrade(pkgName string) []string {
-	return []string{"bun", "update", "--global", bunBaseName(pkgName)}
+	// `bun update --global <pkg>` looks for a local package.json and is a no-op
+	// for globally-installed packages ("No package.json, so nothing to update"),
+	// which breaks scheduled upgrades that run without a project directory.
+	// `bun add --global <pkg>` reinstalls the latest version, which is the
+	// correct, package.json-independent way to upgrade a global package.
+	return []string{"bun", "add", "--global", bunBaseName(pkgName)}
 }
 
 func (Bun) PlanClean() [][]string {

--- a/internal/adapter/bun_test.go
+++ b/internal/adapter/bun_test.go
@@ -49,10 +49,10 @@ func TestBun_PlanUninstall(t *testing.T) {
 
 func TestBun_PlanUpgrade(t *testing.T) {
 	a := Bun{}
-	if got, want := a.PlanUpgrade("cf"), []string{"bun", "update", "--global", "cf"}; !slices.Equal(got, want) {
+	if got, want := a.PlanUpgrade("cf"), []string{"bun", "add", "--global", "cf"}; !slices.Equal(got, want) {
 		t.Errorf("PlanUpgrade(cf) = %v, want %v", got, want)
 	}
-	if got, want := a.PlanUpgrade("cf@latest"), []string{"bun", "update", "--global", "cf"}; !slices.Equal(got, want) {
+	if got, want := a.PlanUpgrade("cf@latest"), []string{"bun", "add", "--global", "cf"}; !slices.Equal(got, want) {
 		t.Errorf("PlanUpgrade(cf@latest) = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Problem

The bun adapter's `PlanUpgrade` runs `bun update --global <pkg>`. But `bun update` looks for a **local `package.json`** to resolve what to update, so for globally-installed packages it prints `No package.json, so nothing to update` and never upgrades them. This surfaced in the managed-updates scheduler: because the launchd job runs without a project directory, every tracked bun global (`add-gitignore`, `cf`, `playwright`) was reported as a failed upgrade.

## Fix

Use `bun add --global <pkg>`, which reinstalls the package at its latest version — the correct, `package.json`-independent way to upgrade a bun global, and consistent with `PlanInstall`.

Verified manually: `bun add --global add-gitignore` upgrades/refreshes the global (exit 0), whereas `bun update --global add-gitignore` is a no-op. Existing `TestBun_PlanUpgrade` updated to assert the corrected command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)