### PR TITLE
Log outdated query timings for scheduled updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Scheduled `updates __run-once` logs per-manager outdated-query timings (and total plan duration) so a slow launchd run can be distinguished from a silent timeout fallback.
+
 ## v4.0.5 - 2026-07-27
 
 ### Fixed

--- a/internal/resolver/outdated_test.go
+++ b/internal/resolver/outdated_test.go
@@ -75,8 +75,8 @@ func TestFilterOutdated_KeepsOnlyOutdated(t *testing.T) {
 	if got := keptIDs(kept); !slices.Equal(got, []string{"wget"}) {
 		t.Fatalf("kept = %v, want [wget]", got)
 	}
-	if len(warnings) != 0 {
-		t.Fatalf("warnings = %v, want none", warnings)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "outdated timing: brew") {
+		t.Fatalf("warnings = %v, want one brew timing line", warnings)
 	}
 }
 
@@ -92,8 +92,8 @@ func TestFilterOutdated_QueryErrorKeepsAllWithWarning(t *testing.T) {
 	if got := keptIDs(kept); !slices.Equal(got, []string{"wget", "jq"}) {
 		t.Fatalf("kept = %v, want all packages", got)
 	}
-	if len(warnings) != 1 || !strings.Contains(warnings[0], "brew") {
-		t.Fatalf("warnings = %v, want one mentioning brew", warnings)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "brew") || !strings.Contains(warnings[0], "after") {
+		t.Fatalf("warnings = %v, want one mentioning brew and duration", warnings)
 	}
 }
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -295,12 +295,17 @@ func FilterOutdated(packages []genvfile.LockedPackage) (kept []genvfile.LockedPa
 			keep[name] = nil // no capability: keep all
 			continue
 		}
+		started := time.Now()
 		outdated, err := lister.ListOutdated(g.pkgNames)
+		elapsed := time.Since(started).Round(time.Millisecond)
 		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("could not determine outdated packages for %s (%v) — keeping all", name, err))
+			warnings = append(warnings, fmt.Sprintf("could not determine outdated packages for %s after %s (%v) — keeping all", name, elapsed, err))
 			keep[name] = nil // query failed: keep all conservatively
 			continue
 		}
+		// Timing is logged as a warning so scheduled updates.log and CLI stderr
+		// can distinguish a real slow query from a silent timeout fallback.
+		warnings = append(warnings, fmt.Sprintf("outdated timing: %s took %s (%d hits)", name, elapsed, len(outdated)))
 		set := make(map[string]bool, len(outdated))
 		for pkgName := range outdated {
 			set[pkgName] = true

--- a/main_updates_worker.go
+++ b/main_updates_worker.go
@@ -81,18 +81,23 @@ func updatesRunOnceBody(ctx context.Context, logger *slog.Logger, f *schema.Genv
 		return exitIO
 	}
 	filters := output.UpgradeFilters{Only: cfg.Only, Skip: cfg.Skip, OnlyManager: cfg.OnlyManagers, SkipManager: cfg.SkipManagers, HooksSkipped: true}
+	planStarted := time.Now()
 	plan, err := updatesBuildPlan(upgrade.UpgradeOptions{Spec: f, Lock: lf, Filters: filters})
+	planDur := time.Since(planStarted).Round(time.Millisecond)
 	if err != nil {
-		logger.Warn("updates.check.plan", slog.Any("err", err))
+		logger.Warn("updates.check.plan", slog.Any("err", err), slog.Duration("duration", planDur))
 		return exitUsage
 	}
+	for _, warn := range plan.Warnings {
+		logger.Info("updates.check.warning", slog.String("warning", warn))
+	}
 	if err := ctx.Err(); err != nil {
-		logger.Warn("updates.check.timeout", slog.Any("err", err))
+		logger.Warn("updates.check.timeout", slog.Any("err", err), slog.Duration("duration", planDur))
 		return exitLogic
 	}
 	if !cfg.AutoApply {
 		outdated := countPlannedPackages(plan)
-		logger.Info("updates.check.planned", slog.Int("packages", outdated), slog.Int("batches", len(plan.Actions)), slog.Int("skipped", len(plan.Skipped)), slog.Bool("auto_apply", false))
+		logger.Info("updates.check.planned", slog.Int("packages", outdated), slog.Int("batches", len(plan.Actions)), slog.Int("skipped", len(plan.Skipped)), slog.Bool("auto_apply", false), slog.Duration("duration", planDur))
 		if outdated > 0 {
 			notifyUpdates(ctx, cfg.Notify, "genv updates", fmt.Sprintf("%d package(s) have updates available", outdated), logger)
 		}


### PR DESCRIPTION
## Summary
- `FilterOutdated` records per-manager duration (and failures include `after <dur>`).
- `updates __run-once` writes those warnings plus total plan `duration` to `updates.log`.

Answers whether a ~60s launchd run is real work vs a capped hang.

## Test plan
- [x] resolver FilterOutdated tests + updates tests
- [x] `make ci`
- [ ] After release: kickstart or wait for hourly run; `rg 'outdated timing|duration=' ~/.config/genv/updates.log`