### PR TITLE
fix(gem): skip gems in a non-writable install directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v3.0.5 - 2026-07-13
+
+### Fixed
+
+- The `gem` adapter no longer reports gems from an installation directory it cannot write to (e.g. macOS system Ruby at `/Library/Ruby/Gems`). Those gems are root-owned, so `genv scan` was adopting dozens of unmanageable packages that failed every `genv upgrade` with `Gem::FilePermissionError`. When the active gem install dir is not writable, the adapter now lists nothing.
+
 ## v3.0.4 - 2026-07-13
 
 ### Fixed

--- a/internal/adapter/gem.go
+++ b/internal/adapter/gem.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -90,6 +91,14 @@ type gemEntry struct {
 }
 
 func (Gem) listEntries() ([]gemEntry, error) {
+	// Skip gems entirely when their installation directory is not writable —
+	// e.g. macOS system Ruby at /Library/Ruby/Gems, whose gems are root-owned.
+	// genv cannot install, upgrade, or uninstall there, so reporting them only
+	// pollutes `scan` with unmanageable packages that fail every upgrade with
+	// Gem::FilePermissionError.
+	if !gemManageable() {
+		return nil, nil
+	}
 	out, err := exec.Command("gem", "list", "--local").Output()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -99,6 +108,40 @@ func (Gem) listEntries() ([]gemEntry, error) {
 		return nil, err
 	}
 	return parseGemListEntries(string(out)), nil
+}
+
+// gemManageable reports whether genv can manage gems in the active gem
+// installation directory. It is a package var so tests can override the probe.
+// When the directory cannot be determined it returns true, preserving the
+// default "list everything" behavior rather than hiding a writable install.
+var gemManageable = func() bool {
+	out, err := exec.Command("gem", "environment", "gemdir").Output()
+	if err != nil {
+		return true
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return true
+	}
+	return dirWritable(dir)
+}
+
+// dirWritable reports whether dir exists and the current user can create files
+// in it, probed by creating and removing a temporary file. This captures POSIX
+// permissions and ACLs that a mode-bit check would miss.
+func dirWritable(dir string) bool {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	f, err := os.CreateTemp(dir, ".genv-writecheck-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	f.Close()
+	os.Remove(name)
+	return true
 }
 
 func findGemEntry(entries []gemEntry, pkgName string) (gemEntry, bool) {

--- a/internal/adapter/ruby_php_dotnet_test.go
+++ b/internal/adapter/ruby_php_dotnet_test.go
@@ -55,6 +55,62 @@ fi`)
 	}
 }
 
+func TestGem_ListInstalled_whenInstallDirNotWritable_returnsNothing(t *testing.T) {
+	// Given: a gem install dir genv cannot manage (e.g. macOS system Ruby).
+	installFakeBinary(t, "gem", `if [ "$1" = "list" ] && [ "$2" = "--local" ]; then
+  echo 'rake (13.0.6)'
+  echo 'nokogiri (1.13.8)'
+fi`)
+	orig := gemManageable
+	gemManageable = func() bool { return false }
+	t.Cleanup(func() { gemManageable = orig })
+
+	// When
+	got, err := Gem{}.ListInstalled()
+
+	// Then: nothing is reported, so scan won't adopt unmanageable system gems.
+	if err != nil {
+		t.Fatalf("Gem.ListInstalled: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ListInstalled = %v, want empty (non-writable install dir)", got)
+	}
+}
+
+func TestGem_ListInstalled_whenInstallDirWritable_listsGems(t *testing.T) {
+	// Given: a writable install dir — gems should be reported normally.
+	installFakeBinary(t, "gem", `if [ "$1" = "list" ] && [ "$2" = "--local" ]; then
+  echo 'rake (13.0.6)'
+  echo 'nokogiri (1.13.8)'
+fi`)
+	orig := gemManageable
+	gemManageable = func() bool { return true }
+	t.Cleanup(func() { gemManageable = orig })
+
+	// When
+	got, err := Gem{}.ListInstalled()
+
+	// Then
+	if err != nil {
+		t.Fatalf("Gem.ListInstalled: %v", err)
+	}
+	if want := []string{"rake", "nokogiri"}; !slices.Equal(got, want) {
+		t.Errorf("ListInstalled = %v, want %v", got, want)
+	}
+}
+
+func TestGem_DirWritable_whenDirMissing_returnsFalse(t *testing.T) {
+	if dirWritable(t.TempDir() + "/does-not-exist") {
+		t.Error("dirWritable = true for a missing directory, want false")
+	}
+}
+
+func TestGem_DirWritable_whenTempDir_returnsTrue(t *testing.T) {
+	if !dirWritable(t.TempDir()) {
+		t.Error("dirWritable = false for a writable temp directory, want true")
+	}
+}
+
 func TestComposer_ParseShowJSON_whenVendorPackagesInstalled(t *testing.T) {
 	// Given
 	data := []byte(`{"installed":[{"name":"laravel/installer","version":"5.7.0"},{"name":"friendsofphp/php-cs-fixer","version":"v3.52.1"}]}`)


### PR DESCRIPTION
## Summary

`genv scan` adopted dozens of unmanageable Ruby gems on macOS. The `gem` adapter ran `gem list --local`, which returns every gem in the root-owned system Ruby (`/Library/Ruby/Gems/2.6.0`). genv can't install, upgrade, or uninstall there, so those gems (`nokogiri`, `rake`, `rexml`, `bundler`, …) got adopted and then failed every `genv upgrade` with `Gem::FilePermissionError`.

## Fix

`listEntries` now probes the active gem install dir via `gem environment gemdir` and reports nothing when it isn't writable. When the directory can't be determined, it falls back to the previous list-everything behavior, so writable Ruby installs (rbenv, Homebrew Ruby) are unaffected.

## Test

- `TestGem_ListInstalled_whenInstallDirNotWritable_returnsNothing` — the mac system-Ruby case.
- `TestGem_ListInstalled_whenInstallDirWritable_listsGems` — writable install still lists gems.
- `TestGem_DirWritable_*` — the write-probe helper.

Full suite + `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)