### PR TITLE
Fix updates __run-once exit 4 after notify hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- `updates __run-once` no longer blocks on desktop notifications after a successful plan. Under launchd, `osascript` could ignore cancel and hold the process until the 5m job deadline (`updates.check.timeout` → exit 4) even though outdated detection had already finished in seconds.
+
 ## v4.0.6 - 2026-07-27
 
 ### Added

--- a/main_test.go
+++ b/main_test.go
@@ -3130,6 +3130,56 @@ func TestUpdatesRunOnce_unsupported_notifier_logs_warning_without_crashing(t *te
 	}
 }
 
+func TestUpdatesRunOnce_hanging_notifier_does_not_block_or_timeout(t *testing.T) {
+	// Regression: under launchd, osascript can ignore CommandContext cancel and
+	// hold __run-once until the 5m job deadline → exit 4 after a successful plan.
+	dir := t.TempDir()
+	xdg := filepath.Join(dir, "xdg")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	if err := os.WriteFile(specPath, []byte(`{"schemaVersion":"6","packages":[{"id":"alpha"}],"updates":{"enabled":true,"interval":"1h","notify":true}}`), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	writeLock(t, lockPath, []genvfile.LockedPackage{{ID: "alpha", Manager: "brew", PkgName: "alpha"}})
+
+	hangBin := filepath.Join(dir, "hang-notify")
+	if err := os.WriteFile(hangBin, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+		t.Fatalf("write hang bin: %v", err)
+	}
+
+	originalBuild := updatesBuildPlan
+	updatesBuildPlan = func(opts upgrade.UpgradeOptions) (upgrade.UpgradePlan, error) {
+		return upgrade.UpgradePlan{Actions: []resolver.UpgradeAction{
+			{LPs: []genvfile.LockedPackage{{ID: "alpha", Manager: "brew", PkgName: "alpha"}}},
+		}}, nil
+	}
+	t.Cleanup(func() { updatesBuildPlan = originalBuild })
+	originalLookPath := updatesLookPath
+	updatesLookPath = func(string) (string, error) { return hangBin, nil }
+	t.Cleanup(func() { updatesLookPath = originalLookPath })
+
+	started := time.Now()
+	code := run([]string{"updates", "__run-once", "--file", specPath, "--lock-file", lockPath})
+	elapsed := time.Since(started)
+	if code != exitOK {
+		t.Fatalf("code = %d, want %d (hanging notifier must not force timeout exit 4)", code, exitOK)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("elapsed = %s, want quick return without waiting on notifier", elapsed)
+	}
+	logBytes, err := os.ReadFile(filepath.Join(xdg, "genv", "updates.log"))
+	if err != nil {
+		t.Fatalf("read updates log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "updates.check.planned") {
+		t.Fatalf("log missing planned event: %s", logBytes)
+	}
+	if strings.Contains(string(logBytes), "updates.check.timeout") {
+		t.Fatalf("log unexpectedly timed out: %s", logBytes)
+	}
+}
+
 func TestUpgradeHookEnv_builds_deterministic_context_in_plan_order(t *testing.T) {
 	// Given: plan, skipped, upgraded, and failed packages deliberately not sorted alphabetically.
 	plan := []resolver.UpgradeAction{

--- a/main_updates_worker.go
+++ b/main_updates_worker.go
@@ -54,17 +54,22 @@ func updatesRunOnceCmd(args []string) int {
 	ctx, cancel := context.WithTimeout(context.Background(), service.ScheduledJobTimeOut(interval))
 	defer cancel()
 
-	type runOnceResult struct{ code int }
-	done := make(chan runOnceResult, 1)
+	done := make(chan int, 1)
 	go func() {
-		done <- runOnceResult{code: updatesRunOnceBody(ctx, logger, f, cfg, *file, *lockFile, *hostFlag, *targetFlag)}
+		done <- updatesRunOnceBody(ctx, logger, f, cfg, *file, *lockFile, *hostFlag, *targetFlag)
 	}()
 	select {
-	case res := <-done:
-		return res.code
+	case code := <-done:
+		return code
 	case <-ctx.Done():
-		logger.Warn("updates.check.timeout", slog.Duration("timeout", service.ScheduledJobTimeOut(interval)), slog.Any("err", ctx.Err()))
-		return exitLogic
+		// Prefer a late completion over a false timeout when both are ready.
+		select {
+		case code := <-done:
+			return code
+		default:
+			logger.Warn("updates.check.timeout", slog.Duration("timeout", service.ScheduledJobTimeOut(interval)), slog.Any("err", ctx.Err()))
+			return exitLogic
+		}
 	}
 }
 
@@ -202,27 +207,35 @@ func countPlannedPackages(plan upgrade.UpgradePlan) int {
 	return n
 }
 
-func notifyUpdates(ctx context.Context, enabled bool, title, message string, logger *slog.Logger) {
+func notifyUpdates(_ context.Context, enabled bool, title, message string, logger *slog.Logger) {
 	if !enabled {
 		return
 	}
+	var notifier string
+	var args []string
 	switch {
 	case service.IsLaunchdAvailable():
-		runNotification(ctx, logger, "osascript", "-e", fmt.Sprintf("display notification %q with title %q", message, title))
+		notifier = "osascript"
+		args = []string{"-e", fmt.Sprintf("display notification %q with title %q", message, title)}
 	default:
-		runNotification(ctx, logger, "notify-send", title, message)
+		notifier = "notify-send"
+		args = []string{title, message}
 	}
-}
-
-func runNotification(ctx context.Context, logger *slog.Logger, notifier string, args ...string) {
 	path, err := updatesLookPath(notifier)
 	if err != nil {
 		logger.Warn("updates.notify.unavailable", slog.String("notifier", notifier), slog.Any("err", err))
 		return
 	}
-	notifyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	// Never block the scheduled worker on a desktop notification. Under launchd,
+	// osascript has been observed to ignore CommandContext cancel and hold the
+	// process until the job deadline (exit 4) even after a successful plan.
+	go runNotificationAsync(logger, notifier, path, args...)
+}
+
+func runNotificationAsync(logger *slog.Logger, notifier, path string, args ...string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	if err := exec.CommandContext(notifyCtx, path, args...).Run(); err != nil {
+	if err := exec.CommandContext(ctx, path, args...).Run(); err != nil {
 		logger.Warn("updates.notify.failed", slog.String("notifier", notifier), slog.Any("err", err))
 	}
 }


### PR DESCRIPTION
## Summary
- Root cause: after `updates.check.planned` (~2–4s), `__run-once` blocked on `osascript` notifications; under launchd cancel was ignored until the 5m job deadline → `updates.check.timeout` and exit 4.
- Fix: resolve notifier synchronously, run notification in a goroutine with an independent 3s timeout; prefer late body completion over a false timeout in the watchdog select.
- TCC/signing: out of scope (cosmetic denials; do nothing).

## Test plan
- [x] `TestUpdatesRunOnce_hanging_notifier_does_not_block_or_timeout`
- [x] `make ci`
- [ ] After release: `genv updates start`; kickstart or wait for hourly; `last exit code = 0` and no `updates.check.timeout` after `planned`