### PR TITLE
fix: reject unknown spec keys and leading-dash package names

### DIFF
--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -22,6 +22,9 @@ func Add(f *schema.GenvFile, id, version, prefer string, managers map[string]str
 	if id == "" {
 		return fmt.Errorf("package id must not be empty")
 	}
+	if !schema.ValidPackageName(id) {
+		return fmt.Errorf("invalid package id %q: must not start with '-' or contain whitespace", id)
+	}
 
 	packages := &f.Packages
 	if f.SchemaVersion == schema.Version8 {
@@ -42,9 +45,12 @@ func Add(f *schema.GenvFile, id, version, prefer string, managers map[string]str
 		return fmt.Errorf("unknown manager %q for --prefer; valid managers: %s", prefer, KnownManagerList())
 	}
 
-	for mgr := range managers {
+	for mgr, pkgName := range managers {
 		if !schema.KnownManagers[mgr] {
 			return fmt.Errorf("unknown manager %q in --manager; valid managers: %s", mgr, KnownManagerList())
+		}
+		if !schema.ValidPackageName(pkgName) {
+			return fmt.Errorf("invalid package name %q for manager %q: must not be empty, start with '-', or contain whitespace", pkgName, mgr)
 		}
 	}
 

--- a/internal/commands/add_test.go
+++ b/internal/commands/add_test.go
@@ -43,10 +43,17 @@ func TestAdd_WithPreferAndManagers(t *testing.T) {
 	}
 }
 
-func TestAdd_EmptyID(t *testing.T) {
+func TestAdd_LeadingDashID(t *testing.T) {
 	f := newFile()
-	if err := Add(f, "", "*", "", nil, ""); err == nil {
-		t.Fatal("expected error for empty id")
+	if err := Add(f, "--asdeps", "", "", nil, ""); err == nil {
+		t.Fatal("expected error for leading-dash id")
+	}
+}
+
+func TestAdd_LeadingDashManagerValue(t *testing.T) {
+	f := newFile()
+	if err := Add(f, "git", "", "", map[string]string{"pacman": "--help"}, ""); err == nil {
+		t.Fatal("expected error for leading-dash manager value")
 	}
 }
 

--- a/internal/complete/repo.go
+++ b/internal/complete/repo.go
@@ -44,6 +44,14 @@ func repoPackagesOnGOOS(
 	goos string,
 	now time.Time,
 ) []string {
+	overall := time.Until(now.Add(OverallTimeout))
+	if overall <= 0 {
+		return nil
+	}
+	return collectRepoNames(prefix, repoJobs(available, goos), overall, SearchTimeout)
+}
+
+func repoJobs(available map[string]bool, goos string) []repoJob {
 	jobs := make([]repoJob, 0, len(adapter.All))
 	for _, candidate := range adapter.All {
 		manager := candidate.Name()
@@ -99,12 +107,7 @@ func repoPackagesOnGOOS(
 		}
 		jobs = append(jobs, job)
 	}
-
-	overall := time.Until(now.Add(OverallTimeout))
-	if overall <= 0 {
-		return nil
-	}
-	return collectRepoNames(prefix, jobs, overall, SearchTimeout)
+	return jobs
 }
 
 func collectRepoNames(

--- a/internal/complete/repo_test.go
+++ b/internal/complete/repo_test.go
@@ -246,11 +246,15 @@ func TestRepoPackagesOnGOOS_deduplicatesBunAndNpmRegistrySearch(t *testing.T) {
 printf 'typescript\tdesc\tdate\tver\tkeywords\n'`)
 	}
 
-	got := repoPackagesOnGOOS(
+	// Production Tab-complete budgets (150ms search / 300ms overall) are too
+	// tight for Windows CI process spawn. The bun/npm skip is what this test
+	// covers; collectRepoNames with a 1s budget still exercises the real npm
+	// Search parser and the one-call invariant.
+	got := collectRepoNames(
 		"type",
-		map[string]bool{"bun": true, "npm": true},
-		"darwin",
-		time.Now(),
+		repoJobs(map[string]bool{"bun": true, "npm": true}, "darwin"),
+		time.Second,
+		time.Second,
 	)
 	if !slices.Equal(got, []string{"typescript"}) {
 		t.Fatalf("got %v want [typescript]", got)

--- a/internal/complete/repo_test.go
+++ b/internal/complete/repo_test.go
@@ -266,7 +266,17 @@ printf 'typescript\tdesc\tdate\tver\tkeywords\n'`)
 
 func TestCollectRepoNames_keepsMasProductIDsMatchedByName(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	testutil.InstallFakeBinary(t, "mas", `printf '497799835  Xcode (16.0)\n'`)
+	if runtime.GOOS == "windows" {
+		// A native .cmd stays under the search timeout; the bash shim is too slow.
+		dir := t.TempDir()
+		shim := "@echo off\r\necho 497799835  Xcode ^(16.0^)\r\n"
+		if err := os.WriteFile(filepath.Join(dir, "mas.cmd"), []byte(shim), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	} else {
+		testutil.InstallFakeBinary(t, "mas", `printf '497799835  Xcode (16.0)\n'`)
+	}
 
 	mas := adapter.Mas{}
 	got := collectRepoNames("xcode", []repoJob{{

--- a/internal/schema/unknown.go
+++ b/internal/schema/unknown.go
@@ -1,0 +1,236 @@
+package schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"unicode"
+)
+
+func validateUnknownKeys(raw map[string]json.RawMessage, positions map[string]Position) []ValidationError {
+	var errs []ValidationError
+	errs = append(errs, rejectUnknown(raw, "", rootFields, positions)...)
+	errs = append(errs, walkPackages(raw["packages"], "packages", positions)...)
+	errs = append(errs, walkEnvMap(raw["env"], "env", positions)...)
+	errs = append(errs, walkShell(raw["shell"], "shell", positions)...)
+	errs = append(errs, walkServiceMap(raw["services"], "services", positions)...)
+	errs = append(errs, walkFiles(raw["files"], "files", positions)...)
+	errs = append(errs, walkHooks(raw["hooks"], "hooks", positions)...)
+	errs = append(errs, walkObject(raw["repo"], "repo", repoFields, positions)...)
+	errs = append(errs, walkObject(raw["updates"], "updates", updatesFields, positions)...)
+	errs = append(errs, walkBundle(raw["defaults"], "defaults", positions)...)
+	if targets, ok := asObject(raw["targets"]); ok {
+		for name, body := range targets {
+			errs = append(errs, walkBundle(body, "targets."+name, positions)...)
+		}
+	}
+	return errs
+}
+
+var (
+	rootFields = strSet(
+		"$schema", "schemaVersion", "packages", "env", "shell", "services",
+		"files", "hooks", "repo", "updates", "defaults", "targets",
+	)
+	packageFields = strSet("id", "version", "prefer", "managers", "host")
+	envVarFields  = strSet("value", "sensitive")
+	shellFields   = strSet("aliases", "functions", "source")
+	aliasFields   = strSet("value", "shell")
+	funcFields    = strSet("body", "shell")
+	serviceFields = strSet("start", "stop", "restart", "status", "brew_formula", "host")
+	filesFields   = strSet("links", "templates", "dirs")
+	linkFields    = strSet("source", "target", "mode", "host", "backup")
+	tmplFields    = strSet("source", "target", "host", "backup")
+	dirFields     = strSet("target", "host")
+	hooksFields   = strSet("preApply", "postApply", "preAdd", "postAdd", "preRemove", "postRemove", "preUpgrade", "postUpgrade")
+	hookFields    = strSet("command", "file", "host")
+	repoFields    = strSet("url", "ref")
+	updatesFields = strSet("enabled", "interval", "autoApply", "notify", "onlyManagers", "skipManagers", "only", "skip")
+	bundleFields  = strSet("packages", "env", "shell", "services", "files", "hooks")
+)
+
+func strSet(keys ...string) map[string]bool {
+	m := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		m[k] = true
+	}
+	return m
+}
+
+func rejectUnknown(obj map[string]json.RawMessage, path string, allowed map[string]bool, positions map[string]Position) []ValidationError {
+	if obj == nil {
+		return nil
+	}
+	var errs []ValidationError
+	for key := range obj {
+		if allowed[key] {
+			continue
+		}
+		field := key
+		if path != "" {
+			field = path + "." + key
+		}
+		errs = append(errs, ValidationError{
+			Position: positions[field],
+			Field:    field,
+			Message:  fmt.Sprintf("unknown field %q", key),
+		})
+	}
+	return errs
+}
+
+func walkObject(raw json.RawMessage, path string, allowed map[string]bool, positions map[string]Position) []ValidationError {
+	obj, ok := asObject(raw)
+	if !ok {
+		return nil
+	}
+	return rejectUnknown(obj, path, allowed, positions)
+}
+
+func walkBundle(raw json.RawMessage, path string, positions map[string]Position) []ValidationError {
+	obj, ok := asObject(raw)
+	if !ok {
+		return nil
+	}
+	var errs []ValidationError
+	errs = append(errs, rejectUnknown(obj, path, bundleFields, positions)...)
+	errs = append(errs, walkPackages(obj["packages"], path+".packages", positions)...)
+	errs = append(errs, walkEnvMap(obj["env"], path+".env", positions)...)
+	errs = append(errs, walkShell(obj["shell"], path+".shell", positions)...)
+	errs = append(errs, walkServiceMap(obj["services"], path+".services", positions)...)
+	errs = append(errs, walkFiles(obj["files"], path+".files", positions)...)
+	errs = append(errs, walkHooks(obj["hooks"], path+".hooks", positions)...)
+	return errs
+}
+
+func walkPackages(raw json.RawMessage, path string, positions map[string]Position) []ValidationError {
+	items, ok := asArray(raw)
+	if !ok {
+		return nil
+	}
+	var errs []ValidationError
+	for i, item := range items {
+		obj, ok := asObject(item)
+		if !ok {
+			continue
+		}
+		pkgPath := fmt.Sprintf("%s[%d]", path, i)
+		errs = append(errs, rejectUnknown(obj, pkgPath, packageFields, positions)...)
+	}
+	return errs
+}
+
+func walkEnvMap(raw json.RawMessage, path string, positions map[string]Position) []ValidationError {
+	return walkKeyedObjects(raw, path, envVarFields, positions)
+}
+
+func walkServiceMap(raw json.RawMessage, path string, positions map[string]Position) []ValidationError {
+	return walkKeyedObjects(raw, path, serviceFields, positions)
+}
+
+func walkShell(raw json.RawMessage, path string, positions map[string]Position) []ValidationError {
+	obj, ok := asObject(raw)
+	if !ok {
+		return nil
+	}
+	var errs []ValidationError
+	errs = append(errs, rejectUnknown(obj, path, shellFields, positions)...)
+	errs = append(errs, walkKeyedObjects(obj["aliases"], path+".aliases", aliasFields, positions)...)
+	errs = append(errs, walkKeyedObjects(obj["functions"], path+".functions", funcFields, positions)...)
+	return errs
+}
+
+func walkFiles(raw json.RawMessage, path string, positions map[string]Position) []ValidationError {
+	obj, ok := asObject(raw)
+	if !ok {
+		return nil
+	}
+	var errs []ValidationError
+	errs = append(errs, rejectUnknown(obj, path, filesFields, positions)...)
+	errs = append(errs, walkObjectArray(obj["links"], path+".links", linkFields, positions)...)
+	errs = append(errs, walkObjectArray(obj["templates"], path+".templates", tmplFields, positions)...)
+	errs = append(errs, walkObjectArray(obj["dirs"], path+".dirs", dirFields, positions)...)
+	return errs
+}
+
+func walkHooks(raw json.RawMessage, path string, positions map[string]Position) []ValidationError {
+	obj, ok := asObject(raw)
+	if !ok {
+		return nil
+	}
+	var errs []ValidationError
+	errs = append(errs, rejectUnknown(obj, path, hooksFields, positions)...)
+	for _, phase := range []string{"preApply", "postApply", "preAdd", "postAdd", "preRemove", "postRemove", "preUpgrade", "postUpgrade"} {
+		errs = append(errs, walkObjectArray(obj[phase], path+"."+phase, hookFields, positions)...)
+	}
+	return errs
+}
+
+func walkKeyedObjects(raw json.RawMessage, path string, allowed map[string]bool, positions map[string]Position) []ValidationError {
+	obj, ok := asObject(raw)
+	if !ok {
+		return nil
+	}
+	var errs []ValidationError
+	for key, val := range obj {
+		if isJSONNull(val) {
+			continue
+		}
+		errs = append(errs, walkObject(val, path+"."+key, allowed, positions)...)
+	}
+	return errs
+}
+
+func walkObjectArray(raw json.RawMessage, path string, allowed map[string]bool, positions map[string]Position) []ValidationError {
+	items, ok := asArray(raw)
+	if !ok {
+		return nil
+	}
+	var errs []ValidationError
+	for i, item := range items {
+		errs = append(errs, walkObject(item, fmt.Sprintf("%s[%d]", path, i), allowed, positions)...)
+	}
+	return errs
+}
+
+func asObject(raw json.RawMessage) (map[string]json.RawMessage, bool) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || raw[0] != '{' {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, false
+	}
+	return obj, true
+}
+
+func asArray(raw json.RawMessage) ([]json.RawMessage, bool) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || raw[0] != '[' {
+		return nil, false
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, false
+	}
+	return items, true
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
+// ValidPackageName reports whether name is safe to pass as a package-manager
+// operand: non-empty, no leading dash, and no whitespace or control characters.
+func ValidPackageName(name string) bool {
+	if name == "" || name[0] == '-' {
+		return false
+	}
+	for _, r := range name {
+		if r <= 0x1f || r == 0x7f || unicode.IsSpace(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -80,6 +80,7 @@ func ParseAndValidate(data []byte) (*GenvFile, []ValidationError, error) {
 
 	var errs []ValidationError
 
+	errs = append(errs, validateUnknownKeys(raw, positions)...)
 	errs = append(errs, validateSchemaVersion(f, raw, positions)...)
 	errs = append(errs, validatePackages(f, raw, positions)...)
 	errs = append(errs, validateEnv(f, raw, positions)...)
@@ -269,6 +270,13 @@ func validatePackageList(packages []Package, fieldPrefix string, positions map[s
 				Field:    pkgPath + ".id",
 				Message:  fmt.Sprintf("duplicate id %q (first seen at %s[%d])", pkg.ID, fieldPrefix, prev),
 			})
+		} else if !ValidPackageName(pkg.ID) {
+			errs = append(errs, ValidationError{
+				Position: positions[pkgPath+".id"],
+				Field:    pkgPath + ".id",
+				Message:  fmt.Sprintf("invalid package id %q: must not start with '-' or contain whitespace", pkg.ID),
+			})
+			seen[pkg.ID] = i
 		} else {
 			seen[pkg.ID] = i
 		}
@@ -281,13 +289,20 @@ func validatePackageList(packages []Package, fieldPrefix string, positions map[s
 			})
 		}
 
-		for mgr := range pkg.Managers {
+		for mgr, pkgName := range pkg.Managers {
+			field := fmt.Sprintf("%s.managers.%s", pkgPath, mgr)
 			if !KnownManagers[mgr] {
-				field := fmt.Sprintf("%s.managers.%s", pkgPath, mgr)
 				errs = append(errs, ValidationError{
 					Position: positions[field],
 					Field:    field,
 					Message:  fmt.Sprintf("unknown manager %q", mgr),
+				})
+			}
+			if !ValidPackageName(pkgName) {
+				errs = append(errs, ValidationError{
+					Position: positions[field],
+					Field:    field,
+					Message:  fmt.Sprintf("invalid package name %q: must not be empty, start with '-', or contain whitespace", pkgName),
 				})
 			}
 		}

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -1411,3 +1411,135 @@ func TestParseAndValidate_UpdatesDisabledUnknownManager(t *testing.T) {
 		t.Errorf("expected unknown manager error even when disabled, got: %v", errs)
 	}
 }
+
+func TestParseAndValidate_UnknownField(t *testing.T) {
+	tests := []struct {
+		name      string
+		json      string
+		wantField string
+		wantKey   string
+	}{
+		{
+			name:      "top-level typo",
+			json:      `{"schemaVersion":"1","packages":[],"enviroment":{"FOO":{"value":"x"}}}`,
+			wantField: "enviroment",
+			wantKey:   "enviroment",
+		},
+		{
+			name:      "package typo",
+			json:      `{"schemaVersion":"1","packages":[{"id":"git","idd":"git"}]}`,
+			wantField: "packages[0].idd",
+			wantKey:   "idd",
+		},
+		{
+			name:      "nested defaults typo",
+			json:      `{"schemaVersion":"8","defaults":{"packges":[]},"targets":{"macos":{"packages":[{"id":"git"}]}}}`,
+			wantField: "defaults.packges",
+			wantKey:   "packges",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, errs, err := ParseAndValidate([]byte(tc.json))
+			if err != nil {
+				t.Fatalf("unexpected fatal error: %v", err)
+			}
+			found := false
+			for _, e := range errs {
+				if e.Field == tc.wantField && strings.Contains(e.Message, tc.wantKey) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected unknown field %q, got: %v", tc.wantField, errs)
+			}
+		})
+	}
+}
+
+func TestParseAndValidate_DollarSchemaAllowed(t *testing.T) {
+	input := `{"$schema":"https://github.com/ks1686/genv/schema/v8/genv.json","schemaVersion":"1","packages":[]}`
+	_, errs, err := ParseAndValidate([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	if len(errs) > 0 {
+		t.Fatalf("$schema should be allowed, got: %v", errs)
+	}
+}
+
+func TestParseAndValidate_V8EnvTombstoneNotUnknown(t *testing.T) {
+	input := `{
+		"schemaVersion":"8",
+		"defaults":{"env":{"EDITOR":{"value":"vim"}}},
+		"targets":{"macos":{"packages":[{"id":"git"}],"env":{"EDITOR":null}}}
+	}`
+	_, errs, err := ParseAndValidate([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	for _, e := range errs {
+		if strings.Contains(e.Message, "unknown field") {
+			t.Fatalf("tombstone should not be unknown field, got: %v", errs)
+		}
+	}
+}
+
+func TestParseAndValidate_LeadingDashPackageID(t *testing.T) {
+	input := `{"schemaVersion":"1","packages":[{"id":"--asdeps"}]}`
+	_, errs, err := ParseAndValidate([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	found := false
+	for _, e := range errs {
+		if e.Field == "packages[0].id" && strings.Contains(e.Message, "invalid package id") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected invalid package id, got: %v", errs)
+	}
+}
+
+func TestParseAndValidate_LeadingDashManagerValue(t *testing.T) {
+	input := `{"schemaVersion":"1","packages":[{"id":"git","managers":{"pacman":"--help"}}]}`
+	_, errs, err := ParseAndValidate([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	found := false
+	for _, e := range errs {
+		if e.Field == "packages[0].managers.pacman" && strings.Contains(e.Message, "invalid package name") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected invalid package name, got: %v", errs)
+	}
+}
+
+func TestValidPackageName(t *testing.T) {
+	tests := []struct {
+		name string
+		ok   bool
+	}{
+		{"git", true},
+		{"@scope/pkg", true},
+		{"441258766", true},
+		{"python3.12", true},
+		{"--asdeps", false},
+		{"-h", false},
+		{"", false},
+		{"has space", false},
+		{"git\n", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidPackageName(tc.name); got != tc.ok {
+				t.Fatalf("ValidPackageName(%q)=%v, want %v", tc.name, got, tc.ok)
+			}
+		})
+	}
+}

--- a/main_v8_status_upgrade_test.go
+++ b/main_v8_status_upgrade_test.go
@@ -225,7 +225,7 @@ func TestEnvListShellStatusServiceList_V8Materialize(t *testing.T) {
 		"schemaVersion":"8",
 		"defaults":{
 			"env":{"EDITOR":{"value":"nvim"}},
-			"shell":{"aliases":{"ll":{"command":"ls -la"}}}
+			"shell":{"aliases":{"ll":{"value":"ls -la"}}}
 		},
 		"targets":{
 			"macos":{

--- a/schema/v8/genv.json
+++ b/schema/v8/genv.json
@@ -5,8 +5,11 @@
   "description": "genv portable targets manifest - schema version 8",
   "type": "object",
   "required": ["schemaVersion", "targets"],
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "schemaVersion": {
       "type": "string",
       "const": "8"
@@ -45,12 +48,15 @@
     },
     "hooks": {
       "type": "null"
+    },
+    "updates": {
+      "type": "object"
     }
   },
   "$defs": {
     "defaultBundle": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "packages": {
           "type": "array",
@@ -83,7 +89,7 @@
     },
     "targetBundle": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "packages": {
           "type": "array",
@@ -142,7 +148,7 @@
     "package": {
       "type": "object",
       "required": ["id"],
-      "additionalProperties": true,
+      "additionalProperties": false,
       "not": {
         "required": ["host"]
       },

--- a/scripts/docker-v8-command-matrix.sh
+++ b/scripts/docker-v8-command-matrix.sh
@@ -114,7 +114,7 @@ write_v8_spec() {
   "schemaVersion": "8",
   "defaults": {
     "env": { "EDITOR": { "value": "nvim" } },
-    "shell": { "aliases": { "ll": { "command": "ls -la" } } },
+    "shell": { "aliases": { "ll": { "value": "ls -la" } } },
     "hooks": {
       "preAdd": [{ "command": "printf preadd >> $HOOK_LOG" }],
       "postAdd": [{ "command": "printf postadd >> $HOOK_LOG" }],


### PR DESCRIPTION
## Summary
- Reject unknown keys in `genv.json` (allow `$schema` only) so typos fail closed instead of being dropped.
- Reject package ids and `managers` values that are empty, contain whitespace, or start with `-` so they cannot be parsed as manager flags.

## Test plan
- [x] Unit tests for unknown fields and `ValidPackageName`
- [ ] Arch v8 command matrix green (fixture now uses alias `value`, not `command`)