### PR TITLE
v4.0.3: hook-skip message + scan dry-run/confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v4.0.3 - 2026-07-26
+
+### Fixed
+
+- When `genv apply` leaves unresolved file mismatches, it now prints that post-apply hooks are being skipped (services still run before files; only hooks are gated).
+
+### Added
+
+- `genv scan --dry-run` previews packages that would be adopted without writing the spec or lock.
+- `genv scan` text mode confirms before adopting unless `--yes` is set (JSON still writes without a prompt, matching `apply --json`).
+
 ## v4.0.2 - 2026-07-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Convenience commands (`add` / `remove` / `adopt` / `disown` / `scan`) update the
 | ------- | ------- |
 | `add` / `remove` (`rm`) | Track + install / untrack + uninstall |
 | `adopt` / `disown` | Track without install / untrack without uninstall |
-| `scan` | Bulk-adopt installed packages |
+| `scan` | Bulk-adopt installed packages (`--dry-run`, `--yes`) |
 | `list` (`ls`) | Show lock-tracked packages |
 | `status` | Spec ↔ lock drift (`--files`, `--target`) |
 | `apply` | Reconcile (`--dry-run`, `--yes`, `--json`, `--force`, `--backup`, `--target`, `--force-new-lock`) |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,6 +23,7 @@ Homebrew, AUR, and the Snap Store automatically — no external reviewer sign-of
 | `v4.0.0` | Schema v7 PowerShell parity + schema v8 portable multi-target (`defaults`/`targets`, migrate/export/map, foreign-lock gate) |
 | `v4.0.1` | Fix schemaVersion 8 materialize gaps (`status` / `upgrade` / `updates` / hooks / env·shell·service reads) + Arch CLI matrix CI |
 | `v4.0.2` | Apply continues past file mismatches; human file plans + `--backup`; brew-formula service status; updates `--help`; launchd re-register after genv upgrade |
+| `v4.0.3` | Explicit skip message for post-apply hooks on file mismatch; `scan --dry-run` + confirmation/`--yes` |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew and AUR

--- a/completions/genv.bash
+++ b/completions/genv.bash
@@ -120,7 +120,7 @@ _genv() {
 		opts="--file --lock-file --json --debug --files --host --target"
 		;;
 	scan)
-		opts="--file --lock-file --json --debug --target"
+		opts="--file --lock-file --json --debug --target --dry-run --yes"
 		;;
 	clean)
 		opts="--dry-run"

--- a/completions/genv.fish
+++ b/completions/genv.fish
@@ -224,6 +224,8 @@ complete -c genv -n '__fish_genv_using_command map' -l target -d 'Destination ta
 complete -c genv -n '__fish_genv_using_command status; or __fish_genv_using_command scan' -l lock-file -d 'Path to genv lock file' -r
 complete -c genv -n '__fish_genv_using_command status; or __fish_genv_using_command scan' -l json -d 'Emit machine-readable JSON to stdout'
 complete -c genv -n '__fish_genv_using_command status; or __fish_genv_using_command scan' -l debug -d 'Emit debug-level structured logs to stderr'
+complete -c genv -n '__fish_genv_using_command scan' -l dry-run -d 'List packages that would be adopted without writing'
+complete -c genv -n '__fish_genv_using_command scan' -l yes -d 'Skip the confirmation prompt'
 complete -c genv -n '__fish_genv_using_command scan' -l target -d 'Portable target id for schemaVersion 8 specs' -x
 complete -c genv -n '__fish_genv_using_command status' -l files -d 'Check files block against the live filesystem only'
 complete -c genv -n '__fish_genv_using_command status' -l host -d 'Host name for host-specific records' -x

--- a/completions/genv.ps1
+++ b/completions/genv.ps1
@@ -173,7 +173,7 @@ function script:Get-GenvCompletions {
 			return (& $completeCandidates -Candidates $flags)
 		}
 		{ $_ -in 'scan' } {
-			$flags = @('--file', '--lock-file', '--json', '--debug', '--target')
+			$flags = @('--file', '--lock-file', '--dry-run', '--yes', '--json', '--debug', '--target')
 			return (& $completeCandidates -Candidates $flags)
 		}
 		{ $_ -in 'completion' } {

--- a/completions/genv.zsh
+++ b/completions/genv.zsh
@@ -224,6 +224,8 @@ _genv() {
 			_arguments \
 				'--file=[Path to genv.json]:path:_files' \
 				'--lock-file=[Path to genv lock file]:path:_files' \
+				'--dry-run[List packages that would be adopted without writing]' \
+				'--yes[Skip the confirmation prompt]' \
 				'--json[Emit machine-readable JSON to stdout]' \
 				'--debug[Emit debug-level structured logs to stderr]' \
 				'--target=[Portable target id for schemaVersion 8 specs]:target:'

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -73,8 +73,10 @@ type StatusResult struct {
 
 // ScanResult is the Data payload for `genv scan --json`.
 type ScanResult struct {
-	Added   int `json:"added"`
-	Skipped int `json:"skipped"`
+	Added    int      `json:"added"`
+	Skipped  int      `json:"skipped"`
+	DryRun   bool     `json:"dryRun,omitempty"`
+	Packages []string `json:"packages,omitempty"`
 }
 
 // ApplyResult is the Data payload for `genv apply --json` (non-dry-run).

--- a/main.go
+++ b/main.go
@@ -1220,6 +1220,11 @@ func runApplyJSON(ctx context.Context, opts applyOptions, lockPath string, f *sc
 		filePlan, filePlanErr = applyFiles(ctx, opts, f, lf)
 		if filePlanErr != nil {
 			errs = append(errs, filePlanErr.Error())
+			if !opts.NoHooks && hasPostApplyHooks(f) {
+				skipMsg := "skipping post-apply hooks due to unresolved file mismatches"
+				errs = append(errs, skipMsg)
+				fprintf(os.Stderr, "genv apply: %s\n", skipMsg)
+			}
 		} else if !opts.NoHooks {
 			failedHooks = runApplyHookPhase(ctx, f, hookContext{Event: "apply", Phase: "post-apply", Host: hostName, Profile: lf.ActiveProfile, Installed: lockedPackageIDs(execResult.Installed), Removed: execResult.Uninstalled, Failed: applyFailedIDs(execResult.Errors)}, opts.HookTimeout, true)
 			errs = append(errs, failedHooks...)
@@ -1375,6 +1380,9 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 		}
 		if appliedFiles != nil && len(appliedFiles.Mismatched) > 0 {
 			writeFileMismatchGuidance(os.Stderr, appliedFiles)
+			if !opts.NoHooks && hasPostApplyHooks(f) {
+				fPrintln(os.Stderr, "genv apply: skipping post-apply hooks due to unresolved file mismatches")
+			}
 		}
 	}
 	var hookErrs []string
@@ -1768,6 +1776,10 @@ func writeFileMismatchGuidance(w io.Writer, res *files.ApplyResult) {
 		fprintf(w, "genv apply: mismatch: %s\n", target)
 	}
 	fPrintln(w, "Hint: re-run with genv apply --force to overwrite, and add --backup (or per-entry backup: true) to preserve the existing file as *.backup.*")
+}
+
+func hasPostApplyHooks(f *schema.GenvFile) bool {
+	return f != nil && f.Hooks != nil && len(f.Hooks.PostApply) > 0
 }
 
 func filePlanEntries(res *files.ApplyResult) []output.FilePlanEntry {
@@ -2429,18 +2441,25 @@ func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (app
 }
 
 // scanCmd implements `genv scan`.
-// Discovers all packages currently installed via available package managers and
-// bulk-adopts them into genv.json and the lock file. Packages already tracked
-// are skipped. Duplicate names discovered across multiple managers are
-// deduplicated — the first adapter in registry order wins.
+// Discovers packages currently installed via available managers and adopts
+// them into genv.json and the lock file. Use --dry-run to preview; text mode
+// confirms unless --yes is set (JSON writes without a prompt, matching apply).
 var scanGOOS = runtime.GOOS
+
+type scanCandidate struct {
+	id      string
+	manager string
+	pkgName string
+	version string
+}
 
 func scanCmd(args []string) int {
 	fs := flag.NewFlagSet("scan", flag.ContinueOnError)
 	fs.Usage = func() {
 		fPrintln(os.Stderr, "usage: genv scan [flags]")
 		fPrintln(os.Stderr)
-		fPrintln(os.Stderr, "Discover all installed packages and adopt them into genv.json.")
+		fPrintln(os.Stderr, "Discover installed packages and adopt them into genv.json.")
+		fPrintln(os.Stderr, "Preview with --dry-run. Text mode prompts unless --yes is set.")
 		fPrintln(os.Stderr)
 		fPrintln(os.Stderr, "flags:")
 		fs.PrintDefaults()
@@ -2450,6 +2469,8 @@ func scanCmd(args []string) int {
 	lockFile := fs.String("lock-file", "", "path to genv lock file")
 	targetFlag := fs.String("target", "", "target ID for schemaVersion 8 (default: $GENV_TARGET or detected host target)")
 	jsonOut := fs.Bool("json", false, "emit machine-readable JSON to stdout instead of human-readable text")
+	dryRun := fs.Bool("dry-run", false, "list packages that would be adopted without writing the spec or lock")
+	yes := fs.Bool("yes", false, "skip the confirmation prompt (for CI and scripts)")
 	debug := fs.Bool("debug", false, "emit debug-level structured logs to stderr")
 
 	if err := fs.Parse(args); err != nil {
@@ -2479,7 +2500,7 @@ func scanCmd(args []string) int {
 				Version: output.SchemaVersion,
 				Command: "scan",
 				OK:      true,
-				Data:    output.ScanResult{Added: 0, Skipped: 0},
+				Data:    output.ScanResult{Added: 0, Skipped: 0, DryRun: *dryRun},
 			})
 		}
 		fPrintln(os.Stdout, "no supported package managers detected.")
@@ -2516,9 +2537,8 @@ func scanCmd(args []string) int {
 		}
 	}
 
-	// Deduplicate across managers using a seen set.
 	seen := make(map[string]bool)
-	var added int
+	var candidates []scanCandidate
 	var skipped int
 
 	for _, a := range scanAdaptersOnGOOS(available, scanGOOS) {
@@ -2549,31 +2569,66 @@ func scanCmd(args []string) int {
 
 			if trackedInSpec[pkgName] {
 				skipped++
-				continue // already in spec
-			}
-
-			// Add to spec.
-			if err := commands.Add(f, pkgName, "", "", nil, targetID); err != nil {
-				// ErrAlreadyTracked can race with trackedInSpec; skip silently.
-				skipped++
 				continue
 			}
-			trackedInSpec[pkgName] = true
 
-			// Record in lock with best-effort version capture.
-			lp := genvfile.LockedPackage{
-				ID:      pkgName,
-				Manager: a.Name(),
-				PkgName: pkgName,
-			}
+			c := scanCandidate{id: pkgName, manager: a.Name(), pkgName: pkgName}
 			if v, ok := versions[pkgName]; ok {
-				lp.InstalledVersion = v
+				c.version = v
 			} else if v, err := a.QueryVersion(pkgName); err == nil {
-				lp.InstalledVersion = v
+				c.version = v
 			}
-			lf.Packages = append(lf.Packages, lp)
-			added++
+			candidates = append(candidates, c)
+			trackedInSpec[pkgName] = true // prevent duplicate IDs across managers in this pass
 		}
+	}
+
+	if *dryRun {
+		ids := make([]string, len(candidates))
+		for i, c := range candidates {
+			ids[i] = c.id
+		}
+		if *jsonOut {
+			return writeJSON(os.Stdout, output.Envelope{
+				Version: output.SchemaVersion,
+				Command: "scan",
+				OK:      true,
+				Data:    output.ScanResult{Added: len(candidates), Skipped: skipped, DryRun: true, Packages: ids},
+			})
+		}
+		if len(candidates) == 0 && skipped == 0 {
+			fPrintln(os.Stdout, "no packages found.")
+			return exitOK
+		}
+		fprintf(os.Stdout, "scan dry-run: would adopt %d package(s), %d already tracked\n", len(candidates), skipped)
+		for _, c := range candidates {
+			fprintf(os.Stdout, "  + %s  via %s\n", c.id, c.manager)
+		}
+		return exitOK
+	}
+
+	if len(candidates) > 0 && !*jsonOut && !*yes {
+		if !confirm(fmt.Sprintf("This will adopt %d package(s) into genv.json. Continue? [y/N] ", len(candidates))) {
+			fPrintln(os.Stdout, "Aborted.")
+			return exitOK
+		}
+	}
+
+	var added int
+	for _, c := range candidates {
+		if err := commands.Add(f, c.id, "", "", nil, targetID); err != nil {
+			// ErrAlreadyTracked can race with trackedInSpec; skip silently.
+			skipped++
+			continue
+		}
+		lp := genvfile.LockedPackage{
+			ID:               c.id,
+			Manager:          c.manager,
+			PkgName:          c.pkgName,
+			InstalledVersion: c.version,
+		}
+		lf.Packages = append(lf.Packages, lp)
+		added++
 	}
 
 	if added > 0 {
@@ -4017,7 +4072,7 @@ Commands:
   disown <id> Stop tracking a package in genv.json without uninstalling it
   list        List all packages installed by genv                   (alias: ls)
   apply       Reconcile system state with genv.json (install added, remove deleted)
-  scan        Discover all installed packages and bulk-adopt them into genv.json
+  scan        Discover installed packages and bulk-adopt them (use --dry-run / --yes)
   status      Show diff between genv.json, the lock file, and recorded versions
   clean       Clear the cache of all detected package managers
   edit        Open genv.json in $EDITOR

--- a/main_apply_files_test.go
+++ b/main_apply_files_test.go
@@ -129,3 +129,48 @@ func TestApply_ForceBackupFlagBacksUpWithoutPerEntryBackup(t *testing.T) {
 		t.Fatalf("expected one backup file, got %v", matches)
 	}
 }
+
+func TestApply_FileMismatchSkipsPostApplyHooksWithMessage(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	t.Setenv("HOME", dir)
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	goodSource := filepath.Join(dir, "good-src.txt")
+	goodTarget := filepath.Join(dir, "good-tgt.txt")
+	badSource := filepath.Join(dir, "bad-src.txt")
+	badTarget := filepath.Join(dir, "bad-tgt.txt")
+	hookLog := filepath.Join(dir, "hook.log")
+
+	writeTestFile(t, goodSource, "good\n")
+	writeTestFile(t, badSource, "desired\n")
+	writeTestFile(t, badTarget, "blocking\n")
+	writeTestFile(t, specPath, `{
+		"schemaVersion":"6",
+		"files":{"links":[
+			{"source":"`+goodSource+`","target":"`+goodTarget+`","mode":"link"},
+			{"source":"`+badSource+`","target":"`+badTarget+`","mode":"link"}
+		]},
+		"hooks":{"postApply":[{"command":"printf ran >> `+hookLog+`"}]}
+	}`)
+
+	var code int
+	var stderr string
+	_ = captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			code = run([]string{"apply", "--file", specPath, "--lock-file", lockPath, "--yes"})
+		})
+	})
+	if code != exitLogic {
+		t.Fatalf("expected exitLogic, got %d; stderr=%s", code, stderr)
+	}
+	if _, err := os.Lstat(goodTarget); err != nil {
+		t.Fatalf("good link should still be created: %v", err)
+	}
+	if _, err := os.Stat(hookLog); !os.IsNotExist(err) {
+		t.Fatalf("post-apply hook should not run on unresolved mismatch; err=%v", err)
+	}
+	if !strings.Contains(stderr, "skipping post-apply hooks") || !strings.Contains(stderr, "mismatch") {
+		t.Fatalf("stderr should explain skipped hooks due to mismatches; got %q", stderr)
+	}
+}

--- a/main_scan_dryrun_test.go
+++ b/main_scan_dryrun_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ks1686/genv/internal/adapter"
+	"github.com/ks1686/genv/internal/genvfile"
+)
+
+func TestScanCmd_DryRunDoesNotWriteSpec(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+
+	snap := &scanManagerNameAdapter{name: "snap", installed: []string{"jq", "ripgrep"}}
+	originalAll := adapter.All
+	adapter.All = []adapter.Adapter{snap}
+	t.Cleanup(func() { adapter.All = originalAll })
+
+	var code int
+	out := captureStdout(t, func() {
+		code = run([]string{"scan", "--file", path, "--lock-file", lockPath, "--dry-run"})
+	})
+	if code != exitOK {
+		t.Fatalf("scan --dry-run: expected exitOK (%d), got %d\n%s", exitOK, code, out)
+	}
+	if !strings.Contains(out, "jq") || !strings.Contains(out, "ripgrep") {
+		t.Fatalf("dry-run should list would-adopt packages; got %q", out)
+	}
+	if !strings.Contains(out, "dry-run") && !strings.Contains(out, "would adopt") {
+		t.Fatalf("dry-run output should say it is a preview; got %q", out)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("dry-run must not create genv.json; err=%v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("dry-run must not create lock; err=%v", err)
+	}
+}
+
+func TestScanCmd_DryRunJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+
+	snap := &scanManagerNameAdapter{name: "snap", installed: []string{"jq"}}
+	originalAll := adapter.All
+	adapter.All = []adapter.Adapter{snap}
+	t.Cleanup(func() { adapter.All = originalAll })
+
+	var code int
+	out := captureStdout(t, func() {
+		code = run([]string{"scan", "--file", path, "--lock-file", lockPath, "--dry-run", "--json"})
+	})
+	if code != exitOK {
+		t.Fatalf("scan --dry-run --json: expected exitOK, got %d\n%s", code, out)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(out), &raw); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if raw["ok"] != true || raw["command"] != "scan" {
+		t.Fatalf("envelope = %+v", raw)
+	}
+	data, _ := raw["data"].(map[string]any)
+	if data["added"] != float64(1) {
+		t.Fatalf("data.added = %v, want 1", data["added"])
+	}
+	if data["dryRun"] != true {
+		t.Fatalf("data.dryRun = %v, want true", data["dryRun"])
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("dry-run --json must not write spec")
+	}
+}
+
+func TestScanCmd_RequiresConfirmationWithoutYes(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+
+	snap := &scanManagerNameAdapter{name: "snap", installed: []string{"jq"}}
+	originalAll := adapter.All
+	adapter.All = []adapter.Adapter{snap}
+	t.Cleanup(func() { adapter.All = originalAll })
+
+	var code int
+	out := captureStdout(t, func() {
+		code = run([]string{"scan", "--file", path, "--lock-file", lockPath})
+	})
+	if code != exitOK {
+		t.Fatalf("scan without --yes: expected exitOK (abort), got %d\n%s", code, out)
+	}
+	if !strings.Contains(out, "Aborted") && !strings.Contains(out, "Continue") {
+		t.Fatalf("expected confirmation abort; got %q", out)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("declined scan must not write genv.json")
+	}
+}
+
+func TestScanCmd_YesWritesSpec(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+
+	snap := &scanManagerNameAdapter{name: "snap", installed: []string{"jq"}}
+	originalAll := adapter.All
+	adapter.All = []adapter.Adapter{snap}
+	t.Cleanup(func() { adapter.All = originalAll })
+
+	code := run([]string{"scan", "--file", path, "--lock-file", lockPath, "--yes"})
+	if code != exitOK {
+		t.Fatalf("scan --yes: expected exitOK, got %d", code)
+	}
+	f, err := genvfile.Read(path)
+	if err != nil {
+		t.Fatalf("read spec: %v", err)
+	}
+	if len(f.Packages) != 1 || f.Packages[0].ID != "jq" {
+		t.Fatalf("packages = %+v, want jq", f.Packages)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1247,7 +1247,7 @@ func TestScanCmd_V8WritesActiveTarget(t *testing.T) {
 	adapter.All = []adapter.Adapter{snap}
 	t.Cleanup(func() { adapter.All = originalAll })
 
-	code := run([]string{"scan", "--file", path, "--lock-file", lockPath, "--target", "arch"})
+	code := run([]string{"scan", "--file", path, "--lock-file", lockPath, "--target", "arch", "--yes"})
 	if code != exitOK {
 		t.Fatalf("scan: expected exitOK (%d), got %d", exitOK, code)
 	}
@@ -1373,7 +1373,6 @@ func TestScanCmd_DarwinDoesNotListLinuxbrew(t *testing.T) {
 	})
 
 	code := run([]string{"scan", "--file", path})
-
 	if code != exitOK {
 		t.Fatalf("scan: expected exitOK (%d), got %d", exitOK, code)
 	}
@@ -1432,7 +1431,7 @@ func TestScanCmd_UsesVersionListerWithoutPerPackageVersionQueries(t *testing.T) 
 	adapter.All = []adapter.Adapter{batch}
 	t.Cleanup(func() { adapter.All = originalAll })
 
-	code := run([]string{"scan", "--file", path})
+	code := run([]string{"scan", "--file", path, "--yes"})
 	if code != exitOK {
 		t.Fatalf("scan: expected exitOK (%d), got %d", exitOK, code)
 	}


### PR DESCRIPTION
## Summary
- Print an explicit message when post-apply hooks are skipped because of unresolved file mismatches (services still run before files)
- Add `genv scan --dry-run` and text-mode confirmation unless `--yes` (JSON still writes without a prompt)

## Test plan
- [x] Focused apply/scan tests
- [x] `go test ./...` + `make ci`
- [ ] GitHub CI green
- [ ] Tag `v4.0.3` after merge