### PR TITLE
fix(scan): skip packages already tracked by manager name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v3.0.4 - 2026-07-13
+
+### Fixed
+
+- `genv scan` no longer re-adopts packages whose friendly ID differs from their manager-specific name. Adapters like `mas` report installed apps by their manager name (a numeric App Store product ID), so an app already tracked as `{"id":"xcode","managers":{"mas":"497799835"}}` was adopted again on every scan as a duplicate bare-numeric `497799835` entry — doubling its App Store upgrade work. Scan now treats every `managers` value as already tracked.
+
 ## v3.0.3 - 2026-07-13
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -2261,10 +2261,18 @@ func scanCmd(args []string) int {
 		return exitIO
 	}
 
-	// Build sets of already-tracked IDs so we can skip them.
+	// Build sets of already-tracked IDs so we can skip them. Besides the
+	// friendly p.ID, register every manager-specific name from p.Managers:
+	// adapters like mas report installed packages by their manager name
+	// (a numeric App Store product ID) rather than the friendly ID, so a
+	// package tracked as {"id":"xcode","managers":{"mas":"497799835"}} would
+	// otherwise be re-adopted as a duplicate bare-numeric entry.
 	trackedInSpec := make(map[string]bool, len(f.Packages))
 	for _, p := range f.Packages {
 		trackedInSpec[p.ID] = true
+		for _, managerName := range p.Managers {
+			trackedInSpec[managerName] = true
+		}
 	}
 
 	// Deduplicate across managers using a seen set.

--- a/main_test.go
+++ b/main_test.go
@@ -1213,6 +1213,70 @@ func TestScanCmd_UsesVersionListerWithoutPerPackageVersionQueries(t *testing.T) 
 	}
 }
 
+// scanManagerNameAdapter mimics mas: ListInstalled reports the manager-specific
+// name (a numeric App Store product ID) rather than the friendly genv ID.
+type scanManagerNameAdapter struct {
+	name      string
+	installed []string
+}
+
+func (a *scanManagerNameAdapter) Name() string    { return a.name }
+func (a *scanManagerNameAdapter) Available() bool { return true }
+func (a *scanManagerNameAdapter) NormalizeID(id string, managers map[string]string) (string, bool) {
+	return id, false
+}
+func (a *scanManagerNameAdapter) PlanInstall(pkgName string) []string   { return []string{"true"} }
+func (a *scanManagerNameAdapter) PlanUninstall(pkgName string) []string { return []string{"true"} }
+func (a *scanManagerNameAdapter) PlanUpgrade(pkgName string) []string   { return []string{"true"} }
+func (a *scanManagerNameAdapter) PlanClean() [][]string                 { return nil }
+func (a *scanManagerNameAdapter) Query(pkgName string) (bool, error)    { return true, nil }
+func (a *scanManagerNameAdapter) ListInstalled() ([]string, error)      { return a.installed, nil }
+func (a *scanManagerNameAdapter) QueryVersion(pkgName string) (string, error) {
+	return "", nil
+}
+
+// TestScanCmd_SkipsPackageTrackedByManagerName guards against re-adopting a
+// package whose friendly ID differs from its manager-specific name — the mas
+// case where {"id":"xcode","managers":{"mas":"497799835"}} was previously
+// duplicated as a second bare-numeric "497799835" entry on every scan.
+func TestScanCmd_SkipsPackageTrackedByManagerName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "genv.json")
+
+	seed := &schema.GenvFile{
+		SchemaVersion: schema.Version,
+		Packages: []schema.Package{
+			{ID: "xcode", Managers: map[string]string{"mas": "497799835"}},
+		},
+	}
+	if err := genvfile.Write(path, seed); err != nil {
+		t.Fatalf("seeding spec: %v", err)
+	}
+
+	mas := &scanManagerNameAdapter{name: "mas", installed: []string{"497799835"}}
+	originalAll := adapter.All
+	adapter.All = []adapter.Adapter{mas}
+	t.Cleanup(func() { adapter.All = originalAll })
+
+	code := run([]string{"scan", "--file", path})
+	if code != exitOK {
+		t.Fatalf("scan: expected exitOK (%d), got %d", exitOK, code)
+	}
+
+	f, _, err := genvfile.ReadOrNew(path)
+	if err != nil {
+		t.Fatalf("ReadOrNew: %v", err)
+	}
+	if len(f.Packages) != 1 {
+		t.Fatalf("packages = %d, want 1 (no duplicate adopted): %+v", len(f.Packages), f.Packages)
+	}
+	for _, p := range f.Packages {
+		if p.ID == "497799835" {
+			t.Fatalf("bare-numeric duplicate %q was re-adopted", p.ID)
+		}
+	}
+}
+
 // ---- genv status -------------------------------------------------------------
 
 func TestStatusCmd_FileNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

`genv scan` re-adopted mas apps on every run. The already-tracked set was built from each package's friendly `id` only, but the `mas` adapter reports installed apps by their manager-specific name (a numeric App Store product ID). That never matched the friendly `id`, so an app tracked as `{"id":"xcode","managers":{"mas":"497799835"}}` was adopted again as a duplicate bare-numeric `497799835` entry — doubling its App Store upgrade work on every scheduled update.

## Fix

Register every `managers` value (not just `id`) into the tracked set in `scanCmd`.

## Test

Adds `TestScanCmd_SkipsPackageTrackedByManagerName`, which reproduces the mas case. Verified it **fails** without the fix (adopts a second `497799835`) and **passes** with it. Full suite + `go vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)