### PR TITLE
Harden Release AUR publish + aur-only repair

### DIFF
--- a/.github/scripts/aur-common.sh
+++ b/.github/scripts/aur-common.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Shared helpers for AUR publish scripts.
+# shellcheck shell=bash
+
+aur_setup_ssh() {
+	mkdir -p ~/.ssh
+	printf '%s\n' "${AUR_KEY}" > ~/.ssh/aur
+	chmod 600 ~/.ssh/aur
+	# Refresh host keys; tolerate transient ssh-keyscan failures.
+	local attempt=1
+	while (( attempt <= 5 )); do
+		if ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null; then
+			break
+		fi
+		if (( attempt == 5 )); then
+			echo "aur-common: ssh-keyscan failed after ${attempt} attempts" >&2
+			return 1
+		fi
+		sleep $((attempt * 3))
+		attempt=$((attempt + 1))
+	done
+	export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o StrictHostKeyChecking=yes -o ConnectTimeout=30"
+}
+
+# Clone an AUR package repo with retries (aur.archlinux.org often drops SSH).
+aur_clone() {
+	local pkg="$1"
+	local dest="$2"
+	local attempt=1
+	local delay=5
+	while (( attempt <= 6 )); do
+		rm -rf "${dest}"
+		if git clone "ssh://aur@aur.archlinux.org/${pkg}.git" "${dest}"; then
+			return 0
+		fi
+		echo "aur-common: clone ${pkg} attempt ${attempt} failed; retrying in ${delay}s..." >&2
+		sleep "${delay}"
+		delay=$((delay * 2))
+		attempt=$((attempt + 1))
+	done
+	echo "aur-common: clone ${pkg} failed after retries" >&2
+	return 1
+}
+
+aur_push() {
+	local attempt=1
+	local delay=5
+	while (( attempt <= 6 )); do
+		if git push origin master; then
+			return 0
+		fi
+		echo "aur-common: push attempt ${attempt} failed; retrying in ${delay}s..." >&2
+		sleep "${delay}"
+		delay=$((delay * 2))
+		attempt=$((attempt + 1))
+	done
+	echo "aur-common: push failed after retries" >&2
+	return 1
+}

--- a/.github/scripts/publish-aur-src.sh
+++ b/.github/scripts/publish-aur-src.sh
@@ -5,6 +5,10 @@
 # Requires: AUR_KEY env var containing the SSH private key.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=aur-common.sh
+source "${SCRIPT_DIR}/aur-common.sh"
+
 VERSION="$1"
 PKGBASE="genv"
 REPO="https://github.com/ks1686/genv"
@@ -14,14 +18,10 @@ curl -fsSL "${REPO}/archive/refs/tags/v${VERSION}.tar.gz" -o /tmp/genv-src.tar.g
 SHA256SRC=$(sha256sum /tmp/genv-src.tar.gz | awk '{print $1}')
 
 # ── SSH setup ─────────────────────────────────────────────────────────────────
-mkdir -p ~/.ssh
-printf '%s\n' "${AUR_KEY}" > ~/.ssh/aur
-chmod 600 ~/.ssh/aur
-ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
-export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o StrictHostKeyChecking=yes"
+aur_setup_ssh
 
 # ── Clone AUR repo ────────────────────────────────────────────────────────────
-git clone "ssh://aur@aur.archlinux.org/${PKGBASE}.git" /tmp/aur-src-pkg
+aur_clone "${PKGBASE}" /tmp/aur-src-pkg
 cd /tmp/aur-src-pkg
 
 # ── Generate PKGBUILD ─────────────────────────────────────────────────────────
@@ -87,4 +87,4 @@ git config user.name  "ks1686"
 git config user.email "ks1686@users.noreply.github.com"
 git add PKGBUILD .SRCINFO
 git diff --cached --quiet || git commit -m "Update to ${VERSION}"
-git push origin master
+aur_push

--- a/.github/scripts/publish-aur.sh
+++ b/.github/scripts/publish-aur.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# Publishes a PKGBUILD and .SRCINFO to the AUR for the genv package.
+# Publishes a PKGBUILD and .SRCINFO to the AUR for the genv-bin package.
 # Usage: publish-aur.sh <version>   (version without leading 'v', e.g. 0.2.0)
 # Requires: AUR_KEY env var containing the SSH private key.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=aur-common.sh
+source "${SCRIPT_DIR}/aur-common.sh"
 
 VERSION="$1"
 PKGBASE="genv-bin"
@@ -15,14 +19,10 @@ SHA256_AMD64=$(grep "genv_${VERSION}_linux_amd64.tar.gz" /tmp/checksums.txt | aw
 SHA256_ARM64=$(grep "genv_${VERSION}_linux_arm64.tar.gz" /tmp/checksums.txt  | awk '{print $1}')
 
 # ── SSH setup ─────────────────────────────────────────────────────────────────
-mkdir -p ~/.ssh
-printf '%s\n' "${AUR_KEY}" > ~/.ssh/aur
-chmod 600 ~/.ssh/aur
-ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
-export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o StrictHostKeyChecking=yes"
+aur_setup_ssh
 
 # ── Clone AUR repo ────────────────────────────────────────────────────────────
-git clone "ssh://aur@aur.archlinux.org/${PKGBASE}.git" /tmp/aur-pkg
+aur_clone "${PKGBASE}" /tmp/aur-pkg
 cd /tmp/aur-pkg
 
 # ── Generate PKGBUILD ─────────────────────────────────────────────────────────
@@ -88,4 +88,4 @@ git config user.name  "ks1686"
 git config user.email "ks1686@users.noreply.github.com"
 git add PKGBUILD .SRCINFO
 git diff --cached --quiet || git commit -m "Update to ${VERSION}"
-git push origin master
+aur_push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,21 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: "full = GoReleaser + AUR; aur-only = republish AUR for an existing GitHub release"
+        type: choice
+        options:
+          - full
+          - aur-only
+        default: full
+      version:
+        description: "Semver without leading v (required for aur-only, e.g. 4.0.3)"
+        required: false
+        type: string
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: write
@@ -16,27 +28,73 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Resolve checkout ref
+        id: ref
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.mode }}" = "aur-only" ]; then
+            version="${{ github.event.inputs.version }}"
+            version="${version#v}"
+            if [ -z "$version" ]; then
+              echo "aur-only requires the version input" >&2
+              exit 1
+            fi
+            echo "ref=v${version}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ steps.ref.outputs.ref }}
+
+      - name: Resolve mode and version
+        id: meta
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            mode="full"
+            version="${GITHUB_REF_NAME#v}"
+          else
+            mode="${{ github.event.inputs.mode }}"
+            version="${{ github.event.inputs.version }}"
+            version="${version#v}"
+            if [ -z "$version" ]; then
+              version="$(git describe --tags --abbrev=0)"
+              version="${version#v}"
+            fi
+          fi
+          if [ -z "$version" ]; then
+            echo "could not resolve release version" >&2
+            exit 1
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved mode=$mode version=$version"
 
       - name: Set up Go
+        if: steps.meta.outputs.mode == 'full'
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
 
       - name: Install cosign
+        if: steps.meta.outputs.mode == 'full'
         uses: sigstore/cosign-installer@v3
 
       - name: Install snapcraft
+        if: steps.meta.outputs.mode == 'full'
         run: sudo snap install snapcraft --classic
 
       - name: Run unit test suite
+        if: steps.meta.outputs.mode == 'full'
         run: go test ./...
 
       - name: Run GoReleaser
+        if: steps.meta.outputs.mode == 'full'
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
@@ -48,15 +106,13 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
 
       - name: Publish to AUR (genv-bin, pre-compiled binary)
-        if: "!contains(github.ref_name, '-')"
+        if: "!contains(steps.meta.outputs.version, '-')"
         env:
           AUR_KEY: ${{ secrets.AUR_KEY }}
-          VERSION: ${{ github.ref_name }}
-        run: bash .github/scripts/publish-aur.sh "${VERSION#v}"
+        run: bash .github/scripts/publish-aur.sh "${{ steps.meta.outputs.version }}"
 
       - name: Publish to AUR (genv, builds from source)
-        if: "!contains(github.ref_name, '-')"
+        if: "!contains(steps.meta.outputs.version, '-')"
         env:
           AUR_KEY: ${{ secrets.AUR_KEY }}
-          VERSION: ${{ github.ref_name }}
-        run: bash .github/scripts/publish-aur-src.sh "${VERSION#v}"
+        run: bash .github/scripts/publish-aur-src.sh "${{ steps.meta.outputs.version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Release workflow: AUR publish retries transient `aur.archlinux.org` SSH drops, and `workflow_dispatch` supports `aur-only` repair for an existing GitHub release without re-running GoReleaser.
+
 ## v4.0.3 - 2026-07-26
 
 ### Fixed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -214,6 +214,15 @@ paru -S genv       # builds from source
    - Push the Homebrew formula to `ks1686/homebrew-tap`
    - Push updated PKGBUILDs to AUR (`genv-bin` pre-compiled and `genv` source)
 
+   If GitHub/Homebrew succeeded but AUR failed (transient `aur.archlinux.org` SSH),
+   do **not** re-run the whole Release job (GoReleaser will hit `already_exists`).
+   Instead dispatch an AUR-only repair:
+
+   ```bash
+   gh workflow run Release -f mode=aur-only -f version=4.0.3
+   gh run watch  # pick the new run
+   ```
+
 6. **Verify** by downloading one artifact and running:
 
    ```bash


### PR DESCRIPTION
## Summary
- Retry AUR clone/push on transient `aur.archlinux.org` SSH failures
- Add `workflow_dispatch` `aur-only` mode so a partial release (GitHub/Homebrew OK, AUR failed) can be repaired without re-running GoReleaser

## Test plan
- [ ] Merge to main
- [ ] `gh workflow run Release -f mode=aur-only -f version=4.0.3`
- [ ] Confirm Release job green and AUR `genv`/`genv-bin` at 4.0.3