### PR TITLE
Add Windows PowerShell env/shell, hooks, and completions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,3 +165,23 @@ codegraph impact "Adapter.Available"    # blast radius of a change
 
 If you wire up a post-commit hook to auto-sync the index, that too is a local,
 opt-in convenience and is not configured in this repository.
+
+## Learned User Preferences
+
+- Prefer `genv upgrade` to plan only packages with detected updates by default, with `--all` as the escape hatch for the old brute-force “touch everything” path.
+- Keep successful upgrade output visible; filtering should drop non-outdated plan noise, not hide upgrades that actually run.
+- When choosing implementation scope, often asks for a recommendation first; if wanting maximum coverage, prefers the most thorough option that still keeps outdated detection honest.
+- Prefers subagent-driven execution for multi-step implementation plans when that option is offered.
+- Prefers agent guidance as a global baseline under `~/.config/genv/` (and Cursor User Rules when configured); add project-specific rules only when explicitly requested.
+- For cross-platform shell/env work (including PowerShell), do not assume PowerShell exists on every host; gate apply/write on availability.
+
+## Learned Workspace Facts
+
+- `genv upgrade` and `genv updates check` share the upgrade planner; default planning uses outdated detection (`Filters.All` false / `OutdatedLister`), and managers without a lister (or on lister error) keep packages rather than silently skipping them.
+- `OutdatedLister` coverage includes brew/linuxbrew, mas, bun, npm/pnpm/yarn, uv/pipx, cargo, winget/scoop/choco, pacman/paru/yay, and snap; mas also implements `BatchUpgrader` so multiple App Store upgrades batch into one `mas upgrade` invocation.
+- Design specs and plans live under `docs/superpowers/`; completed items (e.g. outdated-aware upgrade, scheduler handoff) are marked COMPLETED/RESOLVED in-place in those docs.
+- Runtime user config, lock files, and a separate global `AGENTS.md`/agent baseline live under `~/.config/genv/`.
+- Project agent guidance is primarily this `AGENTS.md`; `.cursor/` is gitignored and there is no project `.cursor/rules` pack yet.
+- `make ci` and GitHub CI enforce statement coverage via `cover-gate` (`COVER_MIN` default 80) and cold-start via `bench-gate`.
+- Schema versions `"1"`–`"7"` are accepted; v7 adds `"shell": "powershell"` targeting for aliases/functions. On Windows, `genv apply` uses a profile-backend abstraction (`POSIXBackend` + `PowerShellBackend`): prefer `pwsh`, else `powershell.exe`; omit PowerShell writes on non-Windows. Shared `env` maps emit both `env.sh` and `env.ps1` when the corresponding backend runs.
+- Publishing the `genv` binary to winget/scoop/choco remains deferred; adapters already manage packages through those managers when present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Native Windows PowerShell parity (schema **v7**): `env`/`shell` profile backends write `env.ps1` / `shell.ps1` and inject the CurrentUser CurrentHost profile when `pwsh` or Windows PowerShell is on `PATH` (prefer `pwsh`). Aliases/functions may set `"shell": "powershell"`; omitted `shell` stays POSIX-only. Hooks on Windows use the detected PowerShell engine (`-NoProfile -Command` / `-File`), with `cmd /C` fallback. `genv completion powershell` embeds and installs `completions/genv.ps1`.
+
 ### Changed
 
 - CI now enforces a statement-coverage floor (`COVER_MIN`, default 80%) via `make cover-gate` and runs `make bench-gate` for the cold-start budget (`BENCH_MAX_MS`; local default 200ms, CI uses 400ms for shared-runner noise). Previously claimed but not wired into GitHub Actions.

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ When you run `genv apply`:
 
 **Fields:**
 
-- `schemaVersion` — `"1"` through `"6"`; older versions still load
+- `schemaVersion` — `"1"` through `"7"`; older versions still load
 - `packages` — array of tracked packages
   - `id` — canonical name for the package (used by genv)
   - `version` — optional version constraint; omit for latest; supports `"x.y.*"` prefix wildcards
@@ -339,7 +339,7 @@ When you run `genv apply`:
 | `genv env <set\|unset\|list>`                     | Manage global environment variables in the spec                        |
 | `genv shell <alias\|status\|edit>`                | Manage shell aliases and shell config drift                            |
 | `genv service <add\|remove\|list\|start\|stop\|status>` | Manage declared user-space services (aliases: `rm`, `ls`)         |
-| `genv completion <bash\|zsh\|fish>`               | Print shell completion script                                          |
+| `genv completion <bash\|zsh\|fish\|powershell>`   | Print shell completion script                                          |
 | `genv completion install [shell] [--dir]`         | Install completion into the shell's completion dir (shell auto-detected from `$SHELL`) |
 | `genv clean [--dry-run]`                          | Clear the cache of all detected package managers                       |
 | `genv edit`                                       | Open genv.json in `$EDITOR`                                            |

--- a/completions/genv.ps1
+++ b/completions/genv.ps1
@@ -1,0 +1,70 @@
+# PowerShell argument completer for genv
+# Install: genv completion install powershell
+# Or: . (genv completion powershell | Out-String)
+
+$script:GenvCommands = @(
+	'add', 'remove', 'rm', 'adopt', 'disown', 'list', 'ls', 'apply', 'edit',
+	'clean', 'scan', 'status', 'completion', 'validate', 'upgrade', 'updates',
+	'pull', 'init', 'env', 'shell', 'service', 'profile', 'version', 'help'
+)
+
+function script:Get-GenvCompletions {
+	param(
+		[string]$WordToComplete,
+		[string]$CommandAst,
+		[int]$CursorPosition
+	)
+
+	$tokens = @()
+	if ($null -ne $CommandAst) {
+		$tokens = $CommandAst.CommandElements | ForEach-Object { $_.Extent.Text }
+	}
+	# Drop the leading 'genv' token when present.
+	if ($tokens.Count -gt 0 -and $tokens[0] -match '(?i)genv(\.exe)?$') {
+		$tokens = $tokens[1..($tokens.Count - 1)]
+	}
+
+	$cmd = $null
+	foreach ($t in $tokens) {
+		if ($script:GenvCommands -contains $t) {
+			$cmd = $t
+			break
+		}
+	}
+
+	if (-not $cmd) {
+		return $script:GenvCommands |
+			Where-Object { $_ -like "$WordToComplete*" } |
+			ForEach-Object {
+				[System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+			}
+	}
+
+	switch ($cmd) {
+		{ $_ -in 'remove', 'rm', 'disown', 'upgrade' } {
+			try {
+				$pkgs = & genv __complete packages 2>$null
+				if ($pkgs) {
+					return ($pkgs -split '\s+') |
+						Where-Object { $_ -and ($_ -like "$WordToComplete*") } |
+						ForEach-Object {
+							[System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+						}
+				}
+			} catch {}
+		}
+		{ $_ -in 'completion' } {
+			$shells = @('bash', 'zsh', 'fish', 'powershell', 'install')
+			return $shells |
+				Where-Object { $_ -like "$WordToComplete*" } |
+				ForEach-Object {
+					[System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+				}
+		}
+	}
+}
+
+Register-ArgumentCompleter -Native -CommandName genv -ScriptBlock {
+	param($wordToComplete, $commandAst, $cursorPosition)
+	Get-GenvCompletions -WordToComplete $wordToComplete -CommandAst $commandAst -CursorPosition $cursorPosition
+}

--- a/docs/superpowers/plans/2026-07-25-powershell-integration.md
+++ b/docs/superpowers/plans/2026-07-25-powershell-integration.md
@@ -1,0 +1,148 @@
+# PowerShell Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Native Windows PowerShell parity for env/shell fragments, profile injection, completions, and hooks (prefer `pwsh`, else `powershell.exe`), without requiring PowerShell on non-Windows hosts.
+
+**Architecture:** Introduce `internal/profilebackend` with `POSIXBackend` and `PowerShellBackend`. Apply selects backends per GOOS/engine. Schema v7 adds `shell: "powershell"`. Hooks on Windows use the detected PS engine. Completions embed `genv.ps1`.
+
+**Tech Stack:** Go 1.24, existing `internal/env`, `internal/shellcfg`, `internal/hooks`, `internal/schema`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-25-powershell-integration-design.md`
+- Prefer `pwsh`, fall back to `powershell` / `powershell.exe`
+- Omitted `shell` target = POSIX-only (never auto-apply to PowerShell)
+- Missing PS engine on Windows: warn + skip PS backend, do not fail apply solely for that
+- Non-Windows: never write `.ps1` profiles
+- Keep `COVER_MIN=80` and existing CI gates green
+- Schema additive v7; do not break v1–v6
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `internal/profilebackend/engine.go` | Detect PowerShell engine |
+| `internal/profilebackend/backend.go` | Backend interface + SelectBackends |
+| `internal/profilebackend/posix.go` | Wrap existing env/shellcfg apply |
+| `internal/profilebackend/powershell.go` | `.ps1` render + profile inject |
+| `internal/profilebackend/*_test.go` | Unit tests with temp HOME / fake PATH |
+| `internal/schema/schema.go` | Version7, KnownShellTargets |
+| `internal/schema/validate.go` | v7 / powershell messages |
+| `internal/hooks/executor.go` | Windows PS runner |
+| `main.go` | Wire apply backends; completion powershell |
+| `completions/genv.ps1` | PowerShell completion script |
+| Docs / CHANGELOG | Windows install + README |
+
+---
+
+### Task 1: Schema v7 + `powershell` shell target
+
+**Files:**
+- Modify: `internal/schema/schema.go`
+- Modify: `internal/schema/validate.go`
+- Modify: `internal/schema/validate_test.go`
+- Modify: `internal/commands/shell_test.go` if it asserts invalid powershell
+
+- [ ] **Step 1:** Add `Version7 = "7"` to `versionOrder`; add `"powershell"` to `KnownShellTargets`; update `ValidShellTargetsMsg`.
+- [ ] **Step 2:** Update validate messages that list schema versions through v6 to include v7 where shell/env blocks are allowed.
+- [ ] **Step 3:** Flip `TestParseAndValidate` / v7 rejection test to accept v7; add case for `shell: "powershell"`.
+- [ ] **Step 4:** `go test ./internal/schema ./internal/commands -count=1`
+
+---
+
+### Task 2: Engine detection + backend selection
+
+**Files:**
+- Create: `internal/profilebackend/engine.go`
+- Create: `internal/profilebackend/backend.go`
+- Create: `internal/profilebackend/engine_test.go`
+- Create: `internal/profilebackend/backend_test.go`
+
+**Interfaces:**
+- Produces: `type Engine struct { Bin string }`; `func DetectEngine() (Engine, bool)`
+- Produces: `type Backend interface { Name() string; ApplyEnv(...); ApplyShell(...) }`
+- Produces: `func SelectBackends(goos string) []Backend`
+
+- [ ] **Step 1:** Failing tests for prefer-pwsh, fallback powershell, neither.
+- [ ] **Step 2:** Implement DetectEngine via `exec.LookPath`.
+- [ ] **Step 3:** SelectBackends: non-windows → posix only; windows+engine → ps (+ posix if `posixRelevant()`); windows no engine → posix if relevant else empty/warn path at call site.
+- [ ] **Step 4:** `go test ./internal/profilebackend -count=1`
+
+---
+
+### Task 3: PowerShellBackend render + inject
+
+**Files:**
+- Create: `internal/profilebackend/powershell.go`
+- Create: `internal/profilebackend/powershell_test.go`
+- Modify: `internal/shellcfg/shellcfg.go` — skip `shell=="powershell"` in POSIX WriteFragment
+
+- [ ] **Step 1:** Tests for env.ps1 / shell.ps1 content and idempotent profile inject.
+- [ ] **Step 2:** Implement WriteEnvPS1, WriteShellPS1, InjectProfileLine (marked block).
+- [ ] **Step 3:** Filter powershell-targeted aliases/functions into PS fragment only; POSIX WriteFragment ignores `shell=="powershell"`.
+- [ ] **Step 4:** `go test ./internal/profilebackend ./internal/shellcfg -count=1`
+
+---
+
+### Task 4: Wire apply in main
+
+**Files:**
+- Modify: `main.go` (`applyEnvVars`, `applyShellCfg`)
+
+- [ ] **Step 1:** Call `profilebackend.SelectBackends(runtime.GOOS)` and apply each; keep lock updates identical.
+- [ ] **Step 2:** On Windows with no engine and PS-only intent, print warning once.
+- [ ] **Step 3:** Extend `main_helpers_coverage_test.go` / env-shell tests if needed.
+- [ ] **Step 4:** `go test . -count=1 -run 'TestApplyEnv|TestEnv|TestShell'`
+
+---
+
+### Task 5: Hooks PowerShell runner
+
+**Files:**
+- Modify: `internal/hooks/executor.go`
+- Modify: `internal/hooks/*_test.go`
+
+- [ ] **Step 1:** Failing test: on goos=windows with fake pwsh on PATH, shellFor/scriptRunner uses pwsh.
+- [ ] **Step 2:** Implement Windows runner via DetectEngine; flags `-NoProfile -Command` / `-File`.
+- [ ] **Step 3:** If no engine, fall back to `cmd /C` (compat) or fail closed with clear error—prefer **cmd fallback** with warning to avoid breaking existing Windows hooks mid-upgrade.
+- [ ] **Step 4:** `go test ./internal/hooks -count=1`
+
+---
+
+### Task 6: Completions
+
+**Files:**
+- Create: `completions/genv.ps1`
+- Modify: `main.go` embed + `completionScriptFor`
+- Modify: `main_coverage_extra_test.go`
+
+- [ ] **Step 1:** Minimal Register-ArgumentCompleter style script covering top-level commands.
+- [ ] **Step 2:** Wire `completion powershell`; install default under genv config `completions/`.
+- [ ] **Step 3:** Update tests that expect powershell as unknown shell.
+- [ ] **Step 4:** `go test . -count=1 -run TestCompletion`
+
+---
+
+### Task 7: Docs + CHANGELOG + CI
+
+**Files:**
+- Modify: `docs/windows-install.md`, `README.md`, `CHANGELOG.md`, `AGENTS.md` CLI notes if needed
+
+- [ ] **Step 1:** Document PS fragments, engine preference, completion, hooks.
+- [ ] **Step 2:** CHANGELOG Unreleased entry.
+- [ ] **Step 3:** `make ci` (or cover-gate + tests).
+- [ ] **Step 4:** Commit.
+
+---
+
+## Done when
+
+- [x] Design spec committed
+- [ ] Schema v7 + powershell target
+- [ ] Profile backends select and apply correctly
+- [ ] Windows hooks prefer pwsh
+- [ ] `genv completion powershell` works
+- [ ] Docs updated; `make ci` green

--- a/docs/superpowers/specs/2026-07-25-powershell-integration-design.md
+++ b/docs/superpowers/specs/2026-07-25-powershell-integration-design.md
@@ -1,0 +1,108 @@
+# PowerShell Integration Design
+
+Date: 2026-07-25  
+Status: Approved
+
+## Goal
+
+Give native Windows hosts first-class PowerShell parity for managed env/shell fragments, profile injection, completions, and hook execution—without requiring PowerShell on non-Windows hosts.
+
+## Decisions
+
+| Topic | Choice |
+|-------|--------|
+| Scope | Env + shell parity, PowerShell completions, PowerShell-backed hooks (Scope C) |
+| Engine | Prefer `pwsh`, fall back to `powershell.exe` (Engine D) |
+| Schema | Extend `shell` target with `"powershell"`; omitted `shell` = POSIX-only; shared `env` map (Schema A) |
+| Architecture | Profile-backend abstraction: `POSIXBackend` + `PowerShellBackend` (Approach B) |
+| Schema version | Additive **v7** |
+
+## Architecture
+
+```mermaid
+flowchart LR
+  apply[applyEnv_applyShell] --> select[selectBackends]
+  select --> posix[POSIXBackend]
+  select --> ps[PowerShellBackend]
+  ps --> detect[prefer_pwsh_else_powershell]
+  hooksWin[hooks_on_windows] --> detect
+  completion[completion_powershell] --> ps1[completions/genv.ps1]
+```
+
+### ProfileBackend
+
+Shared apply/status owns lock updates and drift-vs-lock. Backends only:
+
+- Resolve fragment paths (`env.sh` / `shell.sh` or `env.ps1` / `shell.ps1` under the genv config dir)
+- Render fragment content
+- Inject/remove a source line in the appropriate profile/rc
+
+### Backend selection
+
+- **Non-Windows:** POSIX only. No PowerShell fragment or profile writes. Spec entries with `shell: "powershell"` are stored but inert.
+- **Windows + engine present:** Always run PowerShellBackend. Also run POSIXBackend only if a POSIX shell/rc is already relevant (`$SHELL` is bash/zsh/fish, or `~/.bashrc` / `~/.zshrc` exists).
+- **Windows + no engine:** Warn and skip PowerShell paths; do not fail the whole apply solely for that.
+
+### Engine detection
+
+`DetectPowerShellEngine()` looks up `pwsh` then `powershell` / `powershell.exe` on `PATH`. Hooks and apply share this preference order.
+
+## Schema (v7)
+
+- Allow `"shell": "powershell"` on aliases and functions.
+- Omitted `shell` remains POSIX-only (never auto-emitted into PowerShell fragments).
+- Shared `env` map: POSIX backend emits `export NAME=...`; PowerShell backend emits `$env:NAME = '...'`.
+- `shell.source` entries: emitted by POSIX backend for all sources; PowerShell backend emits `. 'path'` for the same list when applying on Windows (sources are path-oriented and useful in both worlds). PowerShell-only source scoping is deferred.
+
+## Rendering
+
+- Env: PowerShell single-quote escaping (`'` → `''`).
+- Aliases with `shell: "powershell"`: emit as `function Name { <value> }` so argument-bearing aliases work.
+- Functions with `shell: "powershell"`: emit `function Name { body }` with validation that rejects newlines used to break out of the function and obvious statement separators where we already reject POSIX metacharacters—reuse a conservative allow/deny set documented in validate.
+- Profile inject: CurrentUserCurrentHost profile (`$PROFILE` equivalent path). Idempotent: append a marked block that dotsources the managed fragment if not already present.
+
+## Hooks (Windows)
+
+Replace `cmd /C` with the detected PowerShell engine:
+
+- Inline: `pwsh|powershell -NoProfile -Command <hook>`
+- Script file: `pwsh|powershell -NoProfile -File <path>`
+
+Non-Windows remains `sh -c` / `sh`.
+
+## Completions
+
+- Embed `completions/genv.ps1`.
+- `genv completion powershell` prints it.
+- `genv completion install powershell` writes to a PowerShell completion directory under the user’s Documents PowerShell/WindowsPowerShell modules or a documented default under the genv config dir if profile-based register is simpler—default install path: `~/.config/genv/completions/genv.ps1` plus a one-line profile register note, or PowerShell’s standard completion path when detectable.
+
+## Errors
+
+- Missing PS engine on Windows: warn, skip PS backend, apply continues.
+- Profile inject failure: warning (match current POSIX inject non-fatal behavior) unless write of fragment itself fails (fatal).
+- Hook failure/timeout: unchanged semantics.
+
+## Testing
+
+- Unit tests with temp HOME and fake profile paths (no live PowerShell required for render/inject).
+- Engine detection with fake PATH binaries.
+- Hook runner argv recording with fake `pwsh`/`powershell`.
+- Schema v7 + `shell: "powershell"` validation tests.
+
+## Non-goals
+
+- `pwsh` apply targets on macOS/Linux
+- Per-env `shell`/`host` scoping
+- Publishing genv to winget/scoop/choco
+- Live session drift probing
+- PSGallery adapters
+
+## Key files
+
+- `internal/profilebackend/` (new)
+- `internal/env`, `internal/shellcfg` (POSIX remains source of truth for POSIX render)
+- `internal/hooks/executor.go`
+- `internal/schema` (Version7, KnownShellTargets)
+- `main.go` apply + completion
+- `completions/genv.ps1`
+- `docs/windows-install.md`, `README.md`, `CHANGELOG.md`

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -51,7 +51,7 @@ Create `%USERPROFILE%\.config\genv\genv.json`:
 New-Item -ItemType Directory -Force $HOME\.config\genv
 @'
 {
-  "schemaVersion": "5",
+  "schemaVersion": "7",
   "packages": [
     {
       "id": "Git.Git",
@@ -102,12 +102,37 @@ genv status
 
 ---
 
+## Native Windows shell, env, and hooks
+
+On native Windows, `genv apply` prefers **PowerShell 7+ (`pwsh`)**, then
+Windows PowerShell 5.1 (`powershell` / `powershell.exe`):
+
+- Shared `env` values are written to `%USERPROFILE%\.config\genv\env.ps1` and
+  injected into the CurrentUser CurrentHost profile.
+- Shell aliases/functions with `"shell": "powershell"` (schema **v7**) go to
+  `shell.ps1`. Entries with an omitted `shell` target stay POSIX-only.
+- If a POSIX shell/rc is already present (e.g. Git Bash), genv also maintains
+  `env.sh` / `shell.sh`.
+- If no PowerShell engine is on `PATH`, genv warns and skips `.ps1` profiles
+  without failing the whole apply.
+
+Hooks on Windows run as `pwsh|powershell -NoProfile -Command …` (or `-File`
+for script hooks). Without an engine they fall back to `cmd /C` with a warning.
+
+Completions:
+
+```powershell
+genv completion powershell
+genv completion install powershell
+# then: . $HOME\.config\genv\completions\genv.ps1
+```
+
+---
+
 ## Native Windows limitations
 
-- The `env` and `shell` commands currently manage POSIX-style shell fragments
-  (`bash`/`zsh`/`fish`). They do not yet write PowerShell profiles.
-- Hooks run through `cmd /C` on native Windows. Use Windows command syntax in
-  hooks whose `host` selector is `windows`.
+- PowerShell apply targets are Windows-only; macOS/Linux never write `.ps1`
+  profiles even if `pwsh` is installed.
 - File links use Windows symlinks. If link creation fails, enable Developer Mode
   or run the shell as Administrator.
 - WSL2 is separate from native Windows: run the Linux binary inside WSL2 and use

--- a/internal/commands/shell.go
+++ b/internal/commands/shell.go
@@ -20,7 +20,7 @@ func ensureShell(f *schema.GenvFile) {
 }
 
 // ShellAliasSet adds or updates the alias name in f's shell block.
-// Shell target may be "bash", "zsh", "fish", or "" (all).
+// Shell target may be "bash", "zsh", "fish", "powershell", or "" (POSIX).
 func ShellAliasSet(f *schema.GenvFile, name, value, shell string) error {
 	if name == "" {
 		return fmt.Errorf("alias name must not be empty\nTip: provide a valid shell identifier as NAME")
@@ -29,6 +29,9 @@ func ShellAliasSet(f *schema.GenvFile, name, value, shell string) error {
 		return fmt.Errorf("unknown shell %q; expected %s", shell, schema.ValidShellTargetsMsg)
 	}
 	ensureShell(f)
+	if shell == "powershell" {
+		f.SchemaVersion = schema.AtLeastVersion(f.SchemaVersion, schema.Version7)
+	}
 	if f.Shell.Aliases == nil {
 		f.Shell.Aliases = make(map[string]schema.ShellAlias)
 	}

--- a/internal/commands/shell_test.go
+++ b/internal/commands/shell_test.go
@@ -110,13 +110,26 @@ func TestShellAliasSet_EmptyName(t *testing.T) {
 
 func TestShellAliasSet_InvalidShellTarget(t *testing.T) {
 	f := &schema.GenvFile{SchemaVersion: schema.Version, Packages: []schema.Package{}}
-	if err := ShellAliasSet(f, "ll", "ls -la", "powershell"); err == nil {
+	if err := ShellAliasSet(f, "ll", "ls -la", "cmd"); err == nil {
 		t.Error("expected error for unknown shell target")
 	}
 }
 
+func TestShellAliasSet_PowerShellRaisesV7(t *testing.T) {
+	f := &schema.GenvFile{SchemaVersion: schema.Version3, Packages: []schema.Package{}}
+	if err := ShellAliasSet(f, "ll", "Get-ChildItem", "powershell"); err != nil {
+		t.Fatalf("ShellAliasSet powershell: %v", err)
+	}
+	if f.SchemaVersion != schema.Version7 {
+		t.Errorf("schemaVersion = %q, want %q", f.SchemaVersion, schema.Version7)
+	}
+	if f.Shell.Aliases["ll"].Shell != "powershell" {
+		t.Errorf("shell target = %q, want powershell", f.Shell.Aliases["ll"].Shell)
+	}
+}
+
 func TestShellAliasSet_AllShellTargets(t *testing.T) {
-	for _, shell := range []string{"bash", "zsh", "fish", ""} {
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell", ""} {
 		f := &schema.GenvFile{SchemaVersion: schema.Version, Packages: []schema.Package{}}
 		if err := ShellAliasSet(f, "foo", "bar", shell); err != nil {
 			t.Errorf("ShellAliasSet with shell=%q: unexpected error: %v", shell, err)

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -12,9 +12,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ks1686/genv/internal/host"
+	"github.com/ks1686/genv/internal/profilebackend"
 	"github.com/ks1686/genv/internal/schema"
 )
 
@@ -64,10 +66,14 @@ type RunOptions struct {
 func fprintf(w io.Writer, format string, a ...any) { _, _ = fmt.Fprintf(w, format, a...) }
 
 // shellFor returns the shell binary and its command flag for the given GOOS.
-// Native Windows has no "sh", so hooks run via "cmd /C"; every other OS uses
-// the POSIX "sh -c".
+// Native Windows prefers pwsh/powershell (-Command); without an engine it falls
+// back to cmd /C. Every other OS uses POSIX sh -c.
 func shellFor(goos string) (bin string, flag string) {
 	if goos == "windows" {
+		if eng, ok := profilebackend.DetectEngine(); ok {
+			return eng.Bin, "-Command"
+		}
+		warnWindowsHookFallback()
 		return "cmd", "/C"
 	}
 	return "sh", "-c"
@@ -75,9 +81,21 @@ func shellFor(goos string) (bin string, flag string) {
 
 func scriptRunnerFor(goos string) []string {
 	if goos == "windows" {
+		if eng, ok := profilebackend.DetectEngine(); ok {
+			return []string{eng.Bin, "-NoProfile", "-File"}
+		}
+		warnWindowsHookFallback()
 		return []string{"cmd", "/C"}
 	}
 	return []string{"sh"}
+}
+
+var windowsHookFallbackOnce sync.Once
+
+func warnWindowsHookFallback() {
+	windowsHookFallbackOnce.Do(func() {
+		_, _ = fmt.Fprintln(os.Stderr, "genv: warning: no PowerShell engine on PATH; running hooks via cmd /C")
+	})
 }
 
 // NewExecutor returns an Executor that writes subprocess output to stdout and stderr.
@@ -208,6 +226,13 @@ func (e *Executor) hookArgs(h schema.Hook) ([]string, error) {
 		}
 		args := scriptRunnerFor(e.goos)
 		return append(args, path), nil
+	}
+	if e.goos == "windows" {
+		if eng, ok := profilebackend.DetectEngine(); ok {
+			return []string{eng.Bin, "-NoProfile", "-Command", h.Command}, nil
+		}
+		warnWindowsHookFallback()
+		return []string{"cmd", "/C", h.Command}, nil
 	}
 	bin, flag := shellFor(e.goos)
 	return []string{bin, flag, h.Command}, nil

--- a/internal/hooks/executor_test.go
+++ b/internal/hooks/executor_test.go
@@ -75,16 +75,41 @@ func TestPreUpgrade_RunsMatchingHooks(t *testing.T) {
 func TestExecutor_ShellArgvPerOS(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {
-		name string
-		goos string
-		bin  string
-		flag string
+		name     string
+		goos     string
+		lookPath func(string) (string, error)
+		want     []string
 	}{
-		{name: "windows uses cmd /C", goos: "windows", bin: "cmd", flag: "/C"},
-		{name: "linux uses sh -c", goos: "linux", bin: "sh", flag: "-c"},
+		{
+			name:     "windows uses cmd /C when no PowerShell",
+			goos:     "windows",
+			lookPath: func(string) (string, error) { return "", os.ErrNotExist },
+			want:     []string{"cmd", "/C", "echo hi"},
+		},
+		{
+			name: "windows uses pwsh when available",
+			goos: "windows",
+			lookPath: func(file string) (string, error) {
+				if file == "pwsh" {
+					return "/usr/bin/pwsh", nil
+				}
+				return "", os.ErrNotExist
+			},
+			want: []string{"/usr/bin/pwsh", "-NoProfile", "-Command", "echo hi"},
+		},
+		{
+			name:     "linux uses sh -c",
+			goos:     "linux",
+			lookPath: nil, // unused for non-windows
+			want:     []string{"sh", "-c", "echo hi"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.lookPath != nil {
+				restore := profilebackend.SetLookPathForTest(tc.lookPath)
+				t.Cleanup(restore)
+			}
 			e, fr := newTestExecutor(nil, nil)
 			e.goos = tc.goos
 			hooks := []schema.Hook{{Command: "echo hi"}}
@@ -96,9 +121,8 @@ func TestExecutor_ShellArgvPerOS(t *testing.T) {
 			if len(fr.calls) != 1 {
 				t.Fatalf("got %d calls, want 1", len(fr.calls))
 			}
-			want := []string{tc.bin, tc.flag, "echo hi"}
-			if !slicesEqual(fr.calls[0], want) {
-				t.Errorf("call 0 = %v, want %v", fr.calls[0], want)
+			if !slicesEqual(fr.calls[0], tc.want) {
+				t.Errorf("call 0 = %v, want %v", fr.calls[0], tc.want)
 			}
 		})
 	}

--- a/internal/hooks/executor_test.go
+++ b/internal/hooks/executor_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ks1686/genv/internal/profilebackend"
 	"github.com/ks1686/genv/internal/schema"
 )
 
@@ -104,6 +105,11 @@ func TestExecutor_ShellArgvPerOS(t *testing.T) {
 }
 
 func TestShellFor(t *testing.T) {
+	restore := profilebackend.SetLookPathForTest(func(string) (string, error) {
+		return "", os.ErrNotExist
+	})
+	t.Cleanup(restore)
+
 	cases := []struct {
 		goos string
 		bin  string
@@ -117,6 +123,50 @@ func TestShellFor(t *testing.T) {
 		bin, flag := shellFor(tc.goos)
 		if bin != tc.bin || flag != tc.flag {
 			t.Errorf("shellFor(%q) = (%q, %q), want (%q, %q)", tc.goos, bin, flag, tc.bin, tc.flag)
+		}
+	}
+}
+
+func TestHookArgs_WindowsPrefersPwsh(t *testing.T) {
+	restore := profilebackend.SetLookPathForTest(func(file string) (string, error) {
+		if file == "pwsh" {
+			return `/fake/pwsh`, nil
+		}
+		return "", os.ErrNotExist
+	})
+	t.Cleanup(restore)
+
+	e, _ := newTestExecutor(nil, nil)
+	e.goos = "windows"
+	args, err := e.hookArgs(schema.Hook{Command: "Write-Host hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{`/fake/pwsh`, "-NoProfile", "-Command", "Write-Host hi"}
+	if len(args) != len(want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("args = %v, want %v", args, want)
+		}
+	}
+
+	script := filepath.Join(t.TempDir(), "hook.ps1")
+	if err := os.WriteFile(script, []byte("Write-Host ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	args, err = e.hookArgs(schema.Hook{File: script})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = []string{`/fake/pwsh`, "-NoProfile", "-File", script}
+	if len(args) != len(want) {
+		t.Fatalf("script args = %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("script args = %v, want %v", args, want)
 		}
 	}
 }

--- a/internal/profilebackend/backend.go
+++ b/internal/profilebackend/backend.go
@@ -1,0 +1,70 @@
+package profilebackend
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ks1686/genv/internal/schema"
+)
+
+// Backend applies env and shell fragments for one profile family.
+type Backend interface {
+	Name() string
+	ApplyEnv(vars map[string]schema.EnvVar) error
+	ApplyShell(cfg *schema.ShellConfig) error
+}
+
+// SelectBackends returns the profile backends that should run for goos.
+//
+// Non-Windows: POSIX only (never writes .ps1).
+// Windows with a PowerShell engine: PowerShell always; POSIX only when a POSIX
+// shell/rc is already relevant.
+// Windows without an engine: POSIX only when relevant; callers should warn
+// about the missing engine separately.
+func SelectBackends(goos string) []Backend {
+	if goos != "windows" {
+		return []Backend{POSIXBackend{}}
+	}
+	_, hasEngine := DetectEngine()
+	var out []Backend
+	if hasEngine {
+		out = append(out, PowerShellBackend{})
+	}
+	if PosixRelevant() {
+		out = append(out, POSIXBackend{})
+	}
+	return out
+}
+
+// MissingEngineWarning returns a user-facing warning when Windows apply cannot
+// use a PowerShell backend, or "" when no warning is needed.
+func MissingEngineWarning(goos string) string {
+	if goos != "windows" {
+		return ""
+	}
+	if _, ok := DetectEngine(); ok {
+		return ""
+	}
+	return "no PowerShell engine (pwsh or powershell) found on PATH; skipping PowerShell env/shell profiles"
+}
+
+// PosixRelevant reports whether a POSIX shell/rc is already in play on this host
+// (so Windows apply should also maintain env.sh / shell.sh).
+func PosixRelevant() bool {
+	shell := strings.ToLower(filepath.Base(os.Getenv("SHELL")))
+	switch shell {
+	case "bash", "zsh", "fish", "sh":
+		return true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	for _, name := range []string{".bashrc", ".zshrc", ".profile"} {
+		if _, err := os.Stat(filepath.Join(home, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/profilebackend/engine.go
+++ b/internal/profilebackend/engine.go
@@ -1,0 +1,40 @@
+// Package profilebackend selects and applies env/shell profile fragments for
+// POSIX shells and Windows PowerShell.
+package profilebackend
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Engine is a detected PowerShell binary (pwsh preferred over Windows PowerShell).
+type Engine struct {
+	// Bin is the absolute path returned by LookPath, or the bare name when that
+	// is all LookPath provides.
+	Bin string
+}
+
+// lookPath is exec.LookPath; tests replace it with PATH fakes.
+var lookPath = exec.LookPath
+
+// DetectEngine looks up pwsh, then powershell / powershell.exe on PATH.
+// It returns false when no PowerShell engine is available.
+func DetectEngine() (Engine, bool) {
+	for _, name := range []string{"pwsh", "powershell", "powershell.exe"} {
+		path, err := lookPath(name)
+		if err != nil {
+			continue
+		}
+		return Engine{Bin: path}, true
+	}
+	return Engine{}, false
+}
+
+// IsPwsh reports whether eng looks like PowerShell 7+ (pwsh) rather than
+// Windows PowerShell 5.1.
+func (eng Engine) IsPwsh() bool {
+	base := strings.ToLower(filepath.Base(eng.Bin))
+	base = strings.TrimSuffix(base, ".exe")
+	return base == "pwsh"
+}

--- a/internal/profilebackend/engine_test.go
+++ b/internal/profilebackend/engine_test.go
@@ -1,0 +1,153 @@
+package profilebackend
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectEngine_PreferPwsh(t *testing.T) {
+	dir := t.TempDir()
+	pwsh := filepath.Join(dir, "pwsh")
+	ps := filepath.Join(dir, "powershell")
+	if err := os.WriteFile(pwsh, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ps, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = func(file string) (string, error) {
+		switch file {
+		case "pwsh":
+			return pwsh, nil
+		case "powershell", "powershell.exe":
+			return ps, nil
+		default:
+			return "", os.ErrNotExist
+		}
+	}
+
+	eng, ok := DetectEngine()
+	if !ok {
+		t.Fatal("expected engine")
+	}
+	if eng.Bin != pwsh {
+		t.Errorf("Bin = %q, want %q", eng.Bin, pwsh)
+	}
+	if !eng.IsPwsh() {
+		t.Error("expected IsPwsh true")
+	}
+}
+
+func TestDetectEngine_FallbackPowerShell(t *testing.T) {
+	dir := t.TempDir()
+	ps := filepath.Join(dir, "powershell.exe")
+	if err := os.WriteFile(ps, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = func(file string) (string, error) {
+		if file == "powershell.exe" {
+			return ps, nil
+		}
+		return "", os.ErrNotExist
+	}
+
+	eng, ok := DetectEngine()
+	if !ok {
+		t.Fatal("expected engine")
+	}
+	if eng.Bin != ps {
+		t.Errorf("Bin = %q, want %q", eng.Bin, ps)
+	}
+	if eng.IsPwsh() {
+		t.Error("expected IsPwsh false for powershell.exe")
+	}
+}
+
+func TestDetectEngine_Neither(t *testing.T) {
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = func(string) (string, error) { return "", os.ErrNotExist }
+
+	if _, ok := DetectEngine(); ok {
+		t.Fatal("expected no engine")
+	}
+}
+
+func TestSelectBackends_NonWindows(t *testing.T) {
+	backends := SelectBackends("darwin")
+	if len(backends) != 1 || backends[0].Name() != "posix" {
+		t.Fatalf("got %#v", backends)
+	}
+}
+
+func TestSelectBackends_WindowsWithEngine(t *testing.T) {
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = func(file string) (string, error) {
+		if file == "pwsh" {
+			return "/fake/pwsh", nil
+		}
+		return "", os.ErrNotExist
+	}
+	t.Setenv("SHELL", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// No POSIX rc → PowerShell only.
+	backends := SelectBackends("windows")
+	if len(backends) != 1 || backends[0].Name() != "powershell" {
+		t.Fatalf("got names %v", backendNames(backends))
+	}
+
+	// With bashrc → both.
+	if err := os.WriteFile(filepath.Join(home, ".bashrc"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	backends = SelectBackends("windows")
+	names := backendNames(backends)
+	if len(names) != 2 || names[0] != "powershell" || names[1] != "posix" {
+		t.Fatalf("got %v, want [powershell posix]", names)
+	}
+}
+
+func TestSelectBackends_WindowsNoEngine(t *testing.T) {
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = func(string) (string, error) { return "", os.ErrNotExist }
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "")
+	backends := SelectBackends("windows")
+	if len(backends) != 0 {
+		t.Fatalf("expected empty, got %v", backendNames(backends))
+	}
+
+	t.Setenv("SHELL", "/usr/bin/bash")
+	backends = SelectBackends("windows")
+	if len(backends) != 1 || backends[0].Name() != "posix" {
+		t.Fatalf("got %v", backendNames(backends))
+	}
+
+	warn := MissingEngineWarning("windows")
+	if warn == "" {
+		t.Fatal("expected missing-engine warning")
+	}
+	if MissingEngineWarning("darwin") != "" {
+		t.Fatal("expected no warning on darwin")
+	}
+}
+
+func backendNames(backends []Backend) []string {
+	names := make([]string, len(backends))
+	for i, b := range backends {
+		names[i] = b.Name()
+	}
+	return names
+}

--- a/internal/profilebackend/posix.go
+++ b/internal/profilebackend/posix.go
@@ -1,0 +1,28 @@
+package profilebackend
+
+import (
+	genvenv "github.com/ks1686/genv/internal/env"
+	"github.com/ks1686/genv/internal/schema"
+	"github.com/ks1686/genv/internal/shellcfg"
+)
+
+// POSIXBackend writes env.sh / shell.sh and injects into bash/zsh rc files.
+type POSIXBackend struct{}
+
+func (POSIXBackend) Name() string { return "posix" }
+
+func (POSIXBackend) ApplyEnv(vars map[string]schema.EnvVar) error {
+	fragPath, err := genvenv.FragmentPath()
+	if err != nil {
+		return err
+	}
+	return genvenv.ApplyEnv(fragPath, vars, genvenv.RcFiles())
+}
+
+func (POSIXBackend) ApplyShell(cfg *schema.ShellConfig) error {
+	fragPath, err := shellcfg.FragmentPath()
+	if err != nil {
+		return err
+	}
+	return shellcfg.ApplyShell(fragPath, cfg, genvenv.RcFiles())
+}

--- a/internal/profilebackend/posix_test.go
+++ b/internal/profilebackend/posix_test.go
@@ -1,0 +1,128 @@
+package profilebackend
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ks1686/genv/internal/schema"
+)
+
+func TestPOSIXBackend_ApplyEnvAndShell(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("SHELL", "/bin/zsh")
+
+	b := POSIXBackend{}
+	if b.Name() != "posix" {
+		t.Fatalf("Name = %q", b.Name())
+	}
+	if err := b.ApplyEnv(map[string]schema.EnvVar{"FOO": {Value: "bar"}}); err != nil {
+		t.Fatal(err)
+	}
+	frag := filepath.Join(home, ".config", "genv", "env.sh")
+	data, err := os.ReadFile(frag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "export FOO=") {
+		t.Fatalf("env.sh missing FOO:\n%s", data)
+	}
+
+	cfg := &schema.ShellConfig{
+		Aliases: map[string]schema.ShellAlias{"ll": {Value: "ls -la"}},
+	}
+	if err := b.ApplyShell(cfg); err != nil {
+		t.Fatal(err)
+	}
+	shellFrag := filepath.Join(home, ".config", "genv", "shell.sh")
+	data, err = os.ReadFile(shellFrag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "alias ll=") {
+		t.Fatalf("shell.sh missing alias:\n%s", data)
+	}
+}
+
+func TestPowerShellBackend_ApplyShell(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	eng := Engine{Bin: filepath.Join(home, "powershell.exe")}
+	b := PowerShellBackend{Home: home, Engine: &eng}
+	cfg := &schema.ShellConfig{
+		Aliases: map[string]schema.ShellAlias{
+			"ll": {Value: "Get-ChildItem", Shell: "powershell"},
+		},
+		Functions: map[string]schema.ShellFunction{
+			"greet": {Body: "Write-Host hi", Shell: "powershell"},
+		},
+	}
+	if err := b.ApplyShell(cfg); err != nil {
+		t.Fatal(err)
+	}
+	frag := filepath.Join(home, ".config", "genv", "shell.ps1")
+	data, err := os.ReadFile(frag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "function ll {") || !strings.Contains(got, "function greet") {
+		t.Fatalf("shell.ps1 missing entries:\n%s", got)
+	}
+	profile := filepath.Join(home, "Documents", "WindowsPowerShell", "Microsoft.PowerShell_profile.ps1")
+	pdata, err := os.ReadFile(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(pdata), frag) {
+		t.Fatalf("profile missing fragment:\n%s", pdata)
+	}
+
+	// Empty / non-PS content removes fragment and skips inject.
+	if err := b.ApplyShell(&schema.ShellConfig{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(frag); !os.IsNotExist(err) {
+		t.Fatal("expected empty shell.ps1 removed")
+	}
+}
+
+func TestSetLookPathForTest_NilRestoresDefault(t *testing.T) {
+	restore := SetLookPathForTest(func(string) (string, error) { return "/x", nil })
+	restore()
+	restore = SetLookPathForTest(nil)
+	t.Cleanup(restore)
+	// Just ensure it does not panic; DetectEngine may or may not find a binary.
+	_, _ = DetectEngine()
+}
+
+func TestWriteShellPS1_EmptyRemoves(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "shell.ps1")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteShellPS1(path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("expected removal")
+	}
+}
+
+func TestMissingEngineWarning_WithEngine(t *testing.T) {
+	restore := SetLookPathForTest(func(file string) (string, error) {
+		if file == "pwsh" {
+			return "/pwsh", nil
+		}
+		return "", os.ErrNotExist
+	})
+	t.Cleanup(restore)
+	if got := MissingEngineWarning("windows"); got != "" {
+		t.Fatalf("want empty warning, got %q", got)
+	}
+}

--- a/internal/profilebackend/powershell.go
+++ b/internal/profilebackend/powershell.go
@@ -1,0 +1,296 @@
+package profilebackend
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ks1686/genv/internal/genvfile"
+	"github.com/ks1686/genv/internal/schema"
+)
+
+// PowerShellBackend writes env.ps1 / shell.ps1 and injects into the CurrentUser
+// CurrentHost PowerShell profile.
+type PowerShellBackend struct {
+	// Home overrides os.UserHomeDir in tests.
+	Home string
+	// Engine overrides DetectEngine in tests.
+	Engine *Engine
+}
+
+func (PowerShellBackend) Name() string { return "powershell" }
+
+func (b PowerShellBackend) ApplyEnv(vars map[string]schema.EnvVar) error {
+	fragPath, err := b.envFragmentPath()
+	if err != nil {
+		return err
+	}
+	if err := WriteEnvPS1(fragPath, vars); err != nil {
+		return err
+	}
+	if len(vars) == 0 {
+		return nil
+	}
+	profile, err := b.profilePath()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "genv: warning: could not resolve PowerShell profile: %v\n", err)
+		return nil
+	}
+	if err := InjectProfileLine(profile, fragPath, "env"); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "genv: warning: could not inject PowerShell env into %s: %v\n", profile, err)
+	}
+	return nil
+}
+
+func (b PowerShellBackend) ApplyShell(cfg *schema.ShellConfig) error {
+	fragPath, err := b.shellFragmentPath()
+	if err != nil {
+		return err
+	}
+	if err := WriteShellPS1(fragPath, cfg); err != nil {
+		return err
+	}
+	if !hasPowerShellFragmentContent(cfg) {
+		return nil
+	}
+	profile, err := b.profilePath()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "genv: warning: could not resolve PowerShell profile: %v\n", err)
+		return nil
+	}
+	if err := InjectProfileLine(profile, fragPath, "shell"); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "genv: warning: could not inject PowerShell shell into %s: %v\n", profile, err)
+	}
+	return nil
+}
+
+func (b PowerShellBackend) envFragmentPath() (string, error) {
+	dir, err := genvfile.DefaultDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "env.ps1"), nil
+}
+
+func (b PowerShellBackend) shellFragmentPath() (string, error) {
+	dir, err := genvfile.DefaultDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "shell.ps1"), nil
+}
+
+func (b PowerShellBackend) homeDir() (string, error) {
+	if b.Home != "" {
+		return b.Home, nil
+	}
+	return os.UserHomeDir()
+}
+
+func (b PowerShellBackend) engine() (Engine, bool) {
+	if b.Engine != nil {
+		return *b.Engine, true
+	}
+	return DetectEngine()
+}
+
+// profilePath returns the CurrentUserCurrentHost profile path for the detected engine.
+func (b PowerShellBackend) profilePath() (string, error) {
+	home, err := b.homeDir()
+	if err != nil {
+		return "", err
+	}
+	eng, ok := b.engine()
+	if !ok {
+		return "", fmt.Errorf("no PowerShell engine")
+	}
+	docs := filepath.Join(home, "Documents")
+	if eng.IsPwsh() {
+		return filepath.Join(docs, "PowerShell", "Microsoft.PowerShell_profile.ps1"), nil
+	}
+	return filepath.Join(docs, "WindowsPowerShell", "Microsoft.PowerShell_profile.ps1"), nil
+}
+
+// WriteEnvPS1 atomically writes a PowerShell fragment that sets every variable
+// in vars. If vars is empty the fragment is removed.
+func WriteEnvPS1(path string, vars map[string]schema.EnvVar) error {
+	if len(vars) == 0 {
+		err := os.Remove(path)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing empty fragment %s: %w", path, err)
+		}
+		return nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# genv managed env — do not edit between these markers\n")
+	sb.WriteString("# BEGIN genv env\n")
+
+	names := make([]string, 0, len(vars))
+	for name := range vars {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		ev := vars[name]
+		sb.WriteString("$env:")
+		sb.WriteString(name)
+		sb.WriteString(" = ")
+		sb.WriteString(psSingleQuote(ev.Value))
+		sb.WriteString("\n")
+	}
+	sb.WriteString("# END genv env\n")
+
+	return writeAtomic(path, sb.String())
+}
+
+// WriteShellPS1 writes PowerShell-targeted aliases/functions plus shared source
+// entries. Non-powershell shell targets are ignored. Empty content removes the file.
+func WriteShellPS1(path string, cfg *schema.ShellConfig) error {
+	if !hasPowerShellFragmentContent(cfg) {
+		err := os.Remove(path)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing empty shell fragment %s: %w", path, err)
+		}
+		return nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# genv managed shell config — do not edit between these markers\n")
+	sb.WriteString("# BEGIN genv shell\n")
+
+	aliases := make([]string, 0)
+	for name, a := range cfg.Aliases {
+		if a.Shell != "powershell" {
+			continue
+		}
+		aliases = append(aliases, name)
+	}
+	sort.Strings(aliases)
+	if len(aliases) > 0 {
+		sb.WriteString("\n# aliases\n")
+		for _, name := range aliases {
+			a := cfg.Aliases[name]
+			_, _ = fmt.Fprintf(&sb, "function %s { %s }\n", name, a.Value)
+		}
+	}
+
+	funcs := make([]string, 0)
+	for name, fn := range cfg.Functions {
+		if fn.Shell != "powershell" {
+			continue
+		}
+		funcs = append(funcs, name)
+	}
+	sort.Strings(funcs)
+	if len(funcs) > 0 {
+		sb.WriteString("\n# functions\n")
+		for _, name := range funcs {
+			fn := cfg.Functions[name]
+			_, _ = fmt.Fprintf(&sb, "function %s {\n%s\n}\n", name, indentPS(fn.Body))
+		}
+	}
+
+	if len(cfg.Source) > 0 {
+		sb.WriteString("\n# source\n")
+		for _, s := range cfg.Source {
+			_, _ = fmt.Fprintf(&sb, ". %s\n", psSingleQuote(s))
+		}
+	}
+
+	sb.WriteString("\n# END genv shell\n")
+	return writeAtomic(path, sb.String())
+}
+
+func hasPowerShellFragmentContent(cfg *schema.ShellConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	if len(cfg.Source) > 0 {
+		return true
+	}
+	for _, a := range cfg.Aliases {
+		if a.Shell == "powershell" {
+			return true
+		}
+	}
+	for _, fn := range cfg.Functions {
+		if fn.Shell == "powershell" {
+			return true
+		}
+	}
+	return false
+}
+
+// InjectProfileLine ensures fragmentPath is dot-sourced exactly once in profilePath
+// inside a marked block for kind ("env" or "shell").
+func InjectProfileLine(profilePath, fragmentPath, kind string) error {
+	begin := fmt.Sprintf("# BEGIN genv %s", kind)
+	end := fmt.Sprintf("# END genv %s", kind)
+	dot := ". " + psSingleQuote(fragmentPath)
+
+	data, err := os.ReadFile(profilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading %s: %w", profilePath, err)
+	}
+	content := string(data)
+	if strings.Contains(content, fragmentPath) || strings.Contains(content, begin) {
+		return nil
+	}
+
+	dir := filepath.Dir(profilePath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating directory %s: %w", dir, err)
+	}
+
+	f, err := os.OpenFile(profilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", profilePath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	_, err = fmt.Fprintf(f, "\n%s\n%s\n%s\n", begin, dot, end)
+	return err
+}
+
+// psSingleQuote wraps v in PowerShell single quotes (' → ”).
+func psSingleQuote(v string) string {
+	var b strings.Builder
+	b.Grow(len(v) + 2)
+	b.WriteByte('\'')
+	for i := 0; i < len(v); i++ {
+		if v[i] == '\'' {
+			b.WriteString("''")
+			continue
+		}
+		b.WriteByte(v[i])
+	}
+	b.WriteByte('\'')
+	return b.String()
+}
+
+func indentPS(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = "  " + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+func writeAtomic(path, content string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating directory %s: %w", dir, err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("saving %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/profilebackend/powershell_test.go
+++ b/internal/profilebackend/powershell_test.go
@@ -1,0 +1,130 @@
+package profilebackend
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ks1686/genv/internal/schema"
+)
+
+func TestWriteEnvPS1_ContentAndEscaping(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "env.ps1")
+	vars := map[string]schema.EnvVar{
+		"FOO": {Value: "bar"},
+		"Q":   {Value: "it's"},
+	}
+	if err := WriteEnvPS1(path, vars); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "$env:FOO = 'bar'") {
+		t.Errorf("missing FOO line:\n%s", got)
+	}
+	if !strings.Contains(got, "$env:Q = 'it''s'") {
+		t.Errorf("missing escaped quote:\n%s", got)
+	}
+
+	if err := WriteEnvPS1(path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected fragment removed, err=%v", err)
+	}
+}
+
+func TestWriteShellPS1_FiltersTargets(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "shell.ps1")
+	cfg := &schema.ShellConfig{
+		Aliases: map[string]schema.ShellAlias{
+			"ll":  {Value: "Get-ChildItem", Shell: "powershell"},
+			"gs":  {Value: "git status", Shell: "zsh"},
+			"all": {Value: "echo all"},
+		},
+		Functions: map[string]schema.ShellFunction{
+			"greet": {Body: "Write-Host hi", Shell: "powershell"},
+		},
+		Source: []string{`C:\tools\extra.ps1`},
+	}
+	if err := WriteShellPS1(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "function ll { Get-ChildItem }") {
+		t.Errorf("missing powershell alias:\n%s", got)
+	}
+	if !strings.Contains(got, "function greet {") || !strings.Contains(got, "Write-Host hi") {
+		t.Errorf("missing powershell function:\n%s", got)
+	}
+	if strings.Contains(got, "git status") || strings.Contains(got, "echo all") {
+		t.Errorf("unexpected non-powershell entries:\n%s", got)
+	}
+	if !strings.Contains(got, ". 'C:\\tools\\extra.ps1'") && !strings.Contains(got, `. 'C:\tools\extra.ps1'`) {
+		t.Errorf("missing source:\n%s", got)
+	}
+}
+
+func TestInjectProfileLine_Idempotent(t *testing.T) {
+	home := t.TempDir()
+	profile := filepath.Join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
+	frag := filepath.Join(home, ".config", "genv", "env.ps1")
+	if err := os.MkdirAll(filepath.Dir(frag), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(frag, []byte("# env\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InjectProfileLine(profile, frag, "env"); err != nil {
+		t.Fatal(err)
+	}
+	if err := InjectProfileLine(profile, frag, "env"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if strings.Count(got, "# BEGIN genv env") != 1 {
+		t.Fatalf("expected one marked block, got:\n%s", got)
+	}
+	if !strings.Contains(got, ". "+psSingleQuote(frag)) {
+		t.Fatalf("missing dotsource:\n%s", got)
+	}
+}
+
+func TestPowerShellBackend_ApplyEnvUsesProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	eng := Engine{Bin: filepath.Join(home, "pwsh")}
+	b := PowerShellBackend{Home: home, Engine: &eng}
+	vars := map[string]schema.EnvVar{"FOO": {Value: "bar"}}
+	if err := b.ApplyEnv(vars); err != nil {
+		t.Fatal(err)
+	}
+
+	frag := filepath.Join(home, ".config", "genv", "env.ps1")
+	if _, err := os.Stat(frag); err != nil {
+		t.Fatalf("env.ps1 missing: %v", err)
+	}
+	profile := filepath.Join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
+	data, err := os.ReadFile(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), frag) {
+		t.Fatalf("profile missing fragment path:\n%s", data)
+	}
+}

--- a/internal/profilebackend/testing.go
+++ b/internal/profilebackend/testing.go
@@ -1,0 +1,15 @@
+package profilebackend
+
+import "os/exec"
+
+// SetLookPathForTest replaces LookPath used by DetectEngine. The returned
+// restore function puts the previous implementation back.
+func SetLookPathForTest(fn func(file string) (string, error)) (restore func()) {
+	prev := lookPath
+	if fn == nil {
+		lookPath = exec.LookPath
+	} else {
+		lookPath = fn
+	}
+	return func() { lookPath = prev }
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1,4 +1,4 @@
-// Package schema defines the genv.json v1-v5 data model and validation logic.
+// Package schema defines the genv.json v1–v7 data model and validation logic.
 package schema
 
 import (
@@ -24,8 +24,11 @@ const Version5 = "5"
 // Version6 is the accepted value for genv.json v6 (adds the updates config block).
 const Version6 = "6"
 
+// Version7 is the accepted value for genv.json v7 (adds PowerShell shell targeting).
+const Version7 = "7"
+
 // versionOrder lists known schemaVersion values from oldest to newest.
-var versionOrder = []string{Version, Version2, Version3, Version4, Version5, Version6}
+var versionOrder = []string{Version, Version2, Version3, Version4, Version5, Version6, Version7}
 
 // versionRank returns the ordinal of a schemaVersion string within versionOrder,
 // or -1 if the value is not a recognized version.
@@ -53,13 +56,14 @@ func AtLeastVersion(current, min string) string {
 // KnownShellTargets is the set of valid per-shell targeting values for alias
 // and function entries. An empty string means "all supported shells".
 var KnownShellTargets = map[string]bool{
-	"bash": true,
-	"zsh":  true,
-	"fish": true,
+	"bash":       true,
+	"zsh":        true,
+	"fish":       true,
+	"powershell": true,
 }
 
 // ValidShellTargetsMsg is the user-facing string describing valid shell target values.
-const ValidShellTargetsMsg = `"bash", "zsh", "fish", or omit for all`
+const ValidShellTargetsMsg = `"bash", "zsh", "fish", "powershell", or omit for all POSIX`
 
 // KnownManagers is the set of package-manager IDs recognized in schema v1.
 var KnownManagers = map[string]bool{
@@ -247,14 +251,14 @@ type ShellConfig struct {
 }
 
 // ShellAlias is a single shell alias declaration.
-// Shell may be "bash", "zsh", "fish", or empty (applied to all supported shells).
+// Shell may be "bash", "zsh", "fish", "powershell", or empty (POSIX shells only).
 type ShellAlias struct {
 	Value string `json:"value"`
 	Shell string `json:"shell,omitempty"`
 }
 
 // ShellFunction is a single shell function declaration.
-// Shell may be "bash", "zsh", "fish", or empty (applied to all supported shells).
+// Shell may be "bash", "zsh", "fish", "powershell", or empty (POSIX shells only).
 type ShellFunction struct {
 	Body  string `json:"body"`
 	Shell string `json:"shell,omitempty"`

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -213,11 +213,11 @@ func validateSchemaVersion(f *GenvFile, raw map[string]json.RawMessage, position
 			Field:   "schemaVersion",
 			Message: "required field is missing",
 		})
-	} else if f.SchemaVersion != Version && f.SchemaVersion != Version2 && f.SchemaVersion != Version3 && f.SchemaVersion != Version4 && f.SchemaVersion != Version5 && f.SchemaVersion != Version6 {
+	} else if f.SchemaVersion != Version && f.SchemaVersion != Version2 && f.SchemaVersion != Version3 && f.SchemaVersion != Version4 && f.SchemaVersion != Version5 && f.SchemaVersion != Version6 && f.SchemaVersion != Version7 {
 		errs = append(errs, ValidationError{
 			Position: positions["schemaVersion"],
 			Field:    "schemaVersion",
-			Message:  fmt.Sprintf("unsupported version %q; expected %q, %q, %q, %q, %q, or %q", f.SchemaVersion, Version, Version2, Version3, Version4, Version5, Version6),
+			Message:  fmt.Sprintf("unsupported version %q; expected %q, %q, %q, %q, %q, %q, or %q", f.SchemaVersion, Version, Version2, Version3, Version4, Version5, Version6, Version7),
 		})
 	}
 	return errs
@@ -228,7 +228,7 @@ func validatePackages(f *GenvFile, raw map[string]json.RawMessage, positions map
 	if _, ok := raw["packages"]; !ok {
 		// Schema v5 adds files/hooks/repo blocks and v6 adds updates; a spec may
 		// legitimately contain only those blocks, so packages is optional there.
-		if f.SchemaVersion != Version5 && f.SchemaVersion != Version6 {
+		if f.SchemaVersion != Version5 && f.SchemaVersion != Version6 && f.SchemaVersion != Version7 {
 			errs = append(errs, ValidationError{
 				Field:   "packages",
 				Message: "required field is missing",
@@ -281,11 +281,11 @@ func validatePackages(f *GenvFile, raw map[string]json.RawMessage, positions map
 func validateEnv(f *GenvFile, raw map[string]json.RawMessage, positions map[string]Position) []ValidationError {
 	var errs []ValidationError
 	if _, hasEnv := raw["env"]; hasEnv {
-		if f.SchemaVersion != Version2 && f.SchemaVersion != Version3 && f.SchemaVersion != Version4 && f.SchemaVersion != Version5 && f.SchemaVersion != Version6 {
+		if f.SchemaVersion != Version2 && f.SchemaVersion != Version3 && f.SchemaVersion != Version4 && f.SchemaVersion != Version5 && f.SchemaVersion != Version6 && f.SchemaVersion != Version7 {
 			errs = append(errs, ValidationError{
 				Position: positions["env"],
 				Field:    "env",
-				Message:  fmt.Sprintf("env block requires schemaVersion %q, %q, %q, %q, or %q (current: %q); run 'genv env set' to upgrade", Version2, Version3, Version4, Version5, Version6, f.SchemaVersion),
+				Message:  fmt.Sprintf("env block requires schemaVersion %q or newer (current: %q); run 'genv env set' to upgrade", Version2, f.SchemaVersion),
 			})
 		}
 		for name := range f.Env {
@@ -303,11 +303,11 @@ func validateEnv(f *GenvFile, raw map[string]json.RawMessage, positions map[stri
 func validateShell(f *GenvFile, raw map[string]json.RawMessage, positions map[string]Position) []ValidationError {
 	var errs []ValidationError
 	if _, hasShell := raw["shell"]; hasShell {
-		if f.SchemaVersion != Version3 && f.SchemaVersion != Version4 && f.SchemaVersion != Version5 && f.SchemaVersion != Version6 {
+		if f.SchemaVersion != Version3 && f.SchemaVersion != Version4 && f.SchemaVersion != Version5 && f.SchemaVersion != Version6 && f.SchemaVersion != Version7 {
 			errs = append(errs, ValidationError{
 				Position: positions["shell"],
 				Field:    "shell",
-				Message:  fmt.Sprintf("shell block requires schemaVersion %q, %q, %q, or %q (current: %q); run 'genv shell alias set' to upgrade", Version3, Version4, Version5, Version6, f.SchemaVersion),
+				Message:  fmt.Sprintf("shell block requires schemaVersion %q or newer (current: %q); run 'genv shell alias set' to upgrade", Version3, f.SchemaVersion),
 			})
 		}
 		if f.Shell != nil {
@@ -328,6 +328,7 @@ func validateShell(f *GenvFile, raw map[string]json.RawMessage, positions map[st
 				}
 			}
 			errs = append(errs, validateShellEntries(funcShells, "shell.functions", "function")...)
+			errs = append(errs, requirePowerShellV7(f, aliasShells, funcShells)...)
 
 			for i, src := range f.Shell.Source {
 				if src == "" {
@@ -368,14 +369,42 @@ func validateShellEntries(shells map[string]string, fieldPrefix, singularName st
 	return errs
 }
 
+// requirePowerShellV7 rejects shell: "powershell" targets on schema versions
+// older than v7 (the version that introduced PowerShell targeting).
+func requirePowerShellV7(f *GenvFile, aliasShells, funcShells map[string]string) []ValidationError {
+	if versionRank(f.SchemaVersion) >= versionRank(Version7) {
+		return nil
+	}
+	var errs []ValidationError
+	for name, sh := range aliasShells {
+		if sh != "powershell" {
+			continue
+		}
+		errs = append(errs, ValidationError{
+			Field:   fmt.Sprintf("shell.aliases.%s.shell", name),
+			Message: fmt.Sprintf(`shell target "powershell" requires schemaVersion %q or newer (current: %q)`, Version7, f.SchemaVersion),
+		})
+	}
+	for name, sh := range funcShells {
+		if sh != "powershell" {
+			continue
+		}
+		errs = append(errs, ValidationError{
+			Field:   fmt.Sprintf("shell.functions.%s.shell", name),
+			Message: fmt.Sprintf(`shell target "powershell" requires schemaVersion %q or newer (current: %q)`, Version7, f.SchemaVersion),
+		})
+	}
+	return errs
+}
+
 func validateServices(f *GenvFile, raw map[string]json.RawMessage, positions map[string]Position) []ValidationError {
 	var errs []ValidationError
 	if _, hasServices := raw["services"]; hasServices {
-		if f.SchemaVersion != Version4 && f.SchemaVersion != Version5 && f.SchemaVersion != Version6 {
+		if f.SchemaVersion != Version4 && f.SchemaVersion != Version5 && f.SchemaVersion != Version6 && f.SchemaVersion != Version7 {
 			errs = append(errs, ValidationError{
 				Position: positions["services"],
 				Field:    "services",
-				Message:  fmt.Sprintf("services block requires schemaVersion %q, %q, or %q (current: %q); run 'genv service add' to upgrade", Version4, Version5, Version6, f.SchemaVersion),
+				Message:  fmt.Sprintf("services block requires schemaVersion %q or newer (current: %q); run 'genv service add' to upgrade", Version4, f.SchemaVersion),
 			})
 		}
 		if f.Services != nil {
@@ -456,11 +485,11 @@ func expandPath(s string) (string, error) {
 func validateFiles(f *GenvFile, raw map[string]json.RawMessage, positions map[string]Position) []ValidationError {
 	var errs []ValidationError
 	if _, hasFiles := raw["files"]; hasFiles {
-		if f.SchemaVersion != Version5 && f.SchemaVersion != Version6 {
+		if f.SchemaVersion != Version5 && f.SchemaVersion != Version6 && f.SchemaVersion != Version7 {
 			errs = append(errs, ValidationError{
 				Position: positions["files"],
 				Field:    "files",
-				Message:  fmt.Sprintf("files block requires schemaVersion %q or %q (current: %q)", Version5, Version6, f.SchemaVersion),
+				Message:  fmt.Sprintf("files block requires schemaVersion %q or newer (current: %q)", Version5, f.SchemaVersion),
 			})
 		}
 		if f.Files == nil {
@@ -524,11 +553,11 @@ func validateFiles(f *GenvFile, raw map[string]json.RawMessage, positions map[st
 func validateHooks(f *GenvFile, raw map[string]json.RawMessage, positions map[string]Position) []ValidationError {
 	var errs []ValidationError
 	if _, hasHooks := raw["hooks"]; hasHooks {
-		if f.SchemaVersion != Version5 && f.SchemaVersion != Version6 {
+		if f.SchemaVersion != Version5 && f.SchemaVersion != Version6 && f.SchemaVersion != Version7 {
 			errs = append(errs, ValidationError{
 				Position: positions["hooks"],
 				Field:    "hooks",
-				Message:  fmt.Sprintf("hooks block requires schemaVersion %q or %q (current: %q)", Version5, Version6, f.SchemaVersion),
+				Message:  fmt.Sprintf("hooks block requires schemaVersion %q or newer (current: %q)", Version5, f.SchemaVersion),
 			})
 		}
 		if f.Hooks == nil {
@@ -540,7 +569,7 @@ func validateHooks(f *GenvFile, raw map[string]json.RawMessage, positions map[st
 		errs = append(errs, err...)
 		err = validateHookPhase("postUpgrade", f.Hooks.PostUpgrade)
 		errs = append(errs, err...)
-		if f.SchemaVersion != Version6 {
+		if f.SchemaVersion != Version6 && f.SchemaVersion != Version7 {
 			errs = append(errs, validateNoV6Hooks(f.Hooks, positions)...)
 			return errs
 		}
@@ -616,11 +645,11 @@ func validateNoV6Hooks(h *HooksConfig, positions map[string]Position) []Validati
 func validateRepo(f *GenvFile, raw map[string]json.RawMessage, positions map[string]Position) []ValidationError {
 	var errs []ValidationError
 	if _, hasRepo := raw["repo"]; hasRepo {
-		if f.SchemaVersion != Version5 && f.SchemaVersion != Version6 {
+		if f.SchemaVersion != Version5 && f.SchemaVersion != Version6 && f.SchemaVersion != Version7 {
 			errs = append(errs, ValidationError{
 				Position: positions["repo"],
 				Field:    "repo",
-				Message:  fmt.Sprintf("repo block requires schemaVersion %q or %q (current: %q)", Version5, Version6, f.SchemaVersion),
+				Message:  fmt.Sprintf("repo block requires schemaVersion %q or newer (current: %q)", Version5, f.SchemaVersion),
 			})
 		}
 		if f.Repo == nil {
@@ -645,11 +674,11 @@ func validateUpdates(f *GenvFile, raw map[string]json.RawMessage, positions map[
 	if _, hasUpdates := raw["updates"]; !hasUpdates {
 		return errs
 	}
-	if f.SchemaVersion != Version6 {
+	if f.SchemaVersion != Version6 && f.SchemaVersion != Version7 {
 		errs = append(errs, ValidationError{
 			Position: positions["updates"],
 			Field:    "updates",
-			Message:  fmt.Sprintf("updates block requires schemaVersion %q (current: %q); bump schemaVersion to %q to use the updates config", Version6, f.SchemaVersion, Version6),
+			Message:  fmt.Sprintf("updates block requires schemaVersion %q or newer (current: %q); bump schemaVersion to %q to use the updates config", Version6, f.SchemaVersion, Version6),
 		})
 	}
 	if f.Updates == nil {

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -841,20 +841,56 @@ func TestParseAndValidate_V4StillValid(t *testing.T) {
 	}
 }
 
-func TestParseAndValidate_RejectsV7(t *testing.T) {
+func TestParseAndValidate_AcceptsV7(t *testing.T) {
 	input := `{"schemaVersion":"7","packages":[]}`
+	f, errs, err := ParseAndValidate([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected no validation errors for v7, got: %v", errs)
+	}
+	if f.SchemaVersion != Version7 {
+		t.Errorf("SchemaVersion = %q, want %q", f.SchemaVersion, Version7)
+	}
+}
+
+func TestParseAndValidate_AcceptsPowerShellShellTarget(t *testing.T) {
+	input := `{
+		"schemaVersion":"7",
+		"packages":[],
+		"shell":{
+			"aliases":{"ll":{"value":"Get-ChildItem","shell":"powershell"}},
+			"functions":{"greet":{"body":"Write-Host hi","shell":"powershell"}}
+		}
+	}`
+	_, errs, err := ParseAndValidate([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected no validation errors, got: %v", errs)
+	}
+}
+
+func TestParseAndValidate_PowerShellRequiresV7(t *testing.T) {
+	input := `{
+		"schemaVersion":"3",
+		"packages":[],
+		"shell":{"aliases":{"ll":{"value":"Get-ChildItem","shell":"powershell"}}}
+	}`
 	_, errs, err := ParseAndValidate([]byte(input))
 	if err != nil {
 		t.Fatalf("unexpected fatal error: %v", err)
 	}
 	found := false
 	for _, e := range errs {
-		if e.Field == "schemaVersion" {
+		if e.Field == "shell.aliases.ll.shell" && strings.Contains(e.Message, "schemaVersion") {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected schemaVersion error for v7, got: %v", errs)
+		t.Errorf("expected powershell target rejected on v3, got: %v", errs)
 	}
 }
 

--- a/internal/shellcfg/shellcfg.go
+++ b/internal/shellcfg/shellcfg.go
@@ -34,10 +34,11 @@ func FragmentPath() (string, error) {
 }
 
 // WriteFragment atomically writes a POSIX-compatible shell fragment that
-// defines every alias, function, and source entry in cfg. If cfg is nil or
-// empty the fragment is removed.
+// defines every alias, function, and source entry in cfg. Entries with
+// shell:"powershell" are omitted (owned by the PowerShell profile backend).
+// If cfg is nil or has no POSIX-relevant content the fragment is removed.
 func WriteFragment(path string, cfg *schema.ShellConfig) error {
-	if cfg == nil || (len(cfg.Aliases) == 0 && len(cfg.Functions) == 0 && len(cfg.Source) == 0) {
+	if !hasPOSIXFragmentContent(cfg) {
 		err := os.Remove(path)
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("removing empty shell fragment %s: %w", path, err)
@@ -50,10 +51,17 @@ func WriteFragment(path string, cfg *schema.ShellConfig) error {
 	sb.WriteString("# BEGIN genv shell\n")
 
 	// --- Aliases ---
-	if len(cfg.Aliases) > 0 {
+	posixAliases := make([]string, 0)
+	for name, a := range cfg.Aliases {
+		if a.Shell == "powershell" {
+			continue
+		}
+		posixAliases = append(posixAliases, name)
+	}
+	sort.Strings(posixAliases)
+	if len(posixAliases) > 0 {
 		sb.WriteString("\n# aliases\n")
-		names := sortedKeys(cfg.Aliases)
-		for _, name := range names {
+		for _, name := range posixAliases {
 			a := cfg.Aliases[name]
 			line := fmt.Sprintf("alias %s=%s", name, singleQuote(a.Value))
 			sb.WriteString(shellGuard(line, a.Shell))
@@ -62,10 +70,17 @@ func WriteFragment(path string, cfg *schema.ShellConfig) error {
 	}
 
 	// --- Functions ---
-	if len(cfg.Functions) > 0 {
+	posixFuncs := make([]string, 0)
+	for name, fn := range cfg.Functions {
+		if fn.Shell == "powershell" {
+			continue
+		}
+		posixFuncs = append(posixFuncs, name)
+	}
+	sort.Strings(posixFuncs)
+	if len(posixFuncs) > 0 {
 		sb.WriteString("\n# functions\n")
-		names := sortedFuncKeys(cfg.Functions)
-		for _, name := range names {
+		for _, name := range posixFuncs {
 			fn := cfg.Functions[name]
 			body := fmt.Sprintf("%s() {\n%s\n}", name, indent(fn.Body))
 			sb.WriteString(shellGuard(body, fn.Shell))
@@ -99,13 +114,33 @@ func WriteFragment(path string, cfg *schema.ShellConfig) error {
 	return nil
 }
 
+func hasPOSIXFragmentContent(cfg *schema.ShellConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	if len(cfg.Source) > 0 {
+		return true
+	}
+	for _, a := range cfg.Aliases {
+		if a.Shell != "powershell" {
+			return true
+		}
+	}
+	for _, fn := range cfg.Functions {
+		if fn.Shell != "powershell" {
+			return true
+		}
+	}
+	return false
+}
+
 // ApplyShell writes the managed shell fragment and injects source lines into
 // rc files. It reuses env.InjectSourceLine so both fragments share one injector.
 func ApplyShell(fragmentPath string, cfg *schema.ShellConfig, rcFiles []string) error {
 	if err := WriteFragment(fragmentPath, cfg); err != nil {
 		return err
 	}
-	if cfg == nil || (len(cfg.Aliases) == 0 && len(cfg.Functions) == 0 && len(cfg.Source) == 0) {
+	if !hasPOSIXFragmentContent(cfg) {
 		return nil
 	}
 	for _, rc := range rcFiles {
@@ -242,7 +277,8 @@ func SpecToLock(cfg *schema.ShellConfig) *genvfile.LockedShellConfig {
 }
 
 // shellGuard wraps line in a per-shell if guard when target is non-empty.
-// target may be "bash", "zsh", or "fish". Empty target = no guard (all shells).
+// target may be "bash", "zsh", or "fish". Empty target = no guard (all POSIX).
+// "powershell" is never emitted here (filtered before shellGuard is called).
 func shellGuard(line, target string) string {
 	switch target {
 	case "bash":
@@ -252,6 +288,8 @@ func shellGuard(line, target string) string {
 	case "fish":
 		// Fish uses a different syntax; emit a comment noting it is fish-only.
 		return fmt.Sprintf("# fish-only (source manually in config.fish):\n# %s", line)
+	case "powershell":
+		return ""
 	default:
 		return line
 	}

--- a/internal/shellcfg/shellcfg_test.go
+++ b/internal/shellcfg/shellcfg_test.go
@@ -186,6 +186,44 @@ func TestWriteFragment_Empty_RemovesFile(t *testing.T) {
 	}
 }
 
+func TestWriteFragment_SkipsPowerShellTargets(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shell.sh")
+	cfg := &schema.ShellConfig{
+		Aliases: map[string]schema.ShellAlias{
+			"ll": {Value: "Get-ChildItem", Shell: "powershell"},
+			"gs": {Value: "git status"},
+		},
+	}
+	if err := WriteFragment(path, cfg); err != nil {
+		t.Fatalf("WriteFragment: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if strings.Contains(got, "Get-ChildItem") || strings.Contains(got, "powershell") {
+		t.Errorf("powershell alias leaked into POSIX fragment:\n%s", got)
+	}
+	if !strings.Contains(got, "alias gs=") {
+		t.Errorf("missing POSIX alias:\n%s", got)
+	}
+
+	// PowerShell-only config should remove the fragment.
+	cfg = &schema.ShellConfig{
+		Aliases: map[string]schema.ShellAlias{
+			"ll": {Value: "Get-ChildItem", Shell: "powershell"},
+		},
+	}
+	if err := WriteFragment(path, cfg); err != nil {
+		t.Fatalf("WriteFragment PS-only: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected PS-only fragment to be removed")
+	}
+}
+
 func TestWriteFragment_Deterministic(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "shell.sh")

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ks1686/genv/internal/logging"
 	"github.com/ks1686/genv/internal/output"
 	"github.com/ks1686/genv/internal/profile"
+	"github.com/ks1686/genv/internal/profilebackend"
 	"github.com/ks1686/genv/internal/resolver"
 	"github.com/ks1686/genv/internal/schema"
 	"github.com/ks1686/genv/internal/search"
@@ -52,6 +53,9 @@ var completionZsh string
 
 //go:embed completions/genv.fish
 var completionFish string
+
+//go:embed completions/genv.ps1
+var completionPowerShell string
 
 // Structured exit codes.
 const (
@@ -1262,19 +1266,13 @@ func writeLockAfterApply(lockPath string, lf *genvfile.LockFile, result resolver
 	}
 }
 
-// applyEnvVars writes the managed env fragment, updates lf.Env in memory, and
-// returns lists of applied and removed variable names. The caller is responsible
-// for persisting the lock file (avoiding a double-write when packages and env
-// vars are both applied in the same run).
+// applyEnvVars writes managed env fragments via selected profile backends,
+// updates lf.Env in memory, and returns lists of applied and removed variable
+// names. The caller is responsible for persisting the lock file (avoiding a
+// double-write when packages and env vars are both applied in the same run).
 // If verbose is true, it prints progress lines to stdout.
 func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (applied, removed []string) {
 	if len(f.Env) == 0 && len(lf.Env) == 0 {
-		return nil, nil
-	}
-
-	fragPath, err := genvenv.FragmentPath()
-	if err != nil {
-		fprintf(os.Stderr, "genv: cannot determine fragment path: %v\n", err)
 		return nil, nil
 	}
 
@@ -1288,9 +1286,22 @@ func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (appl
 		}
 	}
 
-	if err := genvenv.ApplyEnv(fragPath, f.Env, genvenv.RcFiles()); err != nil {
-		fprintf(os.Stderr, "genv: writing env fragment: %v\n", err)
-		return applied, removed
+	if warn := profilebackend.MissingEngineWarning(runtime.GOOS); warn != "" {
+		fprintf(os.Stderr, "genv: warning: %s\n", warn)
+	}
+
+	backends := profilebackend.SelectBackends(runtime.GOOS)
+	var lastFrag string
+	for _, b := range backends {
+		if err := b.ApplyEnv(f.Env); err != nil {
+			fprintf(os.Stderr, "genv: writing env fragment (%s): %v\n", b.Name(), err)
+			return applied, removed
+		}
+		lastFrag = b.Name()
+	}
+	if lastFrag == "" && (len(applied) > 0 || len(removed) > 0 || len(f.Env) > 0) {
+		// No backend ran (e.g. Windows without PowerShell and without POSIX rc).
+		fprintf(os.Stderr, "genv: warning: no profile backend available to write env fragment\n")
 	}
 
 	if verbose {
@@ -1301,7 +1312,9 @@ func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (appl
 			fprintf(os.Stdout, "  env: removed %s\n", name)
 		}
 		if len(applied) > 0 || len(removed) > 0 {
-			fprintf(os.Stdout, "env fragment written to %s\n", fragPath)
+			if fragPath, err := genvenv.FragmentPath(); err == nil {
+				fprintf(os.Stdout, "env fragment written (%s backends) e.g. %s\n", lastFrag, fragPath)
+			}
 		}
 	}
 
@@ -2127,17 +2140,11 @@ func shellEditCmd(args []string) int {
 	return exitOK
 }
 
-// applyShellCfg writes the managed shell fragment, updates lf.Shell in memory,
-// and returns lists of applied and removed entry names. The caller writes the lock.
-// If verbose is true, it prints progress lines to stdout.
+// applyShellCfg writes managed shell fragments via selected profile backends,
+// updates lf.Shell in memory, and returns lists of applied and removed entry
+// names. The caller writes the lock. If verbose is true, it prints progress.
 func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (applied, removed []string) {
 	if f.Shell == nil && lf.Shell == nil {
-		return nil, nil
-	}
-
-	fragPath, err := shellcfg.FragmentPath()
-	if err != nil {
-		fprintf(os.Stderr, "genv: cannot determine shell fragment path: %v\n", err)
 		return nil, nil
 	}
 
@@ -2170,13 +2177,24 @@ func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (app
 		}
 	}
 
+	if warn := profilebackend.MissingEngineWarning(runtime.GOOS); warn != "" {
+		// Avoid duplicate warning when applyEnvVars already printed it in the same run;
+		// still useful when only shell is applied.
+		if len(f.Env) == 0 && len(lf.Env) == 0 {
+			fprintf(os.Stderr, "genv: warning: %s\n", warn)
+		}
+	}
+
 	var cfg *schema.ShellConfig
 	if f.Shell != nil {
 		cfg = f.Shell
 	}
-	if err := shellcfg.ApplyShell(fragPath, cfg, genvenv.RcFiles()); err != nil {
-		fprintf(os.Stderr, "genv: writing shell fragment: %v\n", err)
-		return applied, removed
+	backends := profilebackend.SelectBackends(runtime.GOOS)
+	for _, b := range backends {
+		if err := b.ApplyShell(cfg); err != nil {
+			fprintf(os.Stderr, "genv: writing shell fragment (%s): %v\n", b.Name(), err)
+			return applied, removed
+		}
 	}
 
 	if verbose {
@@ -2187,10 +2205,13 @@ func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (app
 			fprintf(os.Stdout, "  shell: removed %s\n", name)
 		}
 		if len(applied) > 0 || len(removed) > 0 {
-			fprintf(os.Stdout, "shell fragment written to %s\n", fragPath)
+			if fragPath, err := shellcfg.FragmentPath(); err == nil {
+				fprintf(os.Stdout, "shell fragment written to %s\n", fragPath)
+			}
 		}
 	}
 	if hasFishEntries {
+		fragPath, _ := shellcfg.FragmentPath()
 		fprintf(os.Stdout, "note: fish-specific shell entries are not auto-applied.\n")
 		fprintf(os.Stdout, "      Add '. %s' to ~/.config/fish/config.fish to source them.\n", fragPath)
 	}
@@ -2882,12 +2903,13 @@ func completionCmd(args []string) int {
 		fPrintln(os.Stderr, "usage: genv completion <shell>")
 		fPrintln(os.Stderr, "       genv completion install [shell] [--dir <path>]")
 		fPrintln(os.Stderr)
-		fPrintln(os.Stderr, "  shell   One of: bash, zsh, fish")
+		fPrintln(os.Stderr, "  shell   One of: bash, zsh, fish, powershell")
 		fPrintln(os.Stderr)
 		fPrintln(os.Stderr, "examples:")
 		fPrintln(os.Stderr, "  genv completion bash >> ~/.bashrc")
 		fPrintln(os.Stderr, "  genv completion zsh  > ~/.zsh/completions/_genv")
 		fPrintln(os.Stderr, "  genv completion fish > ~/.config/fish/completions/genv.fish")
+		fPrintln(os.Stderr, "  genv completion powershell > ~/.config/genv/completions/genv.ps1")
 		fPrintln(os.Stderr, "  genv completion install        # auto-detect the current shell")
 		fPrintln(os.Stderr, "  genv completion install zsh    # install for a specific shell")
 	}
@@ -2895,7 +2917,7 @@ func completionCmd(args []string) int {
 		return exitUsage
 	}
 	if fs.NArg() < 1 {
-		fPrintln(os.Stderr, "genv completion: missing shell argument (bash, zsh, or fish)")
+		fPrintln(os.Stderr, "genv completion: missing shell argument (bash, zsh, fish, or powershell)")
 		fs.Usage()
 		return exitUsage
 	}
@@ -2923,10 +2945,17 @@ func completionScriptFor(shell string) (script, filename, defaultDir string, err
 		return completionZsh, "_genv", filepath.Join(xdgDataHome(), "zsh", "site-functions"), nil
 	case "fish":
 		return completionFish, "genv.fish", filepath.Join(xdgConfigHome(), "fish", "completions"), nil
+	case "powershell":
+		// Default under the genv config dir; users dot-source from their profile.
+		dir, derr := genvfile.DefaultDir()
+		if derr != nil {
+			dir = filepath.Join(xdgConfigHome(), "genv")
+		}
+		return completionPowerShell, "genv.ps1", filepath.Join(dir, "completions"), nil
 	case "":
-		return "", "", "", fmt.Errorf("missing shell argument (bash, zsh, or fish)")
+		return "", "", "", fmt.Errorf("missing shell argument (bash, zsh, fish, or powershell)")
 	default:
-		return "", "", "", fmt.Errorf("unknown shell %q — supported shells are: bash, zsh, fish", shell)
+		return "", "", "", fmt.Errorf("unknown shell %q — supported shells are: bash, zsh, fish, powershell", shell)
 	}
 }
 
@@ -2940,7 +2969,7 @@ func completionInstallCmd(args []string) int {
 	fs.Usage = func() {
 		fPrintln(os.Stderr, "usage: genv completion install [shell] [--dir <path>]")
 		fPrintln(os.Stderr)
-		fPrintln(os.Stderr, "  shell   One of: bash, zsh, fish (default: detected from $SHELL)")
+		fPrintln(os.Stderr, "  shell   One of: bash, zsh, fish, powershell (default: detected from $SHELL)")
 		fPrintln(os.Stderr, "  --dir   Install into this directory instead of the shell default")
 	}
 	shell, flagArgs := extractPositional(args)
@@ -2950,7 +2979,7 @@ func completionInstallCmd(args []string) int {
 	if shell == "" {
 		shell = detectShell()
 		if shell == "" {
-			fPrintln(os.Stderr, "genv completion install: could not detect shell from $SHELL; pass one of: bash, zsh, fish")
+			fPrintln(os.Stderr, "genv completion install: could not detect shell from $SHELL; pass one of: bash, zsh, fish, powershell")
 			return exitUsage
 		}
 	}
@@ -2979,11 +3008,15 @@ func completionInstallCmd(args []string) int {
 	if shell == "zsh" && *dir == "" {
 		fprintf(os.Stdout, "Ensure %s is on your $fpath before compinit runs, then restart your shell.\n", target)
 	}
+	if shell == "powershell" {
+		fprintf(os.Stdout, "Add this line to your PowerShell profile to enable completions:\n")
+		fprintf(os.Stdout, "  . %s\n", path)
+	}
 	return exitOK
 }
 
-// detectShell returns "bash", "zsh", or "fish" based on the basename of $SHELL,
-// or "" when it is unset or unrecognized.
+// detectShell returns "bash", "zsh", "fish", or "powershell" based on the
+// basename of $SHELL, or "" when it is unset or unrecognized.
 func detectShell() string {
 	switch filepath.Base(os.Getenv("SHELL")) {
 	case "bash":
@@ -2992,6 +3025,8 @@ func detectShell() string {
 		return "zsh"
 	case "fish":
 		return "fish"
+	case "pwsh", "powershell":
+		return "powershell"
 	default:
 		return ""
 	}

--- a/main_coverage_extra_test.go
+++ b/main_coverage_extra_test.go
@@ -43,6 +43,7 @@ func TestCompletionCmd_PrintsScriptsAndInstalls(t *testing.T) {
 		{shell: "bash", marker: "bash completion"},
 		{shell: "zsh", marker: "#compdef genv"},
 		{shell: "fish", marker: "fish completion"},
+		{shell: "powershell", marker: "Register-ArgumentCompleter"},
 	} {
 		t.Run(tc.shell, func(t *testing.T) {
 			var code int
@@ -63,7 +64,10 @@ func TestCompletionCmd_PrintsScriptsAndInstalls(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, "genv.fish")); err != nil {
 		t.Fatalf("installed completion: %v", err)
 	}
-	if code := run([]string{"completion", "powershell"}); code != exitUsage {
+	if code := run([]string{"completion", "powershell"}); code != exitOK {
+		t.Errorf("completion powershell = %d, want exitOK", code)
+	}
+	if code := run([]string{"completion", "unknownshell"}); code != exitUsage {
 		t.Errorf("completion unknown shell = %d, want exitUsage", code)
 	}
 }


### PR DESCRIPTION
## Summary
- Schema **v7** adds `"shell": "powershell"` targeting; omitted `shell` stays POSIX-only with a shared `env` map.
- New `internal/profilebackend` (`POSIXBackend` + `PowerShellBackend`) prefers `pwsh`, then Windows PowerShell; no `.ps1` writes on non-Windows; missing engine warns and skips without failing apply.
- Windows hooks use the detected PS engine (`-NoProfile -Command` / `-File`) with `cmd /C` fallback; `genv completion powershell` embeds/installs `completions/genv.ps1`.

## Test plan
- [ ] `make ci` (cover-gate ≥80%, bench-gate)
- [ ] `go test ./internal/profilebackend ./internal/hooks ./internal/schema ./internal/shellcfg -count=1`
- [ ] `genv completion powershell` prints `Register-ArgumentCompleter`
- [ ] On Windows (manual): apply with env + `shell: "powershell"` alias writes `env.ps1`/`shell.ps1` and injects profile when `pwsh` or `powershell` is on PATH