### PR TITLE
Prefer PATH-stable genv path for updates scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `genv updates start` prefers a PATH-stable self path (e.g. Homebrew `bin/genv`) over a version-pinned Caskroom path from `os.Executable` / cask `post_install`, so the updates LaunchAgent/systemd unit survives upgrades. `updates status` warns and `validate` fails when genv-managed agents point at a missing executable.
 - Release workflow: AUR publish retries transient `aur.archlinux.org` SSH drops, and `workflow_dispatch` supports `aur-only` repair for an existing GitHub release without re-running GoReleaser.
 
 ## v4.0.3 - 2026-07-26

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Convenience commands (`add` / `remove` / `adopt` / `disown` / `scan`) update the
 | `list` (`ls`) | Show lock-tracked packages |
 | `status` | Spec ↔ lock drift (`--files`, `--target`) |
 | `apply` | Reconcile (`--dry-run`, `--yes`, `--json`, `--force`, `--backup`, `--target`, `--force-new-lock`) |
-| `validate` | Validate spec only |
+| `validate` | Validate spec + genv-managed agent executables |
 | `upgrade` | Upgrade outdated tracked packages (`--all`, `--target`) |
 | `updates` | Background checker (`check` / `start` / `stop` / `status`; `--target` on check/start) |
 | `profile` | Named overlays (`list` / `create` / `switch`) |

--- a/internal/selfpath/selfpath.go
+++ b/internal/selfpath/selfpath.go
@@ -1,0 +1,56 @@
+// Package selfpath chooses an invocation path for the running binary that
+// survives package-manager upgrades when a stable symlink is available.
+package selfpath
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// PreferStable returns a path that refers to the same file as exe when possible,
+// preferring a PATH hit for filepath.Base(exe) over a version-pinned install
+// path (e.g. Homebrew Caskroom/.../<version>/genv used by cask post_install).
+//
+// lookPath defaults to exec.LookPath when nil. If no same-file PATH candidate
+// exists, exe is returned unchanged.
+func PreferStable(exe, arg0 string, lookPath func(string) (string, error)) string {
+	if exe == "" {
+		return exe
+	}
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	base := filepath.Base(exe)
+	if base != "" && base != "." {
+		if p, err := lookPath(base); err == nil && sameFile(p, exe) {
+			return p
+		}
+	}
+	if arg0 != "" && arg0 != exe {
+		cand := arg0
+		if !filepath.IsAbs(cand) {
+			p, err := lookPath(cand)
+			if err != nil {
+				return exe
+			}
+			cand = p
+		}
+		if sameFile(cand, exe) {
+			return cand
+		}
+	}
+	return exe
+}
+
+func sameFile(a, b string) bool {
+	fa, err := os.Stat(a)
+	if err != nil {
+		return false
+	}
+	fb, err := os.Stat(b)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(fa, fb)
+}

--- a/internal/selfpath/selfpath_test.go
+++ b/internal/selfpath/selfpath_test.go
@@ -1,0 +1,158 @@
+package selfpath
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPreferStable_prefersPATHLookupOverVersionedCaskroomPath(t *testing.T) {
+	dir := t.TempDir()
+	caskroom := filepath.Join(dir, "Caskroom", "genv", "4.0.3")
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(caskroom, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realBin := filepath.Join(caskroom, "genv")
+	if err := os.WriteFile(realBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stable := filepath.Join(binDir, "genv")
+	if err := os.Symlink(realBin, stable); err != nil {
+		t.Fatal(err)
+	}
+
+	lookPath := func(file string) (string, error) {
+		if file == "genv" {
+			return stable, nil
+		}
+		return "", os.ErrNotExist
+	}
+
+	// Simulate Homebrew cask post_install: process started via staged_path.
+	got := PreferStable(realBin, realBin, lookPath)
+	if got != stable {
+		t.Fatalf("PreferStable = %q, want stable symlink %q", got, stable)
+	}
+}
+
+func TestPreferStable_doesNotPreferDifferentBinaryOnPATH(t *testing.T) {
+	dir := t.TempDir()
+	running := filepath.Join(dir, "build", "genv")
+	other := filepath.Join(dir, "bin", "genv")
+	if err := os.MkdirAll(filepath.Dir(running), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(other), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(running, []byte("a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(other, []byte("b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lookPath := func(file string) (string, error) {
+		if file == "genv" {
+			return other, nil
+		}
+		return "", os.ErrNotExist
+	}
+
+	got := PreferStable(running, running, lookPath)
+	if got != running {
+		t.Fatalf("PreferStable = %q, want running binary %q (PATH hit is a different inode)", got, running)
+	}
+}
+
+func TestPreferStable_keepsUnresolvedStablePathWhenAlreadyStable(t *testing.T) {
+	dir := t.TempDir()
+	caskroom := filepath.Join(dir, "Caskroom", "genv", "4.0.3")
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(caskroom, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realBin := filepath.Join(caskroom, "genv")
+	if err := os.WriteFile(realBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stable := filepath.Join(binDir, "genv")
+	if err := os.Symlink(realBin, stable); err != nil {
+		t.Fatal(err)
+	}
+
+	lookPath := func(file string) (string, error) {
+		if file == "genv" {
+			return stable, nil
+		}
+		return "", os.ErrNotExist
+	}
+
+	got := PreferStable(stable, stable, lookPath)
+	if got != stable {
+		t.Fatalf("PreferStable = %q, want %q", got, stable)
+	}
+}
+
+func TestPreferStable_fallsBackWhenNotOnPATH(t *testing.T) {
+	dir := t.TempDir()
+	running := filepath.Join(dir, "genv")
+	if err := os.WriteFile(running, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lookPath := func(string) (string, error) { return "", os.ErrNotExist }
+	got := PreferStable(running, running, lookPath)
+	if got != running {
+		t.Fatalf("PreferStable = %q, want %q", got, running)
+	}
+}
+
+func TestPreferStable_emptyExe(t *testing.T) {
+	if got := PreferStable("", "/bin/genv", nil); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestPreferStable_nilLookPathUsesExecLookPath(t *testing.T) {
+	// Cover the nil lookPath default without asserting a specific PATH hit:
+	// when LookPath fails or points elsewhere, PreferStable returns exe.
+	dir := t.TempDir()
+	running := filepath.Join(dir, "unique-genv-not-on-path-"+filepath.Base(t.TempDir()))
+	if err := os.WriteFile(running, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got := PreferStable(running, running, nil)
+	if got != running {
+		t.Fatalf("PreferStable = %q, want %q", got, running)
+	}
+}
+
+func TestPreferStable_prefersAbsoluteArg0WhenSameFile(t *testing.T) {
+	dir := t.TempDir()
+	realBin := filepath.Join(dir, "real", "genv")
+	link := filepath.Join(dir, "link", "genv")
+	if err := os.MkdirAll(filepath.Dir(realBin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(realBin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realBin, link); err != nil {
+		t.Fatal(err)
+	}
+	lookPath := func(string) (string, error) { return "", os.ErrNotExist }
+	got := PreferStable(realBin, link, lookPath)
+	if got != link {
+		t.Fatalf("PreferStable = %q, want arg0 symlink %q", got, link)
+	}
+}

--- a/internal/service/agent_health.go
+++ b/internal/service/agent_health.go
@@ -1,0 +1,184 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// AgentProgramIssue describes a genv-managed supervisor artifact whose primary
+// executable path is missing or not executable.
+type AgentProgramIssue struct {
+	Label  string
+	Path   string
+	Detail string
+}
+
+var (
+	launchdProgramArgsRE = regexp.MustCompile(`(?s)<key>ProgramArguments</key>\s*<array>\s*<string>([^<]*)</string>`)
+	systemdExecStartRE   = regexp.MustCompile(`(?m)^ExecStart=(.*)$`)
+)
+
+// FirstLaunchdProgramArgument returns ProgramArguments[0] from a launchd plist.
+func FirstLaunchdProgramArgument(plist []byte) (string, error) {
+	m := launchdProgramArgsRE.FindSubmatch(plist)
+	if m == nil {
+		return "", fmt.Errorf("ProgramArguments not found")
+	}
+	return string(m[1]), nil
+}
+
+// FirstSystemdExecStartArgument returns the first ExecStart token from a unit file.
+func FirstSystemdExecStartArgument(unit string) (string, error) {
+	m := systemdExecStartRE.FindStringSubmatch(unit)
+	if m == nil {
+		return "", fmt.Errorf("ExecStart not found")
+	}
+	toks := splitSystemdExecStart(m[1])
+	if len(toks) == 0 || toks[0] == "" {
+		return "", fmt.Errorf("ExecStart has no command")
+	}
+	return toks[0], nil
+}
+
+func splitSystemdExecStart(line string) []string {
+	line = strings.TrimSpace(line)
+	var out []string
+	for len(line) > 0 {
+		if line[0] == '"' {
+			end := 1
+			for end < len(line) {
+				if line[end] == '\\' && end+1 < len(line) {
+					end += 2
+					continue
+				}
+				if line[end] == '"' {
+					break
+				}
+				end++
+			}
+			if end >= len(line) {
+				out = append(out, unescapeSystemdArg(line[1:]))
+				break
+			}
+			out = append(out, unescapeSystemdArg(line[1:end]))
+			line = strings.TrimSpace(line[end+1:])
+			continue
+		}
+		sp := strings.IndexByte(line, ' ')
+		if sp < 0 {
+			out = append(out, line)
+			break
+		}
+		out = append(out, line[:sp])
+		line = strings.TrimSpace(line[sp+1:])
+	}
+	return out
+}
+
+func unescapeSystemdArg(s string) string {
+	s = strings.ReplaceAll(s, `\"`, `"`)
+	return strings.ReplaceAll(s, `\\`, `\`)
+}
+
+// ExecutablePathStatus reports whether path exists and is executable by the current user.
+func ExecutablePathStatus(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("empty executable path")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%q is a directory", path)
+	}
+	mode := info.Mode()
+	if mode&0o111 == 0 {
+		return fmt.Errorf("%q is not executable", path)
+	}
+	return nil
+}
+
+// ListManagedAgentProgramIssues scans genv-managed launchd plists and systemd
+// units under home for primary executables that are missing or not executable.
+func ListManagedAgentProgramIssues(home string) []AgentProgramIssue {
+	var issues []AgentProgramIssue
+	issues = append(issues, launchdAgentProgramIssues(home)...)
+	issues = append(issues, systemdAgentProgramIssues(home)...)
+	return issues
+}
+
+func launchdAgentProgramIssues(home string) []AgentProgramIssue {
+	agentDir := filepath.Join(home, "Library", "LaunchAgents")
+	entries, err := os.ReadDir(agentDir)
+	if err != nil {
+		return nil
+	}
+	var issues []AgentProgramIssue
+	for _, ent := range entries {
+		name := ent.Name()
+		if ent.IsDir() || !strings.HasPrefix(name, "genv.") || !strings.HasSuffix(name, ".plist") {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(agentDir, name))
+		if err != nil {
+			continue
+		}
+		prog, err := FirstLaunchdProgramArgument(content)
+		if err != nil || prog == "" {
+			continue
+		}
+		// Skip sentinel commands used by placeholder services.
+		if prog == "true" || prog == "/usr/bin/true" || prog == "/bin/true" {
+			continue
+		}
+		if err := ExecutablePathStatus(prog); err != nil {
+			label := strings.TrimSuffix(name, ".plist")
+			issues = append(issues, AgentProgramIssue{
+				Label:  label,
+				Path:   prog,
+				Detail: fmt.Sprintf("%s ProgramArguments[0]=%q: %v", label, prog, err),
+			})
+		}
+	}
+	return issues
+}
+
+func systemdAgentProgramIssues(home string) []AgentProgramIssue {
+	unitDir := filepath.Join(home, ".config", "systemd", "user")
+	entries, err := os.ReadDir(unitDir)
+	if err != nil {
+		return nil
+	}
+	var issues []AgentProgramIssue
+	for _, ent := range entries {
+		name := ent.Name()
+		if ent.IsDir() || !strings.HasPrefix(name, "genv-") || !strings.HasSuffix(name, ".service") {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(unitDir, name))
+		if err != nil {
+			continue
+		}
+		prog, err := FirstSystemdExecStartArgument(string(content))
+		if err != nil || prog == "" {
+			continue
+		}
+		if prog == "true" || prog == "/usr/bin/true" || prog == "/bin/true" {
+			continue
+		}
+		if err := ExecutablePathStatus(prog); err != nil {
+			label := strings.TrimSuffix(name, ".service")
+			issues = append(issues, AgentProgramIssue{
+				Label:  label,
+				Path:   prog,
+				Detail: fmt.Sprintf("%s ExecStart[0]=%q: %v", label, prog, err),
+			})
+		}
+	}
+	return issues
+}

--- a/internal/service/agent_health_test.go
+++ b/internal/service/agent_health_test.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ks1686/genv/internal/schema"
+)
+
+func TestFirstLaunchdProgramArgument(t *testing.T) {
+	plist := LaunchdScheduledPlistContent("updates", []string{"/opt/homebrew/bin/genv", "updates", "__run-once"}, time.Hour, nil)
+	got, err := FirstLaunchdProgramArgument([]byte(plist))
+	if err != nil {
+		t.Fatalf("FirstLaunchdProgramArgument: %v", err)
+	}
+	if got != "/opt/homebrew/bin/genv" {
+		t.Fatalf("got %q, want /opt/homebrew/bin/genv", got)
+	}
+}
+
+func TestFirstSystemdExecStartArgument(t *testing.T) {
+	unit := SystemdScheduledUnitContent("updates", []string{"/usr/local/bin/genv", "updates", "__run-once"}, nil)
+	got, err := FirstSystemdExecStartArgument(unit)
+	if err != nil {
+		t.Fatalf("FirstSystemdExecStartArgument: %v", err)
+	}
+	if got != "/usr/local/bin/genv" {
+		t.Fatalf("got %q, want /usr/local/bin/genv", got)
+	}
+}
+
+func TestExecutablePathStatus_missing(t *testing.T) {
+	err := ExecutablePathStatus(filepath.Join(t.TempDir(), "missing-bin"))
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+}
+
+func TestExecutablePathStatus_ok(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bin")
+	if err := os.WriteFile(path, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ExecutablePathStatus(path); err != nil {
+		t.Fatalf("ExecutablePathStatus: %v", err)
+	}
+}
+
+func TestListManagedAgentProgramIssues_reportsMissingLaunchdArgv0(t *testing.T) {
+	home := t.TempDir()
+	agentDir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(home, "gone", "genv")
+	plist := LaunchdScheduledPlistContent("updates", []string{missing, "updates", "__run-once"}, time.Hour, nil)
+	if err := os.WriteFile(filepath.Join(agentDir, "genv.updates.plist"), []byte(plist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Non-genv agent should be ignored.
+	if err := os.WriteFile(filepath.Join(agentDir, "com.example.other.plist"), []byte(plist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Placeholder true command should be ignored.
+	truePlist := LaunchdPlistContent("mod-svc", schemaServiceTrue())
+	if err := os.WriteFile(filepath.Join(agentDir, "genv.mod-svc.plist"), []byte(truePlist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	issues := ListManagedAgentProgramIssues(home)
+	if len(issues) != 1 {
+		t.Fatalf("issues = %#v, want one", issues)
+	}
+	if issues[0].Label != "genv.updates" || !strings.Contains(issues[0].Detail, missing) {
+		t.Fatalf("issue = %#v, want genv.updates missing path", issues[0])
+	}
+}
+
+func TestListManagedAgentProgramIssues_reportsMissingSystemdExecStart(t *testing.T) {
+	home := t.TempDir()
+	unitDir := filepath.Join(home, ".config", "systemd", "user")
+	if err := os.MkdirAll(unitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(home, "gone", "genv")
+	unit := SystemdScheduledUnitContent("updates", []string{missing, "updates", "__run-once"}, nil)
+	if err := os.WriteFile(filepath.Join(unitDir, "genv-updates.service"), []byte(unit), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(unitDir, "other.service"), []byte(unit), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	issues := ListManagedAgentProgramIssues(home)
+	if len(issues) != 1 {
+		t.Fatalf("issues = %#v, want one", issues)
+	}
+	if issues[0].Label != "genv-updates" || !strings.Contains(issues[0].Detail, missing) {
+		t.Fatalf("issue = %#v, want genv-updates missing path", issues[0])
+	}
+}
+
+func TestFirstLaunchdProgramArgument_missing(t *testing.T) {
+	if _, err := FirstLaunchdProgramArgument([]byte(`<plist></plist>`)); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFirstSystemdExecStartArgument_variants(t *testing.T) {
+	got, err := FirstSystemdExecStartArgument("ExecStart=/usr/bin/true\n")
+	if err != nil || got != "/usr/bin/true" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+	got, err = FirstSystemdExecStartArgument(`ExecStart="/usr/bin/env" "genv" "updates"`)
+	if err != nil || got != "/usr/bin/env" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+	if _, err := FirstSystemdExecStartArgument("Description=no exec\n"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestExecutablePathStatus_emptyAndDirectory(t *testing.T) {
+	if err := ExecutablePathStatus("  "); err == nil {
+		t.Fatal("expected empty path error")
+	}
+	dir := t.TempDir()
+	if err := ExecutablePathStatus(dir); err == nil {
+		t.Fatal("expected directory error")
+	}
+	path := filepath.Join(dir, "noexec")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ExecutablePathStatus(path); err == nil {
+		t.Fatal("expected not-executable error")
+	}
+}
+
+func schemaServiceTrue() schema.Service {
+	return schema.Service{Start: []string{"true"}}
+}

--- a/main.go
+++ b/main.go
@@ -3377,11 +3377,14 @@ func completeInternalCmd(args []string) int {
 }
 
 // validateCmd implements `genv validate`.
-// Reads and validates genv.json, exiting 0 on success and 3 on any error.
+// Reads and validates genv.json, then fails if any genv-managed launchd/systemd
+// agent points at a missing or non-executable ProgramArguments[0]/ExecStart.
 func validateCmd(args []string) int {
 	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
 	fs.Usage = func() {
 		fPrintln(os.Stderr, "usage: genv validate [flags]")
+		fPrintln(os.Stderr)
+		fPrintln(os.Stderr, "Validates genv.json and checks genv-managed supervisor agents for dangling executables.")
 		fPrintln(os.Stderr)
 		fPrintln(os.Stderr, "flags:")
 		fs.PrintDefaults()
@@ -3401,6 +3404,15 @@ func validateCmd(args []string) int {
 		return exitValidation
 	}
 	fprintf(os.Stdout, "%s is valid.\n", *file)
+	if home, homeErr := managedAgentHomeDir(); homeErr == nil {
+		if issues := service.ListManagedAgentProgramIssues(home); len(issues) > 0 {
+			for _, issue := range issues {
+				fprintf(os.Stderr, "genv validate: %s\n", issue.Detail)
+			}
+			fPrintln(os.Stderr, "Hint: re-run genv updates start (and re-apply services) so supervisor artifacts point at a live executable")
+			return exitValidation
+		}
+	}
 	return exitOK
 }
 

--- a/main_coverage_extra_test.go
+++ b/main_coverage_extra_test.go
@@ -13,6 +13,9 @@ import (
 func TestValidateCmd_ValidInvalidAndMissing(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	originalHome := managedAgentHomeDir
+	managedAgentHomeDir = func() (string, error) { return t.TempDir(), nil }
+	t.Cleanup(func() { managedAgentHomeDir = originalHome })
 	valid := filepath.Join(dir, "valid.json")
 	if err := os.WriteFile(valid, []byte(`{"schemaVersion":"6","packages":[]}`), 0o644); err != nil {
 		t.Fatalf("write valid spec: %v", err)

--- a/main_test.go
+++ b/main_test.go
@@ -2504,6 +2504,9 @@ func TestUpdatesStart_valid_config_registers_scheduler_without_auto_apply(t *tes
 	originalExecutable := updatesExecutable
 	updatesExecutable = func() (string, error) { return "/tmp/genv-test-bin", nil }
 	t.Cleanup(func() { updatesExecutable = originalExecutable })
+	originalLookPath := updatesSelfLookPath
+	updatesSelfLookPath = func(string) (string, error) { return "", os.ErrNotExist }
+	t.Cleanup(func() { updatesSelfLookPath = originalLookPath })
 	invokingPath := "/custom/bin:relative:/usr/bin:/custom/bin"
 	t.Setenv("PATH", invokingPath)
 
@@ -2534,6 +2537,124 @@ func TestUpdatesStart_valid_config_registers_scheduler_without_auto_apply(t *tes
 	}
 	if !strings.Contains(out, "check/log/notify only") || strings.Contains(out, "auto-apply enabled") {
 		t.Fatalf("stdout = %q, want explicit default check-only mode", out)
+	}
+}
+
+func TestUpdatesStart_prefers_stable_PATH_executable_over_caskroom(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	caskroom := filepath.Join(dir, "Caskroom", "genv", "4.0.3")
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(caskroom, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realBin := filepath.Join(caskroom, "genv")
+	if err := os.WriteFile(realBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stable := filepath.Join(binDir, "genv")
+	if err := os.Symlink(realBin, stable); err != nil {
+		t.Fatal(err)
+	}
+
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	if err := os.WriteFile(specPath, []byte(`{"schemaVersion":"6","packages":[],"updates":{"enabled":true,"interval":"1h"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	supervisor := &fakeUpdatesSupervisor{supported: true}
+	withUpdatesSupervisor(t, supervisor)
+
+	originalExecutable := updatesExecutable
+	updatesExecutable = func() (string, error) { return realBin, nil }
+	t.Cleanup(func() { updatesExecutable = originalExecutable })
+	originalLookPath := updatesSelfLookPath
+	updatesSelfLookPath = func(file string) (string, error) {
+		if file == "genv" {
+			return stable, nil
+		}
+		return "", os.ErrNotExist
+	}
+	t.Cleanup(func() { updatesSelfLookPath = originalLookPath })
+
+	var code int
+	captureStdout(t, func() {
+		code = run([]string{"updates", "start", "--file", specPath, "--lock-file", lockPath, "--host", "macos"})
+	})
+	if code != exitOK {
+		t.Fatalf("code = %d, want %d", code, exitOK)
+	}
+	if len(supervisor.started) != 1 {
+		t.Fatalf("started = %#v", supervisor.started)
+	}
+	if got := supervisor.started[0].Command[0]; got != stable {
+		t.Fatalf("command[0] = %q, want stable PATH symlink %q", got, stable)
+	}
+}
+
+func TestUpdatesStatus_warns_when_agent_executable_missing(t *testing.T) {
+	home := t.TempDir()
+	originalHome := managedAgentHomeDir
+	managedAgentHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { managedAgentHomeDir = originalHome })
+
+	agentDir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(home, "Caskroom", "genv", "4.0.2", "genv")
+	plist := service.LaunchdScheduledPlistContent("updates", []string{missing, "updates", "__run-once"}, time.Hour, nil)
+	if err := os.WriteFile(filepath.Join(agentDir, "genv.updates.plist"), []byte(plist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	supervisor := &fakeUpdatesSupervisor{
+		supported: true,
+		status:    service.ScheduledJobStatus{Registered: true, LastRun: service.ScheduledRunSuccess, Detail: "genv.updates"},
+	}
+	withUpdatesSupervisor(t, supervisor)
+
+	var code int
+	out := captureStdout(t, func() { code = run([]string{"updates", "status"}) })
+	if code != exitOK {
+		t.Fatalf("code = %d, want %d", code, exitOK)
+	}
+	if !strings.Contains(out, "Warning:") || !strings.Contains(out, missing) || !strings.Contains(out, "genv updates start") {
+		t.Fatalf("stdout = %q, want dangling-path warning and re-register hint", out)
+	}
+}
+
+func TestValidateCmd_rejects_broken_managed_agent_executable(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	originalHome := managedAgentHomeDir
+	managedAgentHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { managedAgentHomeDir = originalHome })
+
+	agentDir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(home, "gone", "genv")
+	plist := service.LaunchdScheduledPlistContent("updates", []string{missing, "updates", "__run-once"}, time.Hour, nil)
+	if err := os.WriteFile(filepath.Join(agentDir, "genv.updates.plist"), []byte(plist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	valid := filepath.Join(dir, "valid.json")
+	if err := os.WriteFile(valid, []byte(`{"schemaVersion":"6","packages":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var code int
+	errOut := captureStderr(t, func() { code = run([]string{"validate", "--file", valid}) })
+	if code != exitValidation {
+		t.Fatalf("code = %d, want %d\nstderr: %s", code, exitValidation, errOut)
+	}
+	if !strings.Contains(errOut, missing) || !strings.Contains(errOut, "genv updates start") {
+		t.Fatalf("stderr = %q, want missing path and repair hint", errOut)
 	}
 }
 

--- a/main_updates_daemon.go
+++ b/main_updates_daemon.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/ks1686/genv/internal/genvfile"
 	"github.com/ks1686/genv/internal/schema"
+	"github.com/ks1686/genv/internal/selfpath"
 	"github.com/ks1686/genv/internal/service"
 )
 
@@ -29,6 +31,8 @@ type updatesSupervisor interface {
 var (
 	newUpdatesSupervisor = func() updatesSupervisor { return service.NewScheduledBackend() }
 	updatesExecutable    = os.Executable
+	updatesSelfLookPath  = exec.LookPath
+	managedAgentHomeDir  = os.UserHomeDir
 )
 
 func updatesStartCmd(args []string) int {
@@ -60,6 +64,9 @@ func updatesStartCmd(args []string) int {
 		fprintf(os.Stderr, "genv updates start: finding current executable: %v\n", err)
 		return exitIO
 	}
+	// Prefer a PATH-stable invocation path (e.g. Homebrew's bin/genv symlink)
+	// over a version-pinned Caskroom path from os.Executable / cask post_install.
+	exe = selfpath.PreferStable(exe, os.Args[0], updatesSelfLookPath)
 	absFile, err := filepath.Abs(*file)
 	if err != nil {
 		fprintf(os.Stderr, "genv updates start: resolving spec path: %v\n", err)
@@ -129,6 +136,7 @@ func updatesStatusCmd(args []string) int {
 	}
 	if status.Executing {
 		fprintf(os.Stdout, "updates checker is registered and executing (%s).\n", status.Detail)
+		adviseBrokenManagedAgents(os.Stdout)
 		return exitOK
 	}
 	switch status.LastRun {
@@ -144,7 +152,23 @@ func updatesStatusCmd(args []string) int {
 	default:
 		fprintf(os.Stdout, "updates checker is registered and idle; last-run outcome is unknown (%s).\n", status.Detail)
 	}
+	adviseBrokenManagedAgents(os.Stdout)
 	return exitOK
+}
+
+func adviseBrokenManagedAgents(w io.Writer) {
+	home, err := managedAgentHomeDir()
+	if err != nil {
+		return
+	}
+	issues := service.ListManagedAgentProgramIssues(home)
+	if len(issues) == 0 {
+		return
+	}
+	for _, issue := range issues {
+		fPrintln(w, "Warning: "+issue.Detail)
+	}
+	fPrintln(w, "Hint: a genv-managed agent points at a missing executable (often a Homebrew Caskroom version path after upgrade); re-run: genv updates start")
 }
 
 func lastRunDetailSuggestsCodesign(detail string) bool {


### PR DESCRIPTION
## Summary
- Prefer a PATH-stable self path (e.g. Homebrew `bin/genv`) when registering the updates LaunchAgent/systemd unit, so cask `post_install` / `os.Executable` no longer bake Caskroom version paths that break after upgrade.
- `updates status` warns and `validate` fails when genv-managed agents point at a missing/non-executable primary path.

## Test plan
- [x] Unit tests for PreferStable + agent health + updates start/status/validate wiring
- [x] `make ci` locally
- [ ] CI green on PR
- [ ] After merge: `genv updates start` writes stable argv[0] (no Caskroom version component)