### PR TITLE
v4.0.2: apply file mismatches + operator bugfixes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,6 +77,12 @@ homebrew_casks:
         install: |
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/genv"]
+            # launchd caches the adhoc codesign identity; reload the updates
+            # agent after binary replace so scheduled runs keep working.
+            plist = File.expand_path("~/Library/LaunchAgents/genv.updates.plist")
+            if File.exist?(plist)
+              system_command "#{staged_path}/genv", args: ["updates", "start"]
+            end
           end
 
 # ── Snap Store ────────────────────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v4.0.2 - 2026-07-26
+
+### Fixed
+
+- `genv apply` no longer aborts the whole run when a managed file mismatches: packages, env, shell, and services still apply; non-conflicting file ops still run; mismatched paths are named; exit `4` if any file issues remain.
+- Text apply plans print per-file `create` / `update` / `mismatch` / `ok` lines (not only a count).
+- `genv service status` works for `brew_formula` services without a `status` argv (delegates to `brew services list`).
+- `genv updates help` / `--help` / `-h` print usage and exit 0.
+- After Homebrew cask upgrades, `post_install` re-runs `genv updates start` when the updates LaunchAgent is present; `updates status` and successful `genv upgrade` of package `genv` hint to re-register when launchd codesign kills the agent.
+- Unit tests for service apply no longer write live launchd plists under the real `$HOME`.
+
+### Added
+
+- `genv apply --backup` backs up mismatched targets before `--force` overwrite (same effect as per-entry `backup: true`).
+
+### Changed
+
+- `genv migrate` warns when host-unscoped packages are copied into every migrated target bucket.
+
 ## v4.0.1 - 2026-07-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Convenience commands (`add` / `remove` / `adopt` / `disown` / `scan`) update the
 | `scan` | Bulk-adopt installed packages |
 | `list` (`ls`) | Show lock-tracked packages |
 | `status` | Spec ↔ lock drift (`--files`, `--target`) |
-| `apply` | Reconcile (`--dry-run`, `--yes`, `--json`, `--target`, `--force-new-lock`) |
+| `apply` | Reconcile (`--dry-run`, `--yes`, `--json`, `--force`, `--backup`, `--target`, `--force-new-lock`) |
 | `validate` | Validate spec only |
 | `upgrade` | Upgrade outdated tracked packages (`--all`, `--target`) |
 | `updates` | Background checker (`check` / `start` / `stop` / `status`; `--target` on check/start) |
@@ -235,10 +235,13 @@ Convenience commands (`add` / `remove` / `adopt` / `disown` / `scan`) update the
 
 ```bash
 genv apply --target ubuntu --dry-run --json
+genv apply --force --backup --yes                 # overwrite mismatched files; keep *.backup.*
 genv apply --target ubuntu --force-new-lock --yes   # after a foreign lock refuse
 genv export --target macos --out ./dist/macos --strict
 genv migrate --write
 ```
+
+File mismatches without `--force` no longer block packages/services: non-conflicting file ops still apply, each mismatched path is printed, and apply exits `4` if any remain.
 
 ### Updates checker
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,6 +22,7 @@ Homebrew, AUR, and the Snap Store automatically — no external reviewer sign-of
 | `v3.2.x` | Outdated-aware `genv upgrade` / `updates check` (default plan only packages with detected updates) |
 | `v4.0.0` | Schema v7 PowerShell parity + schema v8 portable multi-target (`defaults`/`targets`, migrate/export/map, foreign-lock gate) |
 | `v4.0.1` | Fix schemaVersion 8 materialize gaps (`status` / `upgrade` / `updates` / hooks / env·shell·service reads) + Arch CLI matrix CI |
+| `v4.0.2` | Apply continues past file mismatches; human file plans + `--backup`; brew-formula service status; updates `--help`; launchd re-register after genv upgrade |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew and AUR

--- a/completions/genv.bash
+++ b/completions/genv.bash
@@ -105,7 +105,7 @@ _genv() {
 		fi
 		;;
 	apply)
-		opts="--file --lock-file --dry-run --force --strict --yes --quiet --json --timeout --no-hooks --hook-timeout --debug --host --target --force-new-lock"
+		opts="--file --lock-file --dry-run --force --backup --strict --yes --quiet --json --timeout --no-hooks --hook-timeout --debug --host --target --force-new-lock"
 		;;
 	migrate)
 		opts="--file --write"
@@ -230,7 +230,7 @@ _genv() {
 			case "${prof_sub}" in
 			list | ls) opts="--file --lock-file" ;;
 			create) opts="--file" ;;
-			switch) opts="--file --lock-file --dry-run --force --strict --yes --quiet --json --timeout --debug --host" ;;
+			switch) opts="--file --lock-file --dry-run --force --backup --strict --yes --quiet --json --timeout --debug --host" ;;
 			esac
 		fi
 		;;

--- a/completions/genv.fish
+++ b/completions/genv.fish
@@ -195,6 +195,7 @@ complete -c genv -n '__fish_genv_seen_sub updates start' -l target -d 'Portable 
 complete -c genv -n '__fish_genv_using_command apply' -l lock-file -d 'Path to genv lock file' -r
 complete -c genv -n '__fish_genv_using_command apply' -l dry-run -d 'Print the reconcile plan without executing'
 complete -c genv -n '__fish_genv_using_command apply' -l force -d 'Overwrite mismatched managed files'
+complete -c genv -n '__fish_genv_using_command apply' -l backup -d 'Back up mismatched files before overwrite'
 complete -c genv -n '__fish_genv_using_command apply' -l strict -d 'Exit with an error if any package cannot be resolved'
 complete -c genv -n '__fish_genv_using_command apply' -l yes -d 'Skip the confirmation prompt'
 complete -c genv -n '__fish_genv_using_command apply' -l quiet -d 'Suppress plan output'

--- a/completions/genv.ps1
+++ b/completions/genv.ps1
@@ -71,7 +71,7 @@ function script:Get-GenvCompletions {
 
 	switch ($cmd) {
 		{ $_ -in 'apply' } {
-			$flags = @('--file', '--lock-file', '--dry-run', '--force', '--strict', '--yes',
+			$flags = @('--file', '--lock-file', '--dry-run', '--force', '--backup', '--strict', '--yes',
 				'--quiet', '--json', '--timeout', '--no-hooks', '--hook-timeout', '--debug',
 				'--host', '--target', '--force-new-lock')
 			return (& $completeCandidates -Candidates $flags)

--- a/completions/genv.zsh
+++ b/completions/genv.zsh
@@ -179,6 +179,7 @@ _genv() {
 				'--lock-file=[Path to genv lock file]:path:_files' \
 				'--dry-run[Print the reconcile plan without executing]' \
 				'--force[Overwrite mismatched managed files]' \
+				'--backup[Back up mismatched files before overwrite]' \
 				'--strict[Exit with an error if any package cannot be resolved]' \
 				'--yes[Skip the confirmation prompt]' \
 				'--quiet[Suppress plan output]' \
@@ -367,6 +368,7 @@ _genv() {
 						'--lock-file=[Path to genv lock file]:path:_files' \
 						'--dry-run[Print the reconcile plan without executing]' \
 						'--force[Overwrite mismatched managed files]' \
+						'--backup[Back up mismatched files before overwrite]' \
 						'--strict[Exit with an error if any package cannot be resolved]' \
 						'--yes[Skip the confirmation prompt]' \
 						'--quiet[Suppress plan output]' \

--- a/docs/superpowers/plans/2026-07-26-v4.0.2-bugfix.md
+++ b/docs/superpowers/plans/2026-07-26-v4.0.2-bugfix.md
@@ -1,0 +1,156 @@
+---
+name: v4.0.2 bugfix plan
+overview: Ship genv v4.0.2 fixing apply abort-on-file-mismatch (packages/services continue), human-readable file plans/paths, brew-formula service status, updates --help, launchd re-register after binary upgrades, and sandboxing service unit tests that leaked into live launchd.
+todos:
+  - id: w1-apply-abort
+    content: Fix runApplyText abort; continue packages; apply non-conflicting files; exit 4 on remaining mismatches
+    status: in_progress
+  - id: w1-file-plan-text
+    content: Human-readable file plan + named mismatch paths; apply --backup
+    status: pending
+  - id: w2-brew-status
+    content: service status delegates to brew for --brew-formula
+    status: pending
+  - id: w3-updates-help
+    content: genv updates --help/-h/help
+    status: pending
+  - id: w4-codesign-rereg
+    content: Cask post_install + status/upgrade guidance to re-register updates agent
+    status: pending
+  - id: w5-test-sandbox
+    content: Sandbox TestApplyServices* to stop live launchd leakage
+    status: pending
+  - id: w6-docs-release
+    content: CHANGELOG/README/migrate note; verify; tag v4.0.2 after CI
+    status: pending
+isProject: false
+---
+
+# v4.0.2 Bugfix Plan
+
+> **For agentic workers:** Use subagent-driven development task-by-task with TDD. Persist this plan under [`docs/superpowers/plans/2026-07-26-v4.0.2-bugfix.md`](docs/superpowers/plans/2026-07-26-v4.0.2-bugfix.md).
+
+**Goal:** Fix the open post-4.0.1 bugs so a stray file mismatch cannot block packages/services, operators can see file plans/paths without `--json`, brew-formula services and updates help work, and upgrades re-register the updates agent.
+
+**Architecture:** Keep `files.Apply`’s existing per-entry semantics (apply non-conflicting; collect mismatches). Change only the **text apply orchestration** that currently treats a dry-run file plan error as fatal before packages. Add text printers mirroring `status --files` / JSON `data.files`. Small CLI fixes for brew status and updates help; cask + status prompts for codesigning; sandbox Darwin service tests.
+
+**Tech Stack:** Go 1.24, existing `internal/files`, `internal/service`, launchd/Homebrew cask in `.goreleaser.yml`, table-driven + e2e integration tests.
+
+**Defaults chosen (from report + code):**
+- On mismatch without `--force`: continue packages/env/shell/services; apply non-conflicting file ops; skip mismatched entries; print each path; exit `4` if any file issues remain.
+- Ownership of existing files: `genv apply --force` (+ per-entry `backup: true`); add global `apply --backup`; improve mismatch guidance. No new adopt semantics beyond clarifying/force path.
+- Dual launchd wrapper redesign and migrate “fat target” note: light docs/migrate message only; no architecture change this release.
+
+## Global Constraints
+
+- Preserve e2e S3 contract: mismatch without force leaves the real file untouched and returns exit `4` (but packages may still run when present).
+- Preserve S4: `--force` + `backup: true` creates `*.backup.*` and installs the link.
+- Do not touch schema version (stay on v8).
+- Review before push; tag `v4.0.2` only after CI green.
+
+```mermaid
+flowchart TD
+  start[apply text] --> planFiles[Plan files dry-run]
+  planFiles --> printPlan[Print package + file plan with paths]
+  printPlan --> pkgs[Execute packages env shell services]
+  pkgs --> applyFiles[Apply files]
+  applyFiles --> okFiles[Create/update non-conflicting]
+  applyFiles --> skipMis[Skip mismatches unless force]
+  okFiles --> exitCode{Any mismatches or errors?}
+  skipMis --> exitCode
+  exitCode -->|yes| exit4[exit 4]
+  exitCode -->|no| exit0[exit 0]
+```
+
+---
+
+## Workstreams
+
+| ID | Stream | Mode |
+|----|--------|------|
+| W1 | Apply file abort + text plan/paths + `--backup` | serial (touches `runApplyText`) |
+| W2 | `service status` brew-formula | parallel-safe with W1 |
+| W3 | `updates --help` | parallel-safe |
+| W4 | Updates launchd re-register after upgrade | parallel-safe |
+| W5 | Sandbox `TestApplyServices*` leakage | parallel-safe |
+| W6 | Docs (repo README/CHANGELOG + note for user `~/.config/genv/docs`) | after W1–W5 |
+| W7 | CHANGELOG + tag v4.0.2 | after Review/CI |
+
+---
+
+## Task 1 — Stop aborting apply on file plan mismatches
+
+**Files:** [`main.go`](main.go) (`runApplyText` ~1278–1288), tests in `main_*_test.go` or new `main_apply_files_test.go`
+
+- [ ] Write failing test: v8/v6 spec with one package + one mismatched link (no `--force`); assert package install/plan still runs and exit is `4` with path named.
+- [ ] Remove early `return exitLogic` when `filePlanErr != nil` after dry-run `applyFiles` in `runApplyText`; keep `filePlan` for printing.
+- [ ] After real `applyFiles`, if mismatches remain, exit `4` (packages already applied).
+- [ ] Keep JSON behavior coherent (already plans both; ensure real apply still runs packages before files).
+
+## Task 2 — Human-readable file plan + named mismatches
+
+**Files:** [`main.go`](main.go) (near `writeFileStatus` ~1729), [`internal/files/applier.go`](internal/files/applier.go) optional
+
+- [ ] Add `writeFilePlan(w, *files.ApplyResult)` printing lines like `create|update|mismatch|ok` + target path (reuse status wording).
+- [ ] Call it from text dry-run and real apply plan sections; replace count-only `"files: N …"` as the sole signal.
+- [ ] On mismatch, print paths from `filePlan.Mismatched` (do not rely on `summarize()`’s count-only string alone). Hint: `genv apply --force` (and `backup: true` / `--backup`).
+- [ ] Unit test asserts dry-run stdout contains the mismatched path.
+
+## Task 3 — `apply --backup` flag
+
+**Files:** [`main.go`](main.go) apply options / `applyFiles`
+
+- [ ] Add `--backup` bool; pass into `files.ApplyOptions.Backup` (today hardcoded `false` at ~1779).
+- [ ] Completions + help text.
+- [ ] Test: `--force --backup` backs up without needing per-entry `backup: true`.
+
+## Task 4 — `service status` for `--brew-formula`
+
+**Files:** [`main.go`](main.go) `serviceStatusCmd`, [`internal/service/brew.go`](internal/service/brew.go)
+
+- [ ] Failing test with fake `brew` on PATH.
+- [ ] If `svc.BrewFormula != ""`, use `BrewServicesRunning` (or thin `BrewServicesInfo`); print running/not; exit 0/4.
+- [ ] Do not require `Status` argv for brew-formula services.
+
+## Task 5 — `genv updates --help`
+
+**Files:** [`main_updates.go`](main_updates.go), [`main_test.go`](main_test.go)
+
+- [ ] Accept `help` / `--help` / `-h` → `printUpdatesUsage()`, return `exitOK`.
+- [ ] Extend usage test; ensure no `"unknown subcommand"`.
+
+## Task 6 — Re-register updates agent after binary replace
+
+**Files:** [`.goreleaser.yml`](.goreleaser.yml) brew cask `post_install`, [`main_updates_daemon.go`](main_updates_daemon.go), optionally upgrade success path
+
+- [ ] Cask `post_install`: if `~/Library/LaunchAgents/genv.updates.plist` exists, run `"#{staged_path}/genv" updates start` (reload after codesign change). Keep existing quarantine xattr strip.
+- [ ] `updates status`: if `LastRunDetail` matches `(?i)codesign|OS_REASON_CODESIGNING`, print actionable `genv updates start` guidance.
+- [ ] After successful `genv upgrade` when any upgraded package id is `genv` (or executable path in plist ≠ current), call re-start or print the same guidance.
+- [ ] Unit test for status guidance string (inject detail); document in CHANGELOG.
+
+## Task 7 — Stop launchd test leakage
+
+**Files:** [`internal/service/service_test.go`](internal/service/service_test.go)
+
+- [ ] Sandbox `TestApplyServices` / `TestApplyServicesModified` / related: `t.Setenv("HOME", temp)` + fake `launchctl` (pattern from `coverage_extra_test.go`), or skip when live launchd and rely on sandboxed twin.
+- [ ] `t.Cleanup` unload/remove if any test must touch real domain (prefer never).
+- [ ] Confirm no write to real `~/Library/LaunchAgents/genv.new-svc.plist`.
+
+## Task 8 — Docs + migrate note + release prep
+
+- [ ] CHANGELOG `v4.0.2` section; RELEASING table row.
+- [ ] README apply flags: `--force`, `--backup`, file plan text behavior.
+- [ ] `genv migrate` stderr/stdout one-liner when synthesizing a large target from unscoped packages (address design surprise lightly).
+- [ ] Note for user: update `~/.config/genv/docs/genv/links.md` / `services.md` after ship (those live outside the repo).
+
+## Task 9 — Verification / ship
+
+- [ ] `go test ./...`; focused e2e `TestFiles_S3` / `S4` / `S6`; `make integration-v8` if Docker available.
+- [ ] Review + CI green on PR/main.
+- [ ] Tag `v4.0.2` per RELEASING.md.
+
+## Out of scope (explicit)
+
+- Redesigning dual `genv.*` + real launchd agents for brew/wrapper services.
+- Changing migrate heuristics for package bucketing (message only).
+- New schema fields for adoption.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -95,7 +95,7 @@ drives the real binary. All eight currently pass.
 | --- | --- | --- |
 | S1 FreshEmptyHome | `status --files` | Empty HOME: exits 4 and reports each target `missing`. |
 | S2 ApplyClean | `apply --yes` | Creates the link, then `status --files` exits 0 (`ok` / `up to date`). |
-| S3 MismatchNoForce | `apply` | A real file blocking a link target: exits 4 and leaves that file byte-for-byte untouched (still a regular file). |
+| S3 MismatchNoForce | `apply --yes` | A real file blocking a link target: exits 4 and leaves that file byte-for-byte untouched (still a regular file). Packages/services still apply when present. |
 | S4 MismatchForceBackup | `apply --force --yes` | Backs up the blocking file to one `target.backup.<timestamp>`, installs the symlink, then `status --files` exits 0. |
 | S5 CodexTemplatedDrift | `status --files`, `apply --force --yes` | Stale rendered `copy-template` target is flagged `mismatch` (exit 4); force re-renders it with the real HOME (no literal `__HOME__`), writes one backup, and status then exits 0. |
 | S6 DryRun | `apply --dry-run --force --yes` | Reports the planned change but writes nothing to disk and creates no backup. |

--- a/e2e/files_test.go
+++ b/e2e/files_test.go
@@ -214,7 +214,7 @@ func TestFiles_S3_MismatchNoForce(t *testing.T) {
 		t.Fatalf("write planted file: %v", err)
 	}
 
-	stdout, stderr, code := r.genv("", "apply")
+	stdout, stderr, code := r.genv("", "apply", "--yes")
 	if code != 4 {
 		t.Errorf("apply mismatch no-force: exit %d, want 4\nstdout: %s\nstderr: %s", code, stdout, stderr)
 	}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/ks1686/genv/internal/schema"
 )
@@ -54,6 +55,11 @@ func ToV8(in *schema.GenvFile) (*schema.GenvFile, []string, error) {
 
 	if err := bucketPackages(out.Targets, targetIDs, in.Packages); err != nil {
 		return nil, nil, err
+	}
+	if unscoped := countUnscopedPackages(in.Packages); unscoped > 0 {
+		warnings = append(warnings, fmt.Sprintf(
+			"%d package(s) without host predicates were copied into migrated target(s) [%s]; review and prune targets you do not use",
+			unscoped, strings.Join(targetIDs, ", ")))
 	}
 	if err := bucketServices(out.Targets, targetIDs, in.Services); err != nil {
 		return nil, nil, err
@@ -184,6 +190,16 @@ func bucketPackages(targets map[string]*schema.TargetBundle, defaultTargetIDs []
 		}
 	}
 	return nil
+}
+
+func countUnscopedPackages(packages []schema.Package) int {
+	n := 0
+	for _, pkg := range packages {
+		if len(pkg.Host) == 0 {
+			n++
+		}
+	}
+	return n
 }
 
 func bucketServices(targets map[string]*schema.TargetBundle, defaultTargetIDs []string, services map[string]schema.Service) error {

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -52,8 +52,8 @@ func TestToV8BucketsHostScopedSpec(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ToV8 returned error: %v", err)
 	}
-	if len(warnings) != 0 {
-		t.Fatalf("warnings = %v, want none", warnings)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "without host predicates") {
+		t.Fatalf("warnings = %v, want unscoped package copy warning", warnings)
 	}
 	if got.SchemaVersion != schema.Version8 {
 		t.Fatalf("schemaVersion = %q, want %q", got.SchemaVersion, schema.Version8)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -71,6 +71,10 @@ func TestServiceStatus(t *testing.T) {
 }
 
 func TestApplyServices(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	installServiceFakeBinary(t, "systemctl", "exit 0")
+	installServiceFakeBinary(t, "launchctl", "exit 0")
 	ctx := context.Background()
 
 	// Case: start a missing service
@@ -136,6 +140,10 @@ func TestApplyServicesFailure(t *testing.T) {
 
 func TestApplyServicesModified(t *testing.T) {
 	// A service whose config changed vs the lock must be re-applied.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	installServiceFakeBinary(t, "systemctl", "exit 0")
+	installServiceFakeBinary(t, "launchctl", "exit 0")
 	ctx := context.Background()
 	spec := map[string]schema.Service{
 		"mod-svc": {Start: []string{"true"}},

--- a/main.go
+++ b/main.go
@@ -1047,6 +1047,7 @@ type applyOptions struct {
 	Quiet         bool
 	JSONOut       bool
 	Force         bool
+	Backup        bool
 	Timeout       time.Duration
 	Debug         bool
 	TargetProfile string
@@ -1070,6 +1071,7 @@ func applyCmd(args []string) int {
 	fs.StringVar(&opts.LockFile, "lock-file", "", "path to genv lock file")
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "print the reconcile plan without executing")
 	fs.BoolVar(&opts.Force, "force", false, "overwrite mismatched managed files")
+	fs.BoolVar(&opts.Backup, "backup", false, "back up mismatched files before overwrite (implies keeping originals as *.backup.*)")
 	fs.BoolVar(&opts.Strict, "strict", false, "exit with an error if any package cannot be resolved")
 	fs.BoolVar(&opts.Yes, "yes", false, "skip the confirmation prompt (for CI and scripts)")
 	fs.BoolVar(&opts.Quiet, "quiet", false, "suppress plan output (useful in scripts)")
@@ -1277,14 +1279,10 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	}
 	planOpts := opts
 	planOpts.DryRun = true
-	filePlan, filePlanErr := applyFiles(ctx, planOpts, f, lf)
+	filePlan, _ := applyFiles(ctx, planOpts, f, lf)
 	fileChanges := 0
 	if filePlan != nil {
 		fileChanges = len(filePlan.Created) + len(filePlan.Updated) + len(filePlan.Mismatched)
-	}
-	if filePlanErr != nil {
-		fprintf(os.Stderr, "genv apply: %v\n", filePlanErr)
-		return exitLogic
 	}
 
 	if toInstall == 0 && toRemove == 0 && envChanges == 0 && shellChanges == 0 && serviceChanges == 0 && fileChanges == 0 {
@@ -1313,6 +1311,10 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 		return exitLogic
 	}
 
+	if fileChanges > 0 && !opts.Quiet {
+		writeFilePlan(planOut, filePlan)
+	}
+
 	if opts.DryRun {
 		if envChanges > 0 && !opts.Quiet {
 			fprintf(os.Stdout, "env: %d variable(s) to apply\n", envChanges)
@@ -1322,9 +1324,6 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 		}
 		if serviceChanges > 0 && !opts.Quiet {
 			fprintf(os.Stdout, "service: %d service(s) to reconcile\n", serviceChanges)
-		}
-		if fileChanges > 0 && !opts.Quiet {
-			fprintf(os.Stdout, "files: %d file entry/entries to reconcile\n", fileChanges)
 		}
 		return exitOK
 	}
@@ -1367,10 +1366,15 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	applyShellCfg(f, lf, !opts.Quiet)
 	_, _, svcErrs := applyServices(ctx, f, lf, !opts.Quiet)
 	var fileErrs []error
+	var appliedFiles *files.ApplyResult
 	if len(execResult.Errors) == 0 {
-		_, filePlanErr = applyFiles(ctx, opts, f, lf)
+		var filePlanErr error
+		appliedFiles, filePlanErr = applyFiles(ctx, opts, f, lf)
 		if filePlanErr != nil {
 			fileErrs = append(fileErrs, filePlanErr)
+		}
+		if appliedFiles != nil && len(appliedFiles.Mismatched) > 0 {
+			writeFileMismatchGuidance(os.Stderr, appliedFiles)
 		}
 	}
 	var hookErrs []string
@@ -1740,6 +1744,32 @@ func writeFileStatus(w io.Writer, res *files.StatusResult) {
 	_ = tw.Flush()
 }
 
+func writeFilePlan(w io.Writer, res *files.ApplyResult) {
+	if res == nil {
+		return
+	}
+	entries := filePlanEntries(res)
+	if len(entries) == 0 {
+		return
+	}
+	fPrintln(w, "files:")
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	for _, e := range entries {
+		fprintf(tw, "  %s\t%s\n", e.Kind, e.Target)
+	}
+	_ = tw.Flush()
+}
+
+func writeFileMismatchGuidance(w io.Writer, res *files.ApplyResult) {
+	if res == nil || len(res.Mismatched) == 0 {
+		return
+	}
+	for _, target := range res.Mismatched {
+		fprintf(w, "genv apply: mismatch: %s\n", target)
+	}
+	fPrintln(w, "Hint: re-run with genv apply --force to overwrite, and add --backup (or per-entry backup: true) to preserve the existing file as *.backup.*")
+}
+
 func filePlanEntries(res *files.ApplyResult) []output.FilePlanEntry {
 	if res == nil {
 		return nil
@@ -1776,7 +1806,7 @@ func applyFiles(ctx context.Context, opts applyOptions, f *schema.GenvFile, lf *
 		SourceRoot: sourceRootForSpec(opts.File, f),
 		Force:      opts.Force,
 		DryRun:     opts.DryRun,
-		Backup:     false,
+		Backup:     opts.Backup,
 	})
 	if err == nil && !opts.DryRun {
 		lf.Files = lockedFilesFromSpec(f.Files)
@@ -3574,6 +3604,9 @@ func upgradeCmd(args []string) int {
 		fprintf(os.Stderr, "genv upgrade: %v\n", runResult.LockWriteError)
 		return exitIO
 	}
+	if exitCode == exitOK {
+		adviseUpdatesReregister(os.Stdout, runResult.Upgraded)
+	}
 	return exitCode
 }
 
@@ -3739,6 +3772,10 @@ func upgradeJSON(dryRun bool, hostName, lockPath string, hookTimeout time.Durati
 			Manager:    u.Manager,
 			NewVersion: u.InstalledVersion,
 		})
+	}
+
+	if len(errs) == 0 {
+		adviseUpdatesReregister(os.Stderr, runResult.Upgraded)
 	}
 
 	return writeJSON(os.Stdout, output.Envelope{
@@ -4436,6 +4473,15 @@ func serviceStatusCmd(args []string) int {
 	svc, ok := f.Services[name]
 	if !ok {
 		fprintf(os.Stderr, "genv: service %q not found in spec\n", name)
+		return exitLogic
+	}
+
+	if svc.BrewFormula != "" {
+		if service.BrewServicesRunning(svc.BrewFormula) {
+			fprintf(os.Stdout, "service %q is running\n", name)
+			return exitOK
+		}
+		fprintf(os.Stdout, "service %q is NOT running\n", name)
 		return exitLogic
 	}
 

--- a/main_apply_files_test.go
+++ b/main_apply_files_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApply_FileMismatchDoesNotAbortPackages(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	t.Setenv("HOME", dir)
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	sourcePath := filepath.Join(dir, "source.txt")
+	targetPath := filepath.Join(dir, "target.txt")
+	installLog := filepath.Join(dir, "install.log")
+
+	writeTestFile(t, sourcePath, "desired\n")
+	writeTestFile(t, targetPath, "blocking-real-file\n")
+	registerLifecycleHookAdapter(t, lifecycleHookAdapter{installMarker: installLog})
+
+	writeTestFile(t, specPath, `{
+		"schemaVersion":"6",
+		"packages":[{"id":"alpha","prefer":"test-hook-manager"}],
+		"files":{"links":[{"source":"`+sourcePath+`","target":"`+targetPath+`","mode":"link"}]}
+	}`)
+
+	var code int
+	var stdout, stderr string
+	stdout = captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			code = run([]string{"apply", "--file", specPath, "--lock-file", lockPath, "--yes", "--no-hooks"})
+		})
+	})
+
+	if code != exitLogic {
+		t.Fatalf("apply with mismatch: expected exitLogic (%d), got %d\nstdout=%s\nstderr=%s", exitLogic, code, stdout, stderr)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "mismatch") {
+		t.Fatalf("expected mismatch in output; stdout=%s stderr=%s", stdout, stderr)
+	}
+	if !strings.Contains(combined, targetPath) && !strings.Contains(combined, filepath.Base(targetPath)) {
+		t.Fatalf("expected mismatch path in output; stdout=%s stderr=%s", stdout, stderr)
+	}
+	got, err := os.ReadFile(installLog)
+	if err != nil {
+		t.Fatalf("package install should still run despite file mismatch; read install log: %v\nstdout=%s stderr=%s", err, stdout, stderr)
+	}
+	if string(got) != "install" {
+		t.Fatalf("install log = %q, want install", got)
+	}
+	fi, err := os.Lstat(targetPath)
+	if err != nil {
+		t.Fatalf("lstat target: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("target became a symlink without --force")
+	}
+}
+
+func TestApply_DryRunTextShowsFilePaths(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	t.Setenv("HOME", dir)
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	sourcePath := filepath.Join(dir, "source.txt")
+	targetPath := filepath.Join(dir, "target.txt")
+
+	writeTestFile(t, sourcePath, "desired\n")
+	writeTestFile(t, targetPath, "blocking\n")
+	writeTestFile(t, specPath, `{
+		"schemaVersion":"5",
+		"files":{"links":[{"source":"`+sourcePath+`","target":"`+targetPath+`","mode":"link"}]}
+	}`)
+
+	var code int
+	stdout := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			code = run([]string{"apply", "--file", specPath, "--lock-file", lockPath, "--dry-run", "--yes"})
+		})
+	})
+	if code != exitOK && code != exitLogic {
+		t.Fatalf("dry-run: unexpected exit %d\n%s", code, stdout)
+	}
+	if !strings.Contains(stdout, targetPath) {
+		t.Fatalf("dry-run text should name file path; got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "mismatch") {
+		t.Fatalf("dry-run text should include mismatch kind; got: %s", stdout)
+	}
+}
+
+func TestApply_ForceBackupFlagBacksUpWithoutPerEntryBackup(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	t.Setenv("HOME", dir)
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	sourcePath := filepath.Join(dir, "source.txt")
+	targetPath := filepath.Join(dir, "target.txt")
+
+	writeTestFile(t, sourcePath, "desired\n")
+	writeTestFile(t, targetPath, "old-content\n")
+	writeTestFile(t, specPath, `{
+		"schemaVersion":"5",
+		"files":{"links":[{"source":"`+sourcePath+`","target":"`+targetPath+`","mode":"link"}]}
+	}`)
+
+	code := run([]string{"apply", "--file", specPath, "--lock-file", lockPath, "--force", "--backup", "--yes", "--no-hooks"})
+	if code != exitOK {
+		t.Fatalf("apply --force --backup: expected exitOK, got %d", code)
+	}
+	fi, err := os.Lstat(targetPath)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected symlink after --force")
+	}
+	matches, err := filepath.Glob(targetPath + ".backup.*")
+	if err != nil {
+		t.Fatalf("glob backup: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected one backup file, got %v", matches)
+	}
+}

--- a/main_service_test.go
+++ b/main_service_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ks1686/genv/internal/genvfile"
@@ -87,4 +89,57 @@ func TestServiceCLIUsageErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServiceStatus_BrewFormula(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	spec := `{"schemaVersion":"6","packages":[],"services":{"redis":{"brew_formula":"redis"}}}`
+	if err := os.WriteFile(path, []byte(spec), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	installBrewServicesList := func(t *testing.T, listBody string) {
+		t.Helper()
+		binDir := t.TempDir()
+		script := "#!/bin/sh\n" +
+			"if [ \"$1\" = \"services\" ] && [ \"$2\" = \"list\" ]; then\n" +
+			"  printf '%s\\n' '" + listBody + "'\n" +
+			"  exit 0\n" +
+			"fi\n" +
+			"exit 0\n"
+		if err := os.WriteFile(filepath.Join(binDir, "brew"), []byte(script), 0o755); err != nil {
+			t.Fatalf("write fake brew: %v", err)
+		}
+		t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
+
+	t.Run("running", func(t *testing.T) {
+		installBrewServicesList(t, "redis started user")
+		var code int
+		out := captureStdout(t, func() {
+			code = run([]string{"service", "status", "redis", "--file", path})
+		})
+		if code != exitOK {
+			t.Fatalf("service status (running): got %d, want %d; stdout=%q", code, exitOK, out)
+		}
+		if !strings.Contains(out, "running") || strings.Contains(out, "NOT running") {
+			t.Fatalf("stdout = %q, want running", out)
+		}
+	})
+
+	t.Run("not running", func(t *testing.T) {
+		installBrewServicesList(t, "redis stopped user")
+		var code int
+		out := captureStdout(t, func() {
+			code = run([]string{"service", "status", "redis", "--file", path})
+		})
+		if code != exitLogic {
+			t.Fatalf("service status (not running): got %d, want %d; stdout=%q", code, exitLogic, out)
+		}
+		if !strings.Contains(out, "NOT running") {
+			t.Fatalf("stdout = %q, want NOT running", out)
+		}
+	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2393,6 +2393,28 @@ func TestUpdates_UsageErrors_are_actionable(t *testing.T) {
 	}
 }
 
+func TestUpdates_Help_returns_ok(t *testing.T) {
+	for _, args := range [][]string{
+		{"updates", "help"},
+		{"updates", "--help"},
+		{"updates", "-h"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var code int
+			errOut := captureStderr(t, func() { code = run(args) })
+			if code != exitOK {
+				t.Fatalf("run(%v): expected exitOK (%d), got %d", args, exitOK, code)
+			}
+			if !strings.Contains(errOut, "usage: genv updates <check|start|stop|status>") {
+				t.Fatalf("stderr = %q, want updates usage", errOut)
+			}
+			if strings.Contains(errOut, "unknown subcommand") {
+				t.Fatalf("stderr = %q, must not report unknown subcommand for help", errOut)
+			}
+		})
+	}
+}
+
 type fakeUpdatesSupervisor struct {
 	supported bool
 	status    service.ScheduledJobStatus
@@ -2553,6 +2575,7 @@ func TestUpdatesStatus_prints_typed_scheduler_state(t *testing.T) {
 		{name: "registered idle no known run", status: service.ScheduledJobStatus{Supported: true, Registered: true, LastRun: service.ScheduledRunUnknown}, want: []string{"registered and idle", "no completed run is known"}},
 		{name: "registered idle last run succeeded", status: service.ScheduledJobStatus{Supported: true, Registered: true, LastRun: service.ScheduledRunSuccess, ExitCode: &exitZero}, want: []string{"registered and idle", "last run succeeded", "status 0"}},
 		{name: "registered idle last run failed", status: service.ScheduledJobStatus{Supported: true, Registered: true, LastRun: service.ScheduledRunFailure, ExitCode: &exitSeven, LastRunDetail: "exit-code"}, want: []string{"registered and idle", "last run failed", "status 7", "exit-code"}},
+		{name: "codesign failure guidance", status: service.ScheduledJobStatus{Supported: true, Registered: true, LastRun: service.ScheduledRunFailure, ExitCode: &exitSeven, LastRunDetail: "OS_REASON_CODESIGNING"}, want: []string{"last run failed", "OS_REASON_CODESIGNING", "genv updates start"}},
 	}
 
 	for _, tt := range tests {
@@ -2577,6 +2600,32 @@ func TestUpdatesStatus_prints_typed_scheduler_state(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestAdviseUpdatesReregister_helpers(t *testing.T) {
+	if !lastRunDetailSuggestsCodesign("OS_REASON_CODESIGNING") {
+		t.Fatal("expected codesign reason to match")
+	}
+	if !lastRunDetailSuggestsCodesign("codesign invalid") {
+		t.Fatal("expected case-insensitive codesign match")
+	}
+	if lastRunDetailSuggestsCodesign("exit-code") {
+		t.Fatal("did not expect non-codesign detail to match")
+	}
+
+	var buf bytes.Buffer
+	adviseUpdatesReregister(&buf, nil)
+	if buf.Len() != 0 {
+		t.Fatalf("unexpected guidance for empty upgraded list: %q", buf.String())
+	}
+	adviseUpdatesReregister(&buf, []genvfile.LockedPackage{{ID: "ripgrep"}})
+	if buf.Len() != 0 {
+		t.Fatalf("unexpected guidance when genv was not upgraded: %q", buf.String())
+	}
+	adviseUpdatesReregister(&buf, []genvfile.LockedPackage{{ID: "ripgrep"}, {ID: "genv"}})
+	if !strings.Contains(buf.String(), "genv updates start") {
+		t.Fatalf("guidance = %q, want genv updates start", buf.String())
 	}
 }
 

--- a/main_updates.go
+++ b/main_updates.go
@@ -19,6 +19,9 @@ func updatesCmd(args []string) int {
 		return exitUsage
 	}
 	switch args[0] {
+	case "help", "--help", "-h":
+		printUpdatesUsage()
+		return exitOK
 	case "check":
 		return updatesCheckCmd(args[1:])
 	case "start":

--- a/main_updates_daemon.go
+++ b/main_updates_daemon.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -135,12 +136,31 @@ func updatesStatusCmd(args []string) int {
 		fprintf(os.Stdout, "updates checker is registered and idle; last run succeeded%s (%s).\n", scheduledRunStatusDetail(status), status.Detail)
 	case service.ScheduledRunFailure:
 		fprintf(os.Stdout, "updates checker is registered and idle; last run failed%s (%s).\n", scheduledRunStatusDetail(status), status.Detail)
+		if lastRunDetailSuggestsCodesign(status.LastRunDetail) {
+			fPrintln(os.Stdout, "Hint: launchd may have cached a stale codesign for the genv binary; re-register with: genv updates start")
+		}
 	case service.ScheduledRunUnknown, "":
 		fprintf(os.Stdout, "updates checker is registered and idle; no completed run is known (%s).\n", status.Detail)
 	default:
 		fprintf(os.Stdout, "updates checker is registered and idle; last-run outcome is unknown (%s).\n", status.Detail)
 	}
 	return exitOK
+}
+
+func lastRunDetailSuggestsCodesign(detail string) bool {
+	d := strings.ToLower(detail)
+	return strings.Contains(d, "codesign") || strings.Contains(d, "os_reason_codesigning")
+}
+
+// adviseUpdatesReregister prints guidance when the genv binary itself was upgraded,
+// so launchd picks up the new codesign identity.
+func adviseUpdatesReregister(w io.Writer, upgraded []genvfile.LockedPackage) {
+	for _, pkg := range upgraded {
+		if pkg.ID == "genv" {
+			fPrintln(w, "Hint: genv was upgraded; if the updates checker is registered, re-run: genv updates start")
+			return
+		}
+	}
 }
 
 func scheduledRunStatusDetail(status service.ScheduledJobStatus) string {


### PR DESCRIPTION
## Summary
- Stop `genv apply` from aborting the whole run on a dry-run file mismatch; packages/env/shell/services continue, non-conflicting files apply, mismatched paths are named, exit `4` if any remain
- Add human-readable file plans and `apply --backup`; brew-formula `service status`; `updates --help`; cask/status/upgrade guidance to re-register the updates agent after codesign; sandbox service unit tests

## Test plan
- [x] `go test ./...`
- [x] `make ci` (cover-gate 80.0%, bench-gate OK)
- [x] `go test -tags=integration -run 'TestFiles_S3|TestFiles_S4|TestFiles_S6' ./e2e/`
- [ ] GitHub CI green
- [ ] Tag `v4.0.2` after merge