### PR TITLE
fix: drop Pro-only GoReleaser keys so OSS can publish

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -119,25 +119,13 @@ snapcrafts:
 
 
 
-# Windows store publishers stay skipped until tokens exist.
-wingets:
-  - name: genv
-    publisher: ks1686
-    short_description: Track, sync, and reproduce your software environment.
-    license: MIT
-    skip_upload: true
-
+# Scoop stays unpublished until a bucket token exists.
+# winget and Chocolatey publishers are GoReleaser Pro-only; do not declare them
+# here or OSS goreleaser check / CI fails to parse the config.
 scoops:
   - name: genv
     description: Track, sync, and reproduce your software environment.
     license: MIT
-    skip_upload: true
-
-chocolateys:
-  - name: genv
-    owners: ks1686
-    title: genv
-    description: Track, sync, and reproduce your software environment.
     skip_upload: true
 
 changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v4.0.12 - 2026-08-15
+
+### Fixed
+
+- Release config no longer declares GoReleaser Pro-only `wingets` / `chocolateys` keys. OSS GoReleaser 2.17 rejected them and aborted before publishing `v4.0.11`. Scoop remains configured with `skip_upload: true`.
+
 ## v4.0.11 - 2026-08-15
 
 ### Fixed
@@ -19,13 +25,13 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Native `apt`, `dnf`, and `apk` adapters (install/uninstall/query/search/outdated, default-fallback eligible). Ubuntu mapping prefers `apt` ahead of snap/linuxbrew.
-- GoReleaser stubs for winget / scoop / chocolatey (skip upload until store tokens are set).
+- GoReleaser Scoop stub (`skip_upload: true`). winget / Chocolatey publishers are GoReleaser Pro-only and are not declared in OSS config.
 - `Regression` GitHub Actions workflow: fail-closed add, v8 defaults, safety, adapter, files e2e, and actionlint.
 - MIT `LICENSE` and `contents: read` on non-release CI workflows.
 
 ### Changed
 
-- Install docs use `brew install --cask genv` and current `v4.0.11` archive names. WSL Ubuntu examples prefer native `apt`.
+- Install docs use `brew install --cask genv` and current archive names. WSL Ubuntu examples prefer native `apt`.
 - Removed leftover Superpowers/handoff session notes and the historical `SECURITY_AUDIT.md` dump. Live security policy remains [SECURITY.md](SECURITY.md).
 
 ## v4.0.10 - 2026-08-12

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Track, sync, and reproduce your software environment across **macOS**, **Windows
 
 `genv` is a thin layer over the package managers you already use. Desired state lives in one git-friendly `genv.json`. Applied state lives in a machine-local lock file. Run `genv apply` and the machine matches the spec.
 
-**Current release:** [latest](https://github.com/ks1686/genv/releases/latest) (v4.0.11+) — schema **v7** PowerShell parity, schema **v8** portable multi-target configs.
+**Current release:** [latest](https://github.com/ks1686/genv/releases/latest) (v4.0.12+) — schema **v7** PowerShell parity, schema **v8** portable multi-target configs.
 
 ```bash
 genv add git                          # track + install
@@ -31,7 +31,7 @@ genv map --target arch                # assist-only manager suggestions
 **Linux x86-64 example** (replace the version to match [Releases](https://github.com/ks1686/genv/releases/latest)):
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.0.11_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 genv version
@@ -40,13 +40,13 @@ genv version
 **Windows (PowerShell):**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.11_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .
 # put genv.exe on PATH, then:
 genv version
 ```
 
-Windows package-manager installers for the **genv binary** (winget / scoop / choco) are prepared in GoReleaser and stay unpublished until the corresponding store tokens are configured. Once genv is on `PATH`, it still **manages packages** through those managers.
+Windows package-manager installers for the **genv binary** (winget / scoop / choco) are not published yet. Scoop is prepared in OSS GoReleaser with upload skipped; winget and Chocolatey need GoReleaser Pro. Once genv is on `PATH`, it still **manages packages** through those managers.
 
 Release archives ship cosign-signed checksums (keyless). Darwin binaries are also Developer ID signed and notarized when Apple secrets are configured — see [SECURITY.md](SECURITY.md).
 
@@ -288,7 +288,7 @@ File mismatches without `--force` no longer block packages/services: non-conflic
 | Schema v8 portable targets | Stable |
 | Background `updates` + profiles + hooks | Stable |
 | apt / dnf / apk adapters | Stable |
-| Publish genv to winget / scoop / choco | Configured, unpublished until store tokens exist |
+| Publish genv to winget / scoop / choco | Not published; Scoop stub skipped in OSS, winget/choco need GoReleaser Pro |
 
 Historical milestone checklists: [ROADMAP.md](ROADMAP.md). Release notes: [CHANGELOG.md](CHANGELOG.md). Tag-driven publishing: [RELEASING.md](RELEASING.md).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,7 +31,8 @@ Homebrew, AUR, and the Snap Store automatically — no external reviewer sign-of
 | `v4.0.8` | `add`/`adopt` Tab completions via `genv __complete repo-packages` (cached dumps + search fallback) |
 | `v4.0.9` | Lifecycle hooks inherit stdin + receive `GENV_YES` when `--yes` is set |
 | `v4.0.10` | Darwin GitHub Release / Homebrew binaries are Developer ID signed and notarized |
-| `v4.0.11` | Fail-closed `add`, schema v8 defaults, native apt/dnf/apk, Windows CI/test hardening |
+| `v4.0.11` | Fail-closed `add`, schema v8 defaults, native apt/dnf/apk, Windows CI/test hardening (tag exists; GitHub Release aborted on Pro-only GoReleaser keys) |
+| `v4.0.12` | Drop Pro-only winget/chocolatey GoReleaser keys so OSS publish can succeed |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew and AUR
@@ -367,7 +368,7 @@ is clear demand; it is not tied to a specific version milestone.
 
 | Channel | Status | Notes |
 | --- | --- | --- |
-| Scoop | Configured, unpublished | GoReleaser `scoops` block is present with `skip_upload: true` until a token exists |
-| winget | Configured, unpublished | GoReleaser `wingets` block is present with `skip_upload: true` until a token exists |
-| Chocolatey | Configured, unpublished | GoReleaser `chocolateys` block is present with `skip_upload: true` until a token exists |
+| Scoop | Configured, unpublished | OSS GoReleaser `scoops` block is present with `skip_upload: true` until a token exists |
+| winget | Deferred | Publisher is GoReleaser Pro-only; not declared in OSS config |
+| Chocolatey | Deferred | Publisher is GoReleaser Pro-only; not declared in OSS config |
 | apt PPA | Deferred | `.deb` artifacts already ship via GitHub Releases |

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -5,7 +5,7 @@ Native Windows is the `windows` target (not WSL). Use a separate Linux install i
 ## 1. Download genv
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.11_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .\genv
 New-Item -ItemType Directory -Force $HOME\bin
 Copy-Item .\genv\genv.exe $HOME\bin\genv.exe
@@ -15,7 +15,7 @@ genv version
 
 Update the version segment when a newer release is current.
 
-Store installers for genv itself (`winget install ks1686.genv`, `scoop install genv`, `choco install genv`) are prepared in release config and stay unpublished until the matching tokens exist. Those managers remain available for **packages** genv manages.
+Store installers for genv itself (`winget install ks1686.genv`, `scoop install genv`, `choco install genv`) are not published yet. Scoop is prepared in OSS GoReleaser with upload skipped; winget and Chocolatey need GoReleaser Pro. Those managers remain available for **packages** genv manages.
 
 ## 2. Install a Windows package manager
 

--- a/docs/wsl2-install.md
+++ b/docs/wsl2-install.md
@@ -31,7 +31,7 @@ wsl --install
 Download the latest Linux binary from the [Releases](https://github.com/ks1686/genv/releases/latest) page:
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.0.11_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 rm genv.tar.gz

--- a/man/genv.1
+++ b/man/genv.1
@@ -1,4 +1,4 @@
-.TH GENV 1 "August 2026" "genv 4.0.11" "User Commands"
+.TH GENV 1 "August 2026" "genv 4.0.12" "User Commands"
 .SH NAME
 genv \\- global environment manager
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary
- OSS GoReleaser 2.17 rejected `wingets` / `chocolateys` (`field not found`) and aborted `v4.0.11` before creating a GitHub Release.
- Remove those Pro-only keys. Keep Scoop with `skip_upload: true`.
- Document **v4.0.12** as the publishable tag. Leave the existing `v4.0.11` tag in place (no GitHub release).

## Test plan
- [x] `goreleaser check` on the updated config
- [ ] GitHub CI / Integration / Regression on this PR
- [ ] Tag `v4.0.12` after merge and confirm Release publishes