### PR TITLE
refactor: v3.2.1 outdated-detection quality cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v3.2.1 - 2026-07-21
+
+### Changed
+
+- Internal cleanup for outdated detection: shared registry HTTP helper, `Filters.All` as the single `--all` / outdated-filter switch (removed redundant `DetectOutdated`), co-located outdated helpers, and table-driven outdated adapter tests.
+
 ## v3.2.0 - 2026-07-21
 
 ### Changed

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -48,31 +48,6 @@ type OutdatedLister interface {
 	ListOutdated(pkgNames []string) (map[string]string, error)
 }
 
-// intersectNameMap limits all to the manager-native package names genv tracks.
-// An empty pkgNames means every outdated package should be returned.
-func intersectNameMap(all map[string]string, pkgNames []string) map[string]string {
-	if len(all) == 0 {
-		return nil
-	}
-	if len(pkgNames) == 0 {
-		return all
-	}
-	want := make(map[string]bool, len(pkgNames))
-	for _, name := range pkgNames {
-		want[name] = true
-	}
-	out := make(map[string]string)
-	for name, version := range all {
-		if want[name] {
-			out[name] = version
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
 // Adapter is the capability contract every package manager must satisfy.
 // Each method maps to one of the four resolver operations: detect, query,
 // plan install, and normalize package IDs.

--- a/internal/adapter/cargo.go
+++ b/internal/adapter/cargo.go
@@ -87,11 +87,9 @@ func (c Cargo) ListOutdated(pkgNames []string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	installed := make(map[string]string, len(entries))
-	for _, e := range entries {
-		installed[e.name] = e.version
-	}
-	return listRegistryOutdated(installed, pkgNames, cargoBaseName, cratesLatestVersion)
+	return listRegistryOutdated(versionMapOf(entries, func(e cargoEntry) (string, string) {
+		return e.name, e.version
+	}), pkgNames, cargoBaseName, cratesLatestVersion)
 }
 
 type cargoEntry struct {

--- a/internal/adapter/js_outdated.go
+++ b/internal/adapter/js_outdated.go
@@ -1,6 +1,0 @@
-package adapter
-
-// listJSOutdated compares installed name->version against the npm registry.
-func listJSOutdated(installed map[string]string, pkgNames []string) (map[string]string, error) {
-	return listRegistryOutdated(installed, pkgNames, jsBasePackageName, npmLatestVersion)
-}

--- a/internal/adapter/outdated_compare.go
+++ b/internal/adapter/outdated_compare.go
@@ -4,6 +4,9 @@ package adapter
 // latest versions. Missing installs are skipped. Transport errors flag the
 // package conservatively with its installed version; an empty latest version
 // means the package is not known by the registry and is treated as up to date.
+//
+// When pkgNames is empty, every installed name is checked — one registry call
+// per name — so callers should prefer passing the tracked name list.
 func listRegistryOutdated(
 	installed map[string]string,
 	pkgNames []string,
@@ -39,4 +42,44 @@ func listRegistryOutdated(
 		return nil, nil
 	}
 	return outdated, nil
+}
+
+// listJSOutdated compares installed name->version against the npm registry.
+func listJSOutdated(installed map[string]string, pkgNames []string) (map[string]string, error) {
+	return listRegistryOutdated(installed, pkgNames, jsBasePackageName, npmLatestVersion)
+}
+
+// intersectNameMap limits all to the manager-native package names genv tracks.
+// An empty pkgNames means every outdated package should be returned.
+func intersectNameMap(all map[string]string, pkgNames []string) map[string]string {
+	if len(all) == 0 {
+		return nil
+	}
+	if len(pkgNames) == 0 {
+		return all
+	}
+	want := make(map[string]bool, len(pkgNames))
+	for _, name := range pkgNames {
+		want[name] = true
+	}
+	out := make(map[string]string)
+	for name, version := range all {
+		if want[name] {
+			out[name] = version
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// versionMapOf builds a name->version map from typed install-list entries.
+func versionMapOf[E any](entries []E, nameVer func(E) (string, string)) map[string]string {
+	out := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		name, version := nameVer(entry)
+		out[name] = version
+	}
+	return out
 }

--- a/internal/adapter/outdated_test.go
+++ b/internal/adapter/outdated_test.go
@@ -7,386 +7,422 @@ import (
 	"testing"
 )
 
-func TestWinget_ListOutdated_ParsesUpgradeTable(t *testing.T) {
-	installFakeBinary(t, "winget", `if [ "$1" = "upgrade" ]; then
-cat <<'EOF'
-Name                  Id                      Version     Available    Source
+type nativeOutdatedCase struct {
+	name      string
+	bin       string
+	script    string
+	pkgNames  []string
+	want      map[string]string
+	wantNil   bool
+	wantError bool
+	list      func(pkgNames []string) (map[string]string, error)
+}
+
+func TestNativeListOutdated(t *testing.T) {
+	wingetTable := `Name                  Id                      Version     Available    Source
 --------------------------------------------------------------------------
 Git                   Git.Git                 2.47.0      2.48.0       winget
 Neovim                Neovim.Neovim           0.10.0      0.11.0       winget
-EOF
-exit 0
-fi
-exit 1`)
-
-	got, err := (Winget{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"Git.Git": "2.48.0", "Neovim.Neovim": "0.11.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestWinget_ListOutdated_IntersectsWithPkgNames(t *testing.T) {
-	installFakeBinary(t, "winget", `cat <<'EOF'
-Name                  Id                      Version     Available    Source
---------------------------------------------------------------------------
-Git                   Git.Git                 2.47.0      2.48.0       winget
-Neovim                Neovim.Neovim           0.10.0      0.11.0       winget
-EOF`)
-
-	got, err := (Winget{}).ListOutdated([]string{"Neovim.Neovim"})
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"Neovim.Neovim": "0.11.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestWinget_ListOutdated_NothingOutdated(t *testing.T) {
-	installFakeBinary(t, "winget", `printf "No installed package has an available upgrade.\n"`)
-
-	got, err := (Winget{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("ListOutdated: got %v, want nil", got)
-	}
-}
-
-func TestWinget_ListOutdated_CommandFailureIsError(t *testing.T) {
-	installFakeBinary(t, "winget", `echo "boom" >&2; exit 1`)
-
-	if _, err := (Winget{}).ListOutdated(nil); err == nil {
-		t.Fatal("ListOutdated: expected error on command failure, got nil")
-	}
-}
-
-func TestScoop_ListOutdated_ParsesStatus(t *testing.T) {
-	installFakeBinary(t, "scoop", `if [ "$1" = "status" ]; then
-cat <<'EOF'
-Name    Version  Available  Info
+`
+	scoopStatus := `Name    Version  Available  Info
 ----    -------  ---------  ----
 git     2.47.0   2.48.0
 neovim  0.10.0   0.11.0
-EOF
+`
+	quLines := "git 2.47.0 -> 2.48.0\nneovim 0.10.0 -> 0.11.0\n"
+	snapList := `Name           Version  Rev   Publisher     Notes
+firefox        139.0-1  1235  mozilla       -
+code           1.95.0   200   vscode        classic
+`
+
+	cases := []nativeOutdatedCase{
+		{
+			name: "winget/parse", bin: "winget",
+			script: `if [ "$1" = "upgrade" ]; then cat <<'EOF'
+` + wingetTable + `EOF
 exit 0
 fi
-exit 1`)
-
-	got, err := (Scoop{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"git": "2.48.0", "neovim": "0.11.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestScoop_ListOutdated_IntersectsWithPkgNames(t *testing.T) {
-	installFakeBinary(t, "scoop", `cat <<'EOF'
-Name    Version  Available  Info
-----    -------  ---------  ----
-git     2.47.0   2.48.0
-neovim  0.10.0   0.11.0
-EOF`)
-
-	got, err := (Scoop{}).ListOutdated([]string{"git"})
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"git": "2.48.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestScoop_ListOutdated_NothingOutdated(t *testing.T) {
-	installFakeBinary(t, "scoop", `printf "Scoop is up to date.\n"`)
-
-	got, err := (Scoop{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("ListOutdated: got %v, want nil", got)
-	}
-}
-
-func TestScoop_ListOutdated_CommandFailureIsError(t *testing.T) {
-	installFakeBinary(t, "scoop", `echo "boom" >&2; exit 1`)
-
-	if _, err := (Scoop{}).ListOutdated(nil); err == nil {
-		t.Fatal("ListOutdated: expected error on command failure, got nil")
-	}
-}
-
-func TestChoco_ListOutdated_ParsesRemoteOutput(t *testing.T) {
-	installFakeBinary(t, "choco", `if [ "$1" = "outdated" ] && [ "$2" = "-r" ]; then
+exit 1`,
+			want: map[string]string{"Git.Git": "2.48.0", "Neovim.Neovim": "0.11.0"},
+			list: (Winget{}).ListOutdated,
+		},
+		{
+			name: "winget/intersect", bin: "winget", script: "cat <<'EOF'\n" + wingetTable + "EOF\n",
+			pkgNames: []string{"Neovim.Neovim"},
+			want:     map[string]string{"Neovim.Neovim": "0.11.0"},
+			list:     (Winget{}).ListOutdated,
+		},
+		{
+			name: "winget/empty", bin: "winget", script: `printf "No installed package has an available upgrade.\n"`,
+			wantNil: true, list: (Winget{}).ListOutdated,
+		},
+		{
+			name: "winget/error", bin: "winget", script: `echo "boom" >&2; exit 1`,
+			wantError: true, list: (Winget{}).ListOutdated,
+		},
+		{
+			name: "scoop/parse", bin: "scoop",
+			script: `if [ "$1" = "status" ]; then cat <<'EOF'
+` + scoopStatus + `EOF
+exit 0
+fi
+exit 1`,
+			want: map[string]string{"git": "2.48.0", "neovim": "0.11.0"},
+			list: (Scoop{}).ListOutdated,
+		},
+		{
+			name: "scoop/intersect", bin: "scoop", script: "cat <<'EOF'\n" + scoopStatus + "EOF\n",
+			pkgNames: []string{"git"}, want: map[string]string{"git": "2.48.0"},
+			list: (Scoop{}).ListOutdated,
+		},
+		{
+			name: "scoop/empty", bin: "scoop", script: `printf "Scoop is up to date.\n"`,
+			wantNil: true, list: (Scoop{}).ListOutdated,
+		},
+		{
+			name: "scoop/error", bin: "scoop", script: `echo "boom" >&2; exit 1`,
+			wantError: true, list: (Scoop{}).ListOutdated,
+		},
+		{
+			name: "choco/parse", bin: "choco",
+			script: `if [ "$1" = "outdated" ] && [ "$2" = "-r" ]; then
 echo "git|2.47.0|2.48.0|false"
 echo "nodejs|22.0.0|22.0.0|false"
 exit 0
 fi
-exit 1`)
-
-	got, err := (Choco{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"git": "2.48.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestChoco_ListOutdated_ParsesRemoteOutputOnExitCode2(t *testing.T) {
-	installFakeBinary(t, "choco", `if [ "$1" = "outdated" ] && [ "$2" = "-r" ]; then
+exit 1`,
+			want: map[string]string{"git": "2.48.0"}, list: (Choco{}).ListOutdated,
+		},
+		{
+			name: "choco/exit2", bin: "choco",
+			script: `if [ "$1" = "outdated" ] && [ "$2" = "-r" ]; then
 echo "git|2.47.0|2.48.0|false"
 echo "nodejs|22.0.0|22.0.0|false"
 exit 2
 fi
-exit 1`)
-
-	got, err := (Choco{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"git": "2.48.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestChoco_ListOutdated_IntersectsWithPkgNames(t *testing.T) {
-	installFakeBinary(t, "choco", `cat <<'EOF'
-git|2.47.0|2.48.0|false
-neovim|0.10.0|0.11.0|false
-EOF`)
-
-	got, err := (Choco{}).ListOutdated([]string{"neovim"})
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"neovim": "0.11.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestChoco_ListOutdated_NothingOutdated(t *testing.T) {
-	installFakeBinary(t, "choco", `printf ""`)
-
-	got, err := (Choco{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("ListOutdated: got %v, want nil", got)
-	}
-}
-
-func TestChoco_ListOutdated_CommandFailureIsError(t *testing.T) {
-	installFakeBinary(t, "choco", `echo "boom" >&2; exit 1`)
-
-	if _, err := (Choco{}).ListOutdated(nil); err == nil {
-		t.Fatal("ListOutdated: expected error on command failure, got nil")
-	}
-}
-
-func TestBrew_ListOutdated_ParsesFormulaeAndCasks(t *testing.T) {
-	installFakeBinary(t, "brew",
-		`if [ "$1" = "outdated" ] && [ "$2" = "--json=v2" ]; then
+exit 1`,
+			want: map[string]string{"git": "2.48.0"}, list: (Choco{}).ListOutdated,
+		},
+		{
+			name: "choco/intersect", bin: "choco",
+			script:   "cat <<'EOF'\ngit|2.47.0|2.48.0|false\nneovim|0.10.0|0.11.0|false\nEOF\n",
+			pkgNames: []string{"neovim"}, want: map[string]string{"neovim": "0.11.0"},
+			list: (Choco{}).ListOutdated,
+		},
+		{
+			name: "choco/empty", bin: "choco", script: `printf ""`,
+			wantNil: true, list: (Choco{}).ListOutdated,
+		},
+		{
+			name: "choco/error", bin: "choco", script: `echo "boom" >&2; exit 1`,
+			wantError: true, list: (Choco{}).ListOutdated,
+		},
+		{
+			name: "brew/parse", bin: "brew",
+			script: `if [ "$1" = "outdated" ] && [ "$2" = "--json=v2" ]; then
 	cat <<'JSON'
-{
-  "formulae": [
-    {"name": "wget", "installed_versions": ["1.21.3"], "current_version": "1.21.4"},
-    {"name": "jq", "installed_versions": ["1.6"], "current_version": "1.7"}
-  ],
-  "casks": [
-    {"name": "firefox", "installed_versions": ["120.0"], "current_version": "121.0"}
-  ]
-}
+{"formulae":[{"name":"wget","current_version":"1.21.4"},{"name":"jq","current_version":"1.7"}],"casks":[{"name":"firefox","current_version":"121.0"}]}
 JSON
 	exit 0
 fi
 echo "unexpected args: $*" >&2
-exit 1`)
-
-	got, err := Brew{}.ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"wget": "1.21.4", "jq": "1.7", "firefox": "121.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestBrew_ListOutdated_IntersectsWithPkgNames(t *testing.T) {
-	installFakeBinary(t, "brew",
-		`cat <<'JSON'
-{"formulae": [{"name": "wget", "current_version": "1.21.4"}, {"name": "jq", "current_version": "1.7"}], "casks": []}
-JSON`)
-
-	got, err := Brew{}.ListOutdated([]string{"jq"})
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"jq": "1.7"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestBrew_ListOutdated_NothingOutdated(t *testing.T) {
-	installFakeBinary(t, "brew", `echo '{"formulae": [], "casks": []}'`)
-	got, err := Brew{}.ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("ListOutdated: got %v, want nil", got)
-	}
-}
-
-func TestBrew_ListOutdated_CommandFailureIsError(t *testing.T) {
-	installFakeBinary(t, "brew", `echo "boom" >&2; exit 1`)
-	if _, err := (Brew{}).ListOutdated(nil); err == nil {
-		t.Fatal("ListOutdated: expected error on command failure, got nil")
-	}
-}
-
-func TestMas_ListOutdated_ParsesArrowAndPlainForms(t *testing.T) {
-	installFakeBinary(t, "mas",
-		`if [ "$1" = "outdated" ]; then
+exit 1`,
+			want: map[string]string{"wget": "1.21.4", "jq": "1.7", "firefox": "121.0"},
+			list: Brew{}.ListOutdated,
+		},
+		{
+			name: "brew/intersect", bin: "brew",
+			script: `cat <<'JSON'
+{"formulae":[{"name":"wget","current_version":"1.21.4"},{"name":"jq","current_version":"1.7"}],"casks":[]}
+JSON`,
+			pkgNames: []string{"jq"}, want: map[string]string{"jq": "1.7"},
+			list: Brew{}.ListOutdated,
+		},
+		{
+			name: "brew/empty", bin: "brew", script: `echo '{"formulae": [], "casks": []}'`,
+			wantNil: true, list: Brew{}.ListOutdated,
+		},
+		{
+			name: "brew/error", bin: "brew", script: `echo "boom" >&2; exit 1`,
+			wantError: true, list: Brew{}.ListOutdated,
+		},
+		{
+			name: "mas/parse", bin: "mas",
+			script: `if [ "$1" = "outdated" ]; then
 	echo "497799835 Xcode (14.0 -> 14.1)"
 	echo "409201541 Pages (13.1)"
 	exit 0
 fi
 echo "unexpected args: $*" >&2
-exit 1`)
-
-	got, err := Mas{}.ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
+exit 1`,
+			want: map[string]string{"497799835": "14.1", "409201541": "13.1"},
+			list: Mas{}.ListOutdated,
+		},
+		{
+			name: "mas/intersect", bin: "mas",
+			script:   "echo \"497799835 Xcode (14.1)\"\necho \"409201541 Pages (13.1)\"\n",
+			pkgNames: []string{"497799835"}, want: map[string]string{"497799835": "14.1"},
+			list: Mas{}.ListOutdated,
+		},
+		{
+			name: "pacman/parse", bin: "pacman",
+			script: `if [ "$1" = "-Qu" ]; then cat <<'EOF'
+` + quLines + `EOF
+exit 0
+fi
+exit 1`,
+			want: map[string]string{"git": "2.48.0", "neovim": "0.11.0"},
+			list: (Pacman{}).ListOutdated,
+		},
+		{
+			name: "pacman/intersect", bin: "pacman", script: "cat <<'EOF'\n" + quLines + "EOF\n",
+			pkgNames: []string{"neovim"}, want: map[string]string{"neovim": "0.11.0"},
+			list: (Pacman{}).ListOutdated,
+		},
+		{
+			name: "pacman/empty", bin: "pacman", script: `exit 1`,
+			wantNil: true, list: (Pacman{}).ListOutdated,
+		},
+		{
+			name: "pacman/error", bin: "pacman", script: `echo "boom" >&2; exit 2`,
+			wantError: true, list: (Pacman{}).ListOutdated,
+		},
+		{
+			name: "paru/parse", bin: "paru",
+			script: `if [ "$1" = "-Qu" ]; then cat <<'EOF'
+` + quLines + `EOF
+exit 0
+fi
+exit 1`,
+			want: map[string]string{"git": "2.48.0", "neovim": "0.11.0"},
+			list: (Paru{}).ListOutdated,
+		},
+		{
+			name: "paru/intersect", bin: "paru", script: "cat <<'EOF'\n" + quLines + "EOF\n",
+			pkgNames: []string{"git"}, want: map[string]string{"git": "2.48.0"},
+			list: (Paru{}).ListOutdated,
+		},
+		{
+			name: "paru/empty", bin: "paru", script: `exit 1`,
+			wantNil: true, list: (Paru{}).ListOutdated,
+		},
+		{
+			name: "paru/error", bin: "paru", script: `echo "boom" >&2; exit 2`,
+			wantError: true, list: (Paru{}).ListOutdated,
+		},
+		{
+			name: "yay/parse", bin: "yay",
+			script: `if [ "$1" = "-Qu" ]; then cat <<'EOF'
+` + quLines + `EOF
+exit 0
+fi
+exit 1`,
+			want: map[string]string{"git": "2.48.0", "neovim": "0.11.0"},
+			list: (Yay{}).ListOutdated,
+		},
+		{
+			name: "yay/intersect", bin: "yay", script: "cat <<'EOF'\n" + quLines + "EOF\n",
+			pkgNames: []string{"neovim"}, want: map[string]string{"neovim": "0.11.0"},
+			list: (Yay{}).ListOutdated,
+		},
+		{
+			name: "yay/empty", bin: "yay", script: `exit 1`,
+			wantNil: true, list: (Yay{}).ListOutdated,
+		},
+		{
+			name: "yay/error", bin: "yay", script: `echo "boom" >&2; exit 2`,
+			wantError: true, list: (Yay{}).ListOutdated,
+		},
+		{
+			name: "snap/parse", bin: "snap",
+			script: `if [ "$1" = "refresh" ] && [ "$2" = "--list" ]; then cat <<'EOF'
+` + snapList + `EOF
+exit 0
+fi
+exit 1`,
+			want: map[string]string{"firefox": "139.0-1", "code": "1.95.0"},
+			list: (Snap{}).ListOutdated,
+		},
+		{
+			name: "snap/intersect", bin: "snap",
+			script: `if [ "$1" = "refresh" ] && [ "$2" = "--list" ]; then cat <<'EOF'
+` + snapList + `EOF
+exit 0
+fi
+exit 1`,
+			pkgNames: []string{"code"}, want: map[string]string{"code": "1.95.0"},
+			list: (Snap{}).ListOutdated,
+		},
+		{
+			name: "snap/empty", bin: "snap",
+			script:  `if [ "$1" = "refresh" ] && [ "$2" = "--list" ]; then printf ""; exit 0; fi; exit 1`,
+			wantNil: true, list: (Snap{}).ListOutdated,
+		},
+		{
+			name: "snap/error", bin: "snap", script: `echo "boom" >&2; exit 2`,
+			wantError: true, list: (Snap{}).ListOutdated,
+		},
 	}
-	want := map[string]string{"497799835": "14.1", "409201541": "13.1"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			installFakeBinary(t, tc.bin, tc.script)
+			got, err := tc.list(tc.pkgNames)
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("got %v, want nil", got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
-func TestMas_ListOutdated_IntersectsWithPkgNames(t *testing.T) {
-	installFakeBinary(t, "mas",
-		`echo "497799835 Xcode (14.1)"
-echo "409201541 Pages (13.1)"`)
-
-	got, err := Mas{}.ListOutdated([]string{"497799835"})
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"497799835": "14.1"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestBun_ListOutdated_ReportsOnlyDiffering(t *testing.T) {
-	installFakeBinary(t, "bun",
-		`if [ "$1" = "pm" ] && [ "$2" = "ls" ] && [ "$3" = "--global" ]; then
+func TestRegistryListOutdated_ReportsOnlyDiffering(t *testing.T) {
+	cases := []struct {
+		name     string
+		bin      string
+		script   string
+		swap     func(*testing.T) func()
+		pkgNames []string
+		want     map[string]string
+		list     func([]string) (map[string]string, error)
+	}{
+		{
+			name: "bun", bin: "bun",
+			script: `if [ "$1" = "pm" ] && [ "$2" = "ls" ] && [ "$3" = "--global" ]; then
 	echo "/Users/x/.bun/install/global node_modules"
 	echo "├── cf@1.2.0"
 	echo "└── typescript@5.0.0"
 	exit 0
 fi
 echo "unexpected args: $*" >&2
-exit 1`)
-
-	restore := swapNpmLatest(t, map[string]string{"cf": "1.3.0", "typescript": "5.0.0"}, nil)
-	defer restore()
-
-	got, err := Bun{}.ListOutdated([]string{"cf", "typescript"})
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"cf": "1.3.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestNpm_ListOutdated_ReportsOnlyDiffering(t *testing.T) {
-	installFakeBinary(t, "npm",
-		`if [ "$1" = "list" ]; then
+exit 1`,
+			swap: func(t *testing.T) func() {
+				return swapNpmLatest(t, map[string]string{"cf": "1.3.0", "typescript": "5.0.0"}, nil)
+			},
+			pkgNames: []string{"cf", "typescript"}, want: map[string]string{"cf": "1.3.0"},
+			list: Bun{}.ListOutdated,
+		},
+		{
+			name: "npm", bin: "npm",
+			script: `if [ "$1" = "list" ]; then
 	cat <<'JSON'
 {"dependencies":{"cf":{"version":"1.2.0"},"typescript":{"version":"5.0.0"}}}
 JSON
 	exit 0
 fi
-echo "unexpected: $*" >&2; exit 1`)
-
-	restore := swapNpmLatest(t, map[string]string{"cf": "1.3.0", "typescript": "5.0.0"}, nil)
-	defer restore()
-
-	got, err := Npm{}.ListOutdated([]string{"cf", "typescript"})
-	if err != nil {
-		t.Fatalf("ListOutdated: %v", err)
-	}
-	want := map[string]string{"cf": "1.3.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-}
-
-func TestPnpm_ListOutdated_ReportsOnlyDiffering(t *testing.T) {
-	installFakeBinary(t, "pnpm",
-		`if [ "$1" = "list" ]; then
+echo "unexpected: $*" >&2; exit 1`,
+			swap: func(t *testing.T) func() {
+				return swapNpmLatest(t, map[string]string{"cf": "1.3.0", "typescript": "5.0.0"}, nil)
+			},
+			pkgNames: []string{"cf", "typescript"}, want: map[string]string{"cf": "1.3.0"},
+			list: Npm{}.ListOutdated,
+		},
+		{
+			name: "pnpm", bin: "pnpm",
+			script: `if [ "$1" = "list" ]; then
 	cat <<'JSON'
 [{"dependencies":{"cf":{"version":"1.2.0"},"typescript":{"version":"5.0.0"}}}]
 JSON
 	exit 0
 fi
-echo "unexpected: $*" >&2; exit 1`)
-
-	restore := swapNpmLatest(t, map[string]string{"cf": "1.3.0", "typescript": "5.0.0"}, nil)
-	defer restore()
-
-	got, err := Pnpm{}.ListOutdated([]string{"cf", "typescript"})
-	if err != nil {
-		t.Fatalf("ListOutdated: %v", err)
-	}
-	want := map[string]string{"cf": "1.3.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-}
-
-func TestYarn_ListOutdated_ReportsOnlyDiffering(t *testing.T) {
-	installFakeBinary(t, "yarn",
-		`if [ "$1" = "global" ] && [ "$2" = "list" ]; then
+echo "unexpected: $*" >&2; exit 1`,
+			swap: func(t *testing.T) func() {
+				return swapNpmLatest(t, map[string]string{"cf": "1.3.0", "typescript": "5.0.0"}, nil)
+			},
+			pkgNames: []string{"cf", "typescript"}, want: map[string]string{"cf": "1.3.0"},
+			list: Pnpm{}.ListOutdated,
+		},
+		{
+			name: "yarn", bin: "yarn",
+			script: `if [ "$1" = "global" ] && [ "$2" = "list" ]; then
 	echo 'yarn global v1.22.22'
 	echo 'info "cf@1.2.0" has binaries:'
 	echo 'info "typescript@5.0.0" has binaries:'
 	exit 0
 fi
-echo "unexpected: $*" >&2; exit 1`)
-
-	restore := swapNpmLatest(t, map[string]string{"cf": "1.3.0", "typescript": "5.0.0"}, nil)
-	defer restore()
-
-	got, err := Yarn{}.ListOutdated([]string{"cf", "typescript"})
-	if err != nil {
-		t.Fatalf("ListOutdated: %v", err)
+echo "unexpected: $*" >&2; exit 1`,
+			swap: func(t *testing.T) func() {
+				return swapNpmLatest(t, map[string]string{"cf": "1.3.0", "typescript": "5.0.0"}, nil)
+			},
+			pkgNames: []string{"cf", "typescript"}, want: map[string]string{"cf": "1.3.0"},
+			list: Yarn{}.ListOutdated,
+		},
+		{
+			name: "uv", bin: "uv",
+			script: `if [ "$1" = "tool" ] && [ "$2" = "list" ]; then
+	echo "ruff v0.6.0"
+	echo "black v24.0.0"
+	exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 1`,
+			swap: func(t *testing.T) func() {
+				return swapPypiLatest(t, map[string]string{"ruff": "0.7.0", "black": "24.0.0"}, nil)
+			},
+			pkgNames: []string{"ruff", "black"}, want: map[string]string{"ruff": "0.7.0"},
+			list: Uv{}.ListOutdated,
+		},
+		{
+			name: "pipx", bin: "pipx",
+			script: `if [ "$1" = "list" ] && [ "$2" = "--json" ]; then
+	cat <<'JSON'
+{"venvs":{"ruff":{"metadata":{"main_package":{"package":"ruff","package_version":"0.6.0"}}},"black":{"metadata":{"main_package":{"package":"black","package_version":"24.0.0"}}}}}
+JSON
+	exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 1`,
+			swap: func(t *testing.T) func() {
+				return swapPypiLatest(t, map[string]string{"ruff": "0.7.0", "black": "24.0.0"}, nil)
+			},
+			pkgNames: []string{"ruff", "black"}, want: map[string]string{"ruff": "0.7.0"},
+			list: Pipx{}.ListOutdated,
+		},
+		{
+			name: "cargo", bin: "cargo",
+			script: `if [ "$1" = "install" ] && [ "$2" = "--list" ]; then
+	echo "ripgrep v14.0.0:"
+	echo "    rg"
+	echo "fd-find v9.0.0:"
+	echo "    fd"
+	exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 1`,
+			swap: func(t *testing.T) func() {
+				return swapCratesLatest(t, map[string]string{"ripgrep": "14.1.0", "fd-find": "9.0.0"}, nil)
+			},
+			pkgNames: []string{"ripgrep", "fd-find"}, want: map[string]string{"ripgrep": "14.1.0"},
+			list: Cargo{}.ListOutdated,
+		},
 	}
-	want := map[string]string{"cf": "1.3.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			installFakeBinary(t, tc.bin, tc.script)
+			defer tc.swap(t)()
+			got, err := tc.list(tc.pkgNames)
+			if err != nil {
+				t.Fatalf("ListOutdated: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -402,58 +438,9 @@ echo "└── cf@1.2.0"`)
 	if err != nil {
 		t.Fatalf("ListOutdated: unexpected error: %v", err)
 	}
-	// Unknown latest (transport error) => keep the installed version so the
-	// package is still flagged as potentially outdated.
 	want := map[string]string{"cf": "1.2.0"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestUv_ListOutdated_ReportsOnlyDiffering(t *testing.T) {
-	installFakeBinary(t, "uv",
-		`if [ "$1" = "tool" ] && [ "$2" = "list" ]; then
-	echo "ruff v0.6.0"
-	echo "black v24.0.0"
-	exit 0
-fi
-echo "unexpected args: $*" >&2
-exit 1`)
-
-	restore := swapPypiLatest(t, map[string]string{"ruff": "0.7.0", "black": "24.0.0"}, nil)
-	defer restore()
-
-	got, err := Uv{}.ListOutdated([]string{"ruff", "black"})
-	if err != nil {
-		t.Fatalf("ListOutdated: %v", err)
-	}
-	want := map[string]string{"ruff": "0.7.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-}
-
-func TestPipx_ListOutdated_ReportsOnlyDiffering(t *testing.T) {
-	installFakeBinary(t, "pipx",
-		`if [ "$1" = "list" ] && [ "$2" = "--json" ]; then
-	cat <<'JSON'
-{"venvs":{"ruff":{"metadata":{"main_package":{"package":"ruff","package_version":"0.6.0"}}},"black":{"metadata":{"main_package":{"package":"black","package_version":"24.0.0"}}}}}
-JSON
-	exit 0
-fi
-echo "unexpected args: $*" >&2
-exit 1`)
-
-	restore := swapPypiLatest(t, map[string]string{"ruff": "0.7.0", "black": "24.0.0"}, nil)
-	defer restore()
-
-	got, err := Pipx{}.ListOutdated([]string{"ruff", "black"})
-	if err != nil {
-		t.Fatalf("ListOutdated: %v", err)
-	}
-	want := map[string]string{"ruff": "0.7.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
 	}
 }
 
@@ -526,294 +513,6 @@ func TestFetchPypiLatest_DecodesVersionAndEscapesName(t *testing.T) {
 	}
 }
 
-// swapNpmLatest replaces the npmLatestVersion seam with a fake returning canned
-// versions (or a transport error for names in errNames). It returns a restore
-// function.
-func swapNpmLatest(t *testing.T, versions map[string]string, errNames map[string]bool) func() {
-	t.Helper()
-	orig := npmLatestVersion
-	npmLatestVersion = func(name string) (string, error) {
-		if errNames[name] {
-			return "", http.ErrHandlerTimeout
-		}
-		return versions[name], nil
-	}
-	return func() { npmLatestVersion = orig }
-}
-
-// swapPypiLatest replaces the pypiLatestVersion seam with a fake returning
-// canned versions (or a transport error for names in errNames).
-func swapPypiLatest(t *testing.T, versions map[string]string, errNames map[string]bool) func() {
-	t.Helper()
-	orig := pypiLatestVersion
-	pypiLatestVersion = func(name string) (string, error) {
-		if errNames[name] {
-			return "", http.ErrHandlerTimeout
-		}
-		return versions[name], nil
-	}
-	return func() { pypiLatestVersion = orig }
-}
-
-func TestPacman_ListOutdated_ParsesQuOutput(t *testing.T) {
-	installFakeBinary(t, "pacman", `if [ "$1" = "-Qu" ]; then
-cat <<'EOF'
-git 2.47.0 -> 2.48.0
-neovim 0.10.0 -> 0.11.0
-EOF
-exit 0
-fi
-exit 1`)
-
-	got, err := (Pacman{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"git": "2.48.0", "neovim": "0.11.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestPacman_ListOutdated_IntersectsWithPkgNames(t *testing.T) {
-	installFakeBinary(t, "pacman", `cat <<'EOF'
-git 2.47.0 -> 2.48.0
-neovim 0.10.0 -> 0.11.0
-EOF`)
-
-	got, err := (Pacman{}).ListOutdated([]string{"neovim"})
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"neovim": "0.11.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestPacman_ListOutdated_NothingOutdated(t *testing.T) {
-	installFakeBinary(t, "pacman", `exit 1`)
-
-	got, err := (Pacman{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("ListOutdated: got %v, want nil", got)
-	}
-}
-
-func TestPacman_ListOutdated_CommandFailureIsError(t *testing.T) {
-	installFakeBinary(t, "pacman", `echo "boom" >&2; exit 2`)
-
-	if _, err := (Pacman{}).ListOutdated(nil); err == nil {
-		t.Fatal("ListOutdated: expected error on command failure, got nil")
-	}
-}
-
-func TestParu_ListOutdated_ParsesQuOutput(t *testing.T) {
-	installFakeBinary(t, "paru", `if [ "$1" = "-Qu" ]; then
-cat <<'EOF'
-git 2.47.0 -> 2.48.0
-neovim 0.10.0 -> 0.11.0
-EOF
-exit 0
-fi
-exit 1`)
-
-	got, err := (Paru{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"git": "2.48.0", "neovim": "0.11.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestParu_ListOutdated_IntersectsWithPkgNames(t *testing.T) {
-	installFakeBinary(t, "paru", `cat <<'EOF'
-git 2.47.0 -> 2.48.0
-neovim 0.10.0 -> 0.11.0
-EOF`)
-
-	got, err := (Paru{}).ListOutdated([]string{"git"})
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"git": "2.48.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestParu_ListOutdated_NothingOutdated(t *testing.T) {
-	installFakeBinary(t, "paru", `exit 1`)
-
-	got, err := (Paru{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("ListOutdated: got %v, want nil", got)
-	}
-}
-
-func TestParu_ListOutdated_CommandFailureIsError(t *testing.T) {
-	installFakeBinary(t, "paru", `echo "boom" >&2; exit 2`)
-
-	if _, err := (Paru{}).ListOutdated(nil); err == nil {
-		t.Fatal("ListOutdated: expected error on command failure, got nil")
-	}
-}
-
-func TestYay_ListOutdated_ParsesQuOutput(t *testing.T) {
-	installFakeBinary(t, "yay", `if [ "$1" = "-Qu" ]; then
-cat <<'EOF'
-git 2.47.0 -> 2.48.0
-neovim 0.10.0 -> 0.11.0
-EOF
-exit 0
-fi
-exit 1`)
-
-	got, err := (Yay{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"git": "2.48.0", "neovim": "0.11.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestYay_ListOutdated_IntersectsWithPkgNames(t *testing.T) {
-	installFakeBinary(t, "yay", `cat <<'EOF'
-git 2.47.0 -> 2.48.0
-neovim 0.10.0 -> 0.11.0
-EOF`)
-
-	got, err := (Yay{}).ListOutdated([]string{"neovim"})
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"neovim": "0.11.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestYay_ListOutdated_NothingOutdated(t *testing.T) {
-	installFakeBinary(t, "yay", `exit 1`)
-
-	got, err := (Yay{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("ListOutdated: got %v, want nil", got)
-	}
-}
-
-func TestYay_ListOutdated_CommandFailureIsError(t *testing.T) {
-	installFakeBinary(t, "yay", `echo "boom" >&2; exit 2`)
-
-	if _, err := (Yay{}).ListOutdated(nil); err == nil {
-		t.Fatal("ListOutdated: expected error on command failure, got nil")
-	}
-}
-
-func TestSnap_ListOutdated_ParsesRefreshList(t *testing.T) {
-	installFakeBinary(t, "snap", `if [ "$1" = "refresh" ] && [ "$2" = "--list" ]; then
-cat <<'EOF'
-Name           Version  Rev   Publisher     Notes
-firefox        139.0-1  1235  mozilla       -
-code           1.95.0   200   vscode        classic
-EOF
-exit 0
-fi
-exit 1`)
-
-	got, err := (Snap{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"firefox": "139.0-1", "code": "1.95.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestSnap_ListOutdated_IntersectsWithPkgNames(t *testing.T) {
-	installFakeBinary(t, "snap", `if [ "$1" = "refresh" ] && [ "$2" = "--list" ]; then
-cat <<'EOF'
-Name           Version  Rev   Publisher     Notes
-firefox        139.0-1  1235  mozilla       -
-code           1.95.0   200   vscode        classic
-EOF
-exit 0
-fi
-exit 1`)
-
-	got, err := (Snap{}).ListOutdated([]string{"code"})
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	want := map[string]string{"code": "1.95.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ListOutdated: got %v, want %v", got, want)
-	}
-}
-
-func TestSnap_ListOutdated_NothingOutdated(t *testing.T) {
-	installFakeBinary(t, "snap", `if [ "$1" = "refresh" ] && [ "$2" = "--list" ]; then
-printf ""
-exit 0
-fi
-exit 1`)
-
-	got, err := (Snap{}).ListOutdated(nil)
-	if err != nil {
-		t.Fatalf("ListOutdated: unexpected error: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("ListOutdated: got %v, want nil", got)
-	}
-}
-
-func TestSnap_ListOutdated_CommandFailureIsError(t *testing.T) {
-	installFakeBinary(t, "snap", `echo "boom" >&2; exit 2`)
-
-	if _, err := (Snap{}).ListOutdated(nil); err == nil {
-		t.Fatal("ListOutdated: expected error on command failure, got nil")
-	}
-}
-
-func TestCargo_ListOutdated_ReportsOnlyDiffering(t *testing.T) {
-	installFakeBinary(t, "cargo",
-		`if [ "$1" = "install" ] && [ "$2" = "--list" ]; then
-	echo "ripgrep v14.0.0:"
-	echo "    rg"
-	echo "fd-find v9.0.0:"
-	echo "    fd"
-	exit 0
-fi
-echo "unexpected args: $*" >&2
-exit 1`)
-
-	restore := swapCratesLatest(t, map[string]string{"ripgrep": "14.1.0", "fd-find": "9.0.0"}, nil)
-	defer restore()
-
-	got, err := Cargo{}.ListOutdated([]string{"ripgrep", "fd-find"})
-	if err != nil {
-		t.Fatalf("ListOutdated: %v", err)
-	}
-	want := map[string]string{"ripgrep": "14.1.0"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-}
-
 func TestFetchCratesLatest_DecodesVersionAndSetsUserAgent(t *testing.T) {
 	var gotPath, gotUA string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -839,8 +538,8 @@ func TestFetchCratesLatest_DecodesVersionAndSetsUserAgent(t *testing.T) {
 	if gotPath != "/api/v1/crates/ripgrep" {
 		t.Fatalf("request path = %q, want /api/v1/crates/ripgrep", gotPath)
 	}
-	if gotUA != "genv (https://github.com/ks1686/genv)" {
-		t.Fatalf("User-Agent = %q, want genv (https://github.com/ks1686/genv)", gotUA)
+	if gotUA != cratesUserAgent {
+		t.Fatalf("User-Agent = %q, want %q", gotUA, cratesUserAgent)
 	}
 
 	v, err = fetchCratesLatest("does-not-exist")
@@ -849,8 +548,30 @@ func TestFetchCratesLatest_DecodesVersionAndSetsUserAgent(t *testing.T) {
 	}
 }
 
-// swapCratesLatest replaces the cratesLatestVersion seam with a fake returning
-// canned versions (or a transport error for names in errNames).
+func swapNpmLatest(t *testing.T, versions map[string]string, errNames map[string]bool) func() {
+	t.Helper()
+	orig := npmLatestVersion
+	npmLatestVersion = func(name string) (string, error) {
+		if errNames[name] {
+			return "", http.ErrHandlerTimeout
+		}
+		return versions[name], nil
+	}
+	return func() { npmLatestVersion = orig }
+}
+
+func swapPypiLatest(t *testing.T, versions map[string]string, errNames map[string]bool) func() {
+	t.Helper()
+	orig := pypiLatestVersion
+	pypiLatestVersion = func(name string) (string, error) {
+		if errNames[name] {
+			return "", http.ErrHandlerTimeout
+		}
+		return versions[name], nil
+	}
+	return func() { pypiLatestVersion = orig }
+}
+
 func swapCratesLatest(t *testing.T, versions map[string]string, errNames map[string]bool) func() {
 	t.Helper()
 	orig := cratesLatestVersion

--- a/internal/adapter/pipx.go
+++ b/internal/adapter/pipx.go
@@ -95,11 +95,9 @@ func (Pipx) ListOutdated(pkgNames []string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	installed := make(map[string]string, len(entries))
-	for _, entry := range entries {
-		installed[entry.name] = entry.version
-	}
-	return listRegistryOutdated(installed, pkgNames, PythonBasePackageName, pypiLatestVersion)
+	return listRegistryOutdated(versionMapOf(entries, func(e pythonEntry) (string, string) {
+		return e.name, e.version
+	}), pkgNames, PythonBasePackageName, pypiLatestVersion)
 }
 
 func (Pipx) listEntries() ([]pythonEntry, error) {

--- a/internal/adapter/registry.go
+++ b/internal/adapter/registry.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -23,9 +24,10 @@ var pypiRegistryBase = "https://pypi.org"
 // httptest server.
 var cratesRegistryBase = "https://crates.io"
 
-// npmHTTPClient is the client used for registry lookups. The short timeout keeps
-// an hourly update check from blocking on a slow or unreachable network.
-var npmHTTPClient = &http.Client{Timeout: 5 * time.Second}
+// registryHTTPClient is the client used for package-registry lookups. The short
+// timeout keeps an hourly update check from blocking on a slow or unreachable
+// network.
+var registryHTTPClient = &http.Client{Timeout: 5 * time.Second}
 
 // npmLatestVersion resolves the "latest" dist-tag version of an npm package.
 // It is a package-level var so tests can inject canned versions without any
@@ -42,13 +44,21 @@ var pypiLatestVersion = fetchPypiLatest
 // network access.
 var cratesLatestVersion = fetchCratesLatest
 
-// fetchNpmLatest queries the npm registry for the latest published version of
-// name. Scoped names (@scope/pkg) are URL-encoded (the "/" becomes %2F). Returns
-// "" with no error when the package is unknown (404); network and transport
-// failures are returned as errors so callers can fall back conservatively.
-func fetchNpmLatest(name string) (string, error) {
-	endpoint := npmRegistryBase + "/" + url.PathEscape(name) + "/latest"
-	resp, err := npmHTTPClient.Get(endpoint)
+const cratesUserAgent = "genv (https://github.com/ks1686/genv)"
+
+// fetchRegistryLatest GETs endpoint, treating 404 as unknown ("" , nil) and other
+// non-200 statuses as errors. extract pulls the version string from a 200 body.
+func fetchRegistryLatest(endpoint, label string, header http.Header, extract func([]byte) (string, error)) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	for k, vals := range header {
+		for _, v := range vals {
+			req.Header.Add(k, v)
+		}
+	}
+	resp, err := registryHTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -57,15 +67,34 @@ func fetchNpmLatest(name string) (string, error) {
 		return "", nil
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("npm registry: %s returned %s", name, resp.Status)
+		return "", fmt.Errorf("%s: %s returned %s", label, endpoint, resp.Status)
 	}
-	var payload struct {
-		Version string `json:"version"`
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("%s: read %s: %w", label, endpoint, err)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", fmt.Errorf("npm registry: decode %s: %w", name, err)
+	version, err := extract(body)
+	if err != nil {
+		return "", fmt.Errorf("%s: decode: %w", label, err)
 	}
-	return payload.Version, nil
+	return version, nil
+}
+
+// fetchNpmLatest queries the npm registry for the latest published version of
+// name. Scoped names (@scope/pkg) are URL-encoded (the "/" becomes %2F). Returns
+// "" with no error when the package is unknown (404); network and transport
+// failures are returned as errors so callers can fall back conservatively.
+func fetchNpmLatest(name string) (string, error) {
+	endpoint := npmRegistryBase + "/" + url.PathEscape(name) + "/latest"
+	return fetchRegistryLatest(endpoint, "npm registry", nil, func(body []byte) (string, error) {
+		var payload struct {
+			Version string `json:"version"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return "", err
+		}
+		return payload.Version, nil
+	})
 }
 
 // fetchPypiLatest queries PyPI for the latest published version of name.
@@ -74,26 +103,17 @@ func fetchNpmLatest(name string) (string, error) {
 // conservatively.
 func fetchPypiLatest(name string) (string, error) {
 	endpoint := pypiRegistryBase + "/pypi/" + url.PathEscape(name) + "/json"
-	resp, err := npmHTTPClient.Get(endpoint)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		return "", nil
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("PyPI registry: %s returned %s", name, resp.Status)
-	}
-	var payload struct {
-		Info struct {
-			Version string `json:"version"`
-		} `json:"info"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", fmt.Errorf("PyPI registry: decode %s: %w", name, err)
-	}
-	return payload.Info.Version, nil
+	return fetchRegistryLatest(endpoint, "PyPI registry", nil, func(body []byte) (string, error) {
+		var payload struct {
+			Info struct {
+				Version string `json:"version"`
+			} `json:"info"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return "", err
+		}
+		return payload.Info.Version, nil
+	})
 }
 
 // fetchCratesLatest queries crates.io for the latest published version of name.
@@ -102,29 +122,16 @@ func fetchPypiLatest(name string) (string, error) {
 // conservatively.
 func fetchCratesLatest(name string) (string, error) {
 	endpoint := cratesRegistryBase + "/api/v1/crates/" + url.PathEscape(name)
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("User-Agent", "genv (https://github.com/ks1686/genv)")
-	resp, err := npmHTTPClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		return "", nil
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("crates.io registry: %s returned %s", name, resp.Status)
-	}
-	var payload struct {
-		Crate struct {
-			MaxVersion string `json:"max_version"`
-		} `json:"crate"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", fmt.Errorf("crates.io registry: decode %s: %w", name, err)
-	}
-	return payload.Crate.MaxVersion, nil
+	header := http.Header{"User-Agent": {cratesUserAgent}}
+	return fetchRegistryLatest(endpoint, "crates.io registry", header, func(body []byte) (string, error) {
+		var payload struct {
+			Crate struct {
+				MaxVersion string `json:"max_version"`
+			} `json:"crate"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return "", err
+		}
+		return payload.Crate.MaxVersion, nil
+	})
 }

--- a/internal/adapter/uv.go
+++ b/internal/adapter/uv.go
@@ -105,11 +105,9 @@ func (Uv) ListOutdated(pkgNames []string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	installed := make(map[string]string, len(entries))
-	for _, entry := range entries {
-		installed[entry.name] = entry.version
-	}
-	return listRegistryOutdated(installed, pkgNames, uvToolName, pypiLatestVersion)
+	return listRegistryOutdated(versionMapOf(entries, func(e uvEntry) (string, string) {
+		return e.name, e.version
+	}), pkgNames, uvToolName, pypiLatestVersion)
 }
 
 type uvEntry struct {

--- a/internal/upgrade/planner.go
+++ b/internal/upgrade/planner.go
@@ -12,14 +12,13 @@ import (
 )
 
 type UpgradeOptions struct {
-	Spec    *schema.GenvFile
-	Lock    *genvfile.LockFile
+	Spec *schema.GenvFile
+	Lock *genvfile.LockFile
+	// Filters control which packages are planned. When Filters.All is false
+	// (the default), the plan is narrowed to packages with an update available
+	// via each manager's OutdatedLister. Filters.All true restores brute-force
+	// planning of every unconstrained tracked package (`genv upgrade --all`).
 	Filters output.UpgradeFilters
-	// DetectOutdated narrows the plan to packages that actually have an update
-	// available (via each manager's OutdatedLister). Default for `genv upgrade`
-	// and for updates check / background worker. `genv upgrade --all` sets this
-	// false to restore brute-force planning of every unconstrained tracked package.
-	DetectOutdated bool
 }
 
 type UpgradePlan struct {
@@ -184,7 +183,7 @@ func BuildUpgradePlan(opts UpgradeOptions) (UpgradePlan, error) {
 		upgradeablePackages = append(upgradeablePackages, lp)
 	}
 
-	if opts.DetectOutdated {
+	if !opts.Filters.All {
 		filtered, warnings := resolver.FilterOutdated(upgradeablePackages)
 		upgradeablePackages = filtered
 		plan.Warnings = append(plan.Warnings, warnings...)

--- a/internal/upgrade/planner_test.go
+++ b/internal/upgrade/planner_test.go
@@ -14,6 +14,45 @@ import (
 	"github.com/ks1686/genv/internal/schema"
 )
 
+// planAll skips outdated detection so planner unit tests exercise filter/constraint
+// logic without requiring fake outdated CLIs.
+var planAll = output.UpgradeFilters{All: true}
+
+func TestBuildUpgradePlan_FiltersAll_skipsOutdatedDetection(t *testing.T) {
+	// Given: brew outdated reports only git, but --all requests every package.
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		`if [ "$1" = "outdated" ]; then echo '{"formulae":[{"name":"git","current_version":"2.44.0"}],"casks":[]}'; exit 0; fi` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "brew"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	spec := &schema.GenvFile{Packages: []schema.Package{{ID: "git"}, {ID: "jq"}}}
+	lock := &genvfile.LockFile{Packages: []genvfile.LockedPackage{
+		{ID: "git", Manager: "brew", PkgName: "git"},
+		{ID: "jq", Manager: "brew", PkgName: "jq"},
+	}}
+
+	plan, err := BuildUpgradePlan(UpgradeOptions{
+		Spec:    spec,
+		Lock:    lock,
+		Filters: output.UpgradeFilters{All: true},
+	})
+	if err != nil {
+		t.Fatalf("BuildUpgradePlan: %v", err)
+	}
+	var gotIDs []string
+	for _, a := range plan.Actions {
+		for _, lp := range a.LPs {
+			gotIDs = append(gotIDs, lp.ID)
+		}
+	}
+	if !slices.Equal(gotIDs, []string{"git", "jq"}) {
+		t.Fatalf("Filters.All plan packages = %v, want [git jq]", gotIDs)
+	}
+}
+
 func TestBuildUpgradePlan_DetectOutdated_filters_to_outdated(t *testing.T) {
 	// Given: two tracked brew packages, but a fake `brew outdated` reports only git.
 	dir := t.TempDir()
@@ -30,8 +69,8 @@ func TestBuildUpgradePlan_DetectOutdated_filters_to_outdated(t *testing.T) {
 		{ID: "jq", Manager: "brew", PkgName: "jq"},
 	}}
 
-	// When: the plan is built with outdated detection enabled.
-	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock, DetectOutdated: true})
+	// When: the plan is built with default outdated detection (Filters.All false).
+	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock})
 	if err != nil {
 		t.Fatalf("BuildUpgradePlan: %v", err)
 	}
@@ -44,7 +83,7 @@ func TestBuildUpgradePlan_DetectOutdated_filters_to_outdated(t *testing.T) {
 		}
 	}
 	if !slices.Equal(gotIDs, []string{"git"}) {
-		t.Fatalf("DetectOutdated plan packages = %v, want [git]", gotIDs)
+		t.Fatalf("outdated plan packages = %v, want [git]", gotIDs)
 	}
 }
 
@@ -54,7 +93,7 @@ func TestBuildUpgradePlan_Constraint_unconstrained_package_plans_normally(t *tes
 	lock := &genvfile.LockFile{Packages: []genvfile.LockedPackage{{ID: "git", Manager: "brew", PkgName: "git"}}}
 
 	// When: the shared upgrade plan is built.
-	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock})
+	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock, Filters: planAll})
 
 	// Then: the package retains the existing upgrade behavior.
 	if err != nil {
@@ -82,7 +121,7 @@ func TestBuildUpgradePlan_Constraint_constrained_packages_are_skipped_in_lock_or
 	}}
 
 	// When: the shared upgrade plan is built.
-	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock})
+	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock, Filters: planAll})
 
 	// Then: only the unconstrained package is planned and constraint skips retain lock order and identity.
 	if err != nil {
@@ -123,7 +162,7 @@ func TestBuildUpgradePlan_Constraint_mixed_batch_excludes_only_constrained_packa
 	}}
 
 	// When: the shared upgrade plan is built.
-	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock})
+	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock, Filters: planAll})
 
 	// Then: the remaining unconstrained packages still form one batch.
 	if err != nil {
@@ -155,12 +194,12 @@ func TestBuildUpgradePlan_Constraint_existing_package_filters_run_first(t *testi
 	}{
 		{
 			name:       "skip excludes before constraint evaluation",
-			filters:    output.UpgradeFilters{Skip: []string{"jq"}},
+			filters:    output.UpgradeFilters{All: true, Skip: []string{"jq"}},
 			wantReason: "excluded by --skip",
 		},
 		{
 			name:       "only takes precedence over skip before constraint evaluation",
-			filters:    output.UpgradeFilters{Only: []string{"jq"}, Skip: []string{"jq"}},
+			filters:    output.UpgradeFilters{All: true, Only: []string{"jq"}, Skip: []string{"jq"}},
 			wantReason: "version-constrained package requires an explicit compatible target",
 		},
 	}
@@ -209,13 +248,14 @@ func TestBuildPlan(t *testing.T) {
 	}{
 		{
 			name:        "no filters",
-			filters:     output.UpgradeFilters{},
+			filters:     output.UpgradeFilters{All: true},
 			wantActions: 2, // brew (batch), npm
 			wantSkipped: 0,
 		},
 		{
 			name: "only pkg1",
 			filters: output.UpgradeFilters{
+				All:  true,
 				Only: []string{"pkg1"},
 			},
 			wantActions: 1,
@@ -224,6 +264,7 @@ func TestBuildPlan(t *testing.T) {
 		{
 			name: "skip pkg3",
 			filters: output.UpgradeFilters{
+				All:  true,
 				Skip: []string{"pkg3"},
 			},
 			wantActions: 1, // brew batch
@@ -232,6 +273,7 @@ func TestBuildPlan(t *testing.T) {
 		{
 			name: "only manager brew",
 			filters: output.UpgradeFilters{
+				All:         true,
 				OnlyManager: []string{"brew"},
 			},
 			wantActions: 1,
@@ -240,6 +282,7 @@ func TestBuildPlan(t *testing.T) {
 		{
 			name: "skip manager brew",
 			filters: output.UpgradeFilters{
+				All:         true,
 				SkipManager: []string{"brew"},
 			},
 			wantActions: 1,
@@ -248,6 +291,7 @@ func TestBuildPlan(t *testing.T) {
 		{
 			name: "unknown manager",
 			filters: output.UpgradeFilters{
+				All:         true,
 				OnlyManager: []string{"unknown"},
 			},
 			wantErr: true,
@@ -285,7 +329,7 @@ func TestBuildUpgradePlan_is_callable_without_cli_side_effects(t *testing.T) {
 	lock := &genvfile.LockFile{Packages: []genvfile.LockedPackage{{ID: "git", Manager: "brew", PkgName: "git", InstalledVersion: "1.0.0"}}}
 
 	// When: the reusable planner is called directly, outside main.go flag parsing.
-	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock})
+	plan, err := BuildUpgradePlan(UpgradeOptions{Spec: spec, Lock: lock, Filters: planAll})
 
 	// Then: planning produces a reusable UpgradePlan and leaves execution results absent.
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -3089,8 +3089,6 @@ func validateCmd(args []string) int {
 // upgradeCmd implements `genv upgrade [--dry-run] [--yes] [--no-hooks] [--debug] [--all]`.
 // By default plans only packages with a detected update; pass --all to plan every
 // unconstrained tracked package without outdated filtering.
-func upgradeDetectOutdated(all bool) bool { return !all }
-
 func upgradeCmd(args []string) int {
 	fs := flag.NewFlagSet("upgrade", flag.ContinueOnError)
 	fs.Usage = func() {
@@ -3222,10 +3220,9 @@ func upgradeCmd(args []string) int {
 	}
 
 	planResult, err := upgrade.BuildUpgradePlan(upgrade.UpgradeOptions{
-		Spec:           f,
-		Lock:           lf,
-		Filters:        filters,
-		DetectOutdated: upgradeDetectOutdated(*all),
+		Spec:    f,
+		Lock:    lf,
+		Filters: filters,
 	})
 	if err != nil {
 		fprintf(os.Stderr, "genv upgrade: %v\n", err)

--- a/main_test.go
+++ b/main_test.go
@@ -1824,15 +1824,6 @@ func TestUpgrade_DryRun_does_not_run_hooks_or_write_lock(t *testing.T) {
 	}
 }
 
-func TestUpgradeFlagAll_disablesDetectOutdated(t *testing.T) {
-	if upgradeDetectOutdated(false) != true {
-		t.Fatal("want DetectOutdated true when --all unset")
-	}
-	if upgradeDetectOutdated(true) != false {
-		t.Fatal("want DetectOutdated false when --all set")
-	}
-}
-
 func TestUpgrade_HookTimeout_bad_duration_fails_usage(t *testing.T) {
 	// Given: a valid spec and lock so flag parsing reaches hook-timeout validation.
 	dir := t.TempDir()
@@ -2430,8 +2421,8 @@ func TestUpdatesRunOnce_CheckOnly_notifies_only_when_packages_outdated(t *testin
 
 			originalBuild := updatesBuildPlan
 			updatesBuildPlan = func(opts upgrade.UpgradeOptions) (upgrade.UpgradePlan, error) {
-				if !opts.DetectOutdated {
-					t.Error("check worker built plan without DetectOutdated")
+				if opts.Filters.All {
+					t.Error("check worker built plan with Filters.All (should filter outdated)")
 				}
 				return tt.plan, nil
 			}

--- a/main_updates.go
+++ b/main_updates.go
@@ -88,7 +88,7 @@ func updatesCheckCmd(args []string) int {
 		SkipManager:  parseCommaList(*skipManagerFlag),
 		HooksSkipped: true,
 	}
-	plan, err := upgrade.BuildUpgradePlan(upgrade.UpgradeOptions{Spec: f, Lock: lf, Filters: filters, DetectOutdated: true})
+	plan, err := upgrade.BuildUpgradePlan(upgrade.UpgradeOptions{Spec: f, Lock: lf, Filters: filters})
 	if err != nil {
 		if *jsonOut {
 			_ = writeJSON(os.Stdout, output.Envelope{Version: output.SchemaVersion, Command: "updates check", OK: false, Errors: []string{err.Error()}})

--- a/main_updates_worker.go
+++ b/main_updates_worker.go
@@ -57,7 +57,7 @@ func updatesRunOnceCmd(args []string) int {
 		return exitIO
 	}
 	filters := output.UpgradeFilters{Only: cfg.Only, Skip: cfg.Skip, OnlyManager: cfg.OnlyManagers, SkipManager: cfg.SkipManagers, HooksSkipped: true}
-	plan, err := updatesBuildPlan(upgrade.UpgradeOptions{Spec: f, Lock: lf, Filters: filters, DetectOutdated: true})
+	plan, err := updatesBuildPlan(upgrade.UpgradeOptions{Spec: f, Lock: lf, Filters: filters})
 	if err != nil {
 		logger.Warn("updates.check.plan", slog.Any("err", err))
 		return exitUsage


### PR DESCRIPTION
## Summary
- Collapse npm/PyPI/crates fetchers into `fetchRegistryLatest`; rename `registryHTTPClient`
- Use `Filters.All` as the single outdated-filter switch (remove `DetectOutdated` + `upgradeDetectOutdated`)
- Co-locate `intersectNameMap` / `listJSOutdated` / `versionMapOf` in `outdated_compare.go`
- Table-drive native + registry outdated tests (~864 → ~571 lines)

## Test plan
- [x] `go test ./internal/adapter ./internal/upgrade ./internal/resolver ./internal/output .`
- [ ] CI green on PR
- [ ] Tag v3.2.1 after merge