### PR TITLE
fix: keep lock files honest on failed mutations and foreign hosts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ks1686/genv
 
 go 1.24.3
+
+require golang.org/x/sys v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
+golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/internal/genvfile/genvfile_test.go
+++ b/internal/genvfile/genvfile_test.go
@@ -535,6 +535,25 @@ func TestWriteLock_InstalledVersion_OmitEmpty(t *testing.T) {
 	}
 }
 
+func TestWriteLock_Mode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits are not POSIX on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "genv.lock.json")
+	lf := &LockFile{SchemaVersion: schema.Version, Packages: []LockedPackage{}}
+	if err := WriteLock(path, lf); err != nil {
+		t.Fatalf("WriteLock: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("lock mode = %o, want 0600", got)
+	}
+}
+
 func TestNew_WritesValidV8(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "genv.json")

--- a/internal/genvfile/lockbackup.go
+++ b/internal/genvfile/lockbackup.go
@@ -1,0 +1,20 @@
+package genvfile
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// RotateBackup renames path to a timestamped sibling. A missing file is not an error.
+func RotateBackup(path string) error {
+	if path == "" {
+		return nil
+	}
+	backupPath := path + ".bak-" + time.Now().UTC().Format("20060102T150405.000000000Z")
+	if err := os.Rename(path, backupPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("backing up %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/genvfile/lockbackup_test.go
+++ b/internal/genvfile/lockbackup_test.go
@@ -1,0 +1,61 @@
+package genvfile
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRotateBackup_RenamesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "genv.lock.json")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := RotateBackup(path); err != nil {
+		t.Fatalf("RotateBackup: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("original lock should be gone, stat err=%v", err)
+	}
+	matches, err := filepath.Glob(path + ".bak-*")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("backups = %v, want 1", matches)
+	}
+}
+
+func TestRotateBackup_MissingFileIsOK(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "genv.lock.json")
+	if err := RotateBackup(path); err != nil {
+		t.Fatalf("missing lock: %v", err)
+	}
+}
+
+func TestRotateBackup_UnwritableParentIsFatal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod is not POSIX on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "genv.lock.json")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	err := RotateBackup(path)
+	if err == nil {
+		t.Fatal("expected backup error on unwritable parent")
+	}
+	if !strings.Contains(err.Error(), "backing up") {
+		t.Fatalf("error = %v, want backing up context", err)
+	}
+}

--- a/internal/genvfile/lockfile.go
+++ b/internal/genvfile/lockfile.go
@@ -114,12 +114,27 @@ func WriteLock(path string, lf *LockFile) error {
 		return fmt.Errorf("creating parent directory for lock file (%s): %w", dir, err)
 	}
 
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return fmt.Errorf("writing %s: %w", tmp, err)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing %s: %w", tmpName, err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing %s: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("saving %s: %w", path, err)
 	}
 	return nil

--- a/internal/genvfile/lockmutex.go
+++ b/internal/genvfile/lockmutex.go
@@ -1,0 +1,31 @@
+package genvfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// LockMutation acquires an exclusive cross-process lock for mutating lockPath.
+// The returned unlock function releases it. Safe to call with an empty path.
+func LockMutation(lockPath string) (unlock func(), err error) {
+	if lockPath == "" {
+		return func() {}, nil
+	}
+	dir := filepath.Dir(lockPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("creating parent directory for lock file (%s): %w", dir, err)
+	}
+	f, err := os.OpenFile(lockPath+".mutex", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("locking %s: %w", lockPath, err)
+	}
+	if err := flockExclusive(f); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("locking %s: %w", lockPath, err)
+	}
+	return func() {
+		_ = flockUnlock(f)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/genvfile/lockmutex_test.go
+++ b/internal/genvfile/lockmutex_test.go
@@ -1,0 +1,29 @@
+package genvfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLockMutation_CreatesMutexAndUnlocks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "genv.lock.json")
+
+	unlock, err := LockMutation(path)
+	if err != nil {
+		t.Fatalf("LockMutation: %v", err)
+	}
+	if _, err := os.Stat(path + ".mutex"); err != nil {
+		t.Fatalf("mutex file missing: %v", err)
+	}
+	unlock()
+}
+
+func TestLockMutation_EmptyPathIsNoop(t *testing.T) {
+	unlock, err := LockMutation("")
+	if err != nil {
+		t.Fatalf("empty path: %v", err)
+	}
+	unlock()
+}

--- a/internal/genvfile/lockmutex_unix.go
+++ b/internal/genvfile/lockmutex_unix.go
@@ -1,0 +1,16 @@
+//go:build unix
+
+package genvfile
+
+import (
+	"os"
+	"syscall"
+)
+
+func flockExclusive(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+func flockUnlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/genvfile/lockmutex_windows.go
+++ b/internal/genvfile/lockmutex_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package genvfile
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func flockExclusive(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &ol)
+}
+
+func flockUnlock(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &ol)
+}

--- a/internal/lockgate/gate.go
+++ b/internal/lockgate/gate.go
@@ -8,11 +8,14 @@ import (
 
 // Decision describes whether a lock file was written for a different host.
 type Decision struct {
-	Foreign bool
-	Reason  string
+	Foreign     bool
+	Reason      string
+	Unavailable []string
 }
 
-// Check decides whether lf belongs to a different target, OS, or manager set.
+// Check decides whether lf belongs to a different target or OS.
+// Unavailable managers on a matching host are listed in Unavailable rather
+// than treating the whole lock as foreign.
 func Check(lf *genvfile.LockFile, activeTarget, goos string, available map[string]bool) Decision {
 	if lf == nil || (len(lf.Packages) == 0 && lf.Target == "" && lf.GOOS == "") {
 		return Decision{}
@@ -29,16 +32,26 @@ func Check(lf *genvfile.LockFile, activeTarget, goos string, available map[strin
 			Reason:  fmt.Sprintf("lock goos %q does not match active goos %q", lf.GOOS, goos),
 		}
 	}
+	var unavailable []string
+	seen := map[string]bool{}
 	for _, pkg := range lf.Packages {
-		if pkg.Manager == "" {
+		if pkg.Manager == "" || available[pkg.Manager] || seen[pkg.Manager] {
 			continue
 		}
-		if !available[pkg.Manager] {
-			return Decision{
-				Foreign: true,
-				Reason:  fmt.Sprintf("lock package %q uses unavailable manager %q", pkg.ID, pkg.Manager),
-			}
+		seen[pkg.Manager] = true
+		unavailable = append(unavailable, pkg.Manager)
+	}
+	return Decision{Unavailable: unavailable}
+}
+
+// CheckStrict is Check plus treating a non-empty lock that lacks target/GOOS
+// metadata as foreign. Use this on schema v8 mutation paths.
+func CheckStrict(lf *genvfile.LockFile, activeTarget, goos string, available map[string]bool) Decision {
+	if lf != nil && len(lf.Packages) > 0 && (lf.Target == "" || lf.GOOS == "") {
+		return Decision{
+			Foreign: true,
+			Reason:  "lock is missing target/goos metadata",
 		}
 	}
-	return Decision{}
+	return Check(lf, activeTarget, goos, available)
 }

--- a/internal/lockgate/gate_test.go
+++ b/internal/lockgate/gate_test.go
@@ -50,41 +50,47 @@ func TestCheck_GOOSMismatchIsForeign(t *testing.T) {
 	}
 }
 
-func TestCheck_MissingManagerIsForeign(t *testing.T) {
+func TestCheck_UnavailableManagerIsNotForeignWhenMetadataMatches(t *testing.T) {
 	lf := &genvfile.LockFile{
 		Target: "arch",
 		GOOS:   "linux",
 		Packages: []genvfile.LockedPackage{
 			{ID: "git", Manager: "pacman", PkgName: "git"},
+			{ID: "nvim", Manager: "pacman", PkgName: "neovim"},
 		},
 	}
 
 	d := Check(lf, "arch", "linux", map[string]bool{"brew": true})
 
-	if !d.Foreign {
-		t.Fatal("expected foreign")
+	if d.Foreign {
+		t.Fatalf("expected local lock with skip list, got foreign %q", d.Reason)
 	}
-	if !strings.Contains(d.Reason, "pacman") {
-		t.Fatalf("expected missing manager reason, got %q", d.Reason)
+	if len(d.Unavailable) != 1 || d.Unavailable[0] != "pacman" {
+		t.Fatalf("unavailable = %v, want [pacman]", d.Unavailable)
 	}
 }
 
-func TestCheck_UnavailableManagerIsForeign(t *testing.T) {
+func TestCheckStrict_MissingMetadataIsForeign(t *testing.T) {
 	lf := &genvfile.LockFile{
 		Packages: []genvfile.LockedPackage{
 			{ID: "git", Manager: "pacman", PkgName: "git"},
 		},
 	}
 
-	d := Check(lf, "arch", "linux", map[string]bool{"pacman": false})
+	d := CheckStrict(lf, "arch", "linux", map[string]bool{"pacman": true})
 
 	if !d.Foreign {
 		t.Fatal("expected foreign")
+	}
+	if !strings.Contains(d.Reason, "target/goos") {
+		t.Fatalf("expected missing metadata reason, got %q", d.Reason)
 	}
 }
 
 func TestCheck_EmptyPackageManagerIsIgnored(t *testing.T) {
 	lf := &genvfile.LockFile{
+		Target: "arch",
+		GOOS:   "linux",
 		Packages: []genvfile.LockedPackage{
 			{ID: "legacy", PkgName: "legacy"},
 		},
@@ -110,5 +116,8 @@ func TestCheck_MatchingTargetOK(t *testing.T) {
 
 	if d.Foreign {
 		t.Fatalf("expected OK, got foreign with reason %q", d.Reason)
+	}
+	if len(d.Unavailable) != 0 {
+		t.Fatalf("unavailable = %v, want empty", d.Unavailable)
 	}
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -413,6 +413,7 @@ type ReconcileResult struct {
 	ToInstall []Action
 	ToRemove  []Action // UninstallCmd populated; Pkg.ID identifies the package
 	Unchanged []genvfile.LockedPackage
+	Warnings  []string
 }
 
 // Reconcile computes the delta between the desired packages (from genv.json)
@@ -461,11 +462,14 @@ func Reconcile(desired []schema.Package, managed []genvfile.LockedPackage, avail
 
 	var toRemove []Action
 	var unchanged []genvfile.LockedPackage
+	var warnings []string
 	for _, lp := range managed {
 		if !desiredByID[lp.ID] {
 			a := getAdapter(lp.Manager)
 			if a == nil {
-				continue // adapter no longer registered; skip silently
+				unchanged = append(unchanged, lp)
+				warnings = append(warnings, fmt.Sprintf("lock package %q uses unregistered manager %q; skipping uninstall", lp.ID, lp.Manager))
+				continue
 			}
 			toRemove = append(toRemove, Action{
 				Pkg:          schema.Package{ID: lp.ID},
@@ -482,7 +486,7 @@ func Reconcile(desired []schema.Package, managed []genvfile.LockedPackage, avail
 		unchanged = append(unchanged, lp)
 	}
 
-	return ReconcileResult{ToInstall: toInstall, ToRemove: toRemove, Unchanged: unchanged}
+	return ReconcileResult{ToInstall: toInstall, ToRemove: toRemove, Unchanged: unchanged, Warnings: warnings}
 }
 
 // PrintReconcilePlan writes a human-readable apply plan to w. Each line is

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -482,8 +482,14 @@ func TestReconcile_RemovalPathSkipsMissingManagers(t *testing.T) {
 	if got := result.ToRemove[0].Manager; got != "brew" {
 		t.Fatalf("expected brew removal action, got %q", got)
 	}
-	if len(result.Unchanged) != 0 {
-		t.Fatalf("expected no unchanged packages, got %d", len(result.Unchanged))
+	if len(result.Unchanged) != 1 {
+		t.Fatalf("expected missing manager to stay locked, got %d unchanged", len(result.Unchanged))
+	}
+	if got := result.Unchanged[0].ID; got != "legacy" {
+		t.Fatalf("expected legacy to remain in lock, got %q", got)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(result.Warnings), result.Warnings)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -391,13 +391,22 @@ func lockPathForSpec(file, override string) string {
 	return genvfile.LockPathFrom(file)
 }
 
-func appendLockEntry(lockPath string, lp genvfile.LockedPackage) int {
+func stampLockTarget(lf *genvfile.LockFile, targetID string) {
+	if lf == nil || targetID == "" {
+		return
+	}
+	lf.Target = targetID
+	lf.GOOS = runtime.GOOS
+}
+
+func appendLockEntry(lockPath string, lp genvfile.LockedPackage, targetID string) int {
 	lf, err := genvfile.ReadLock(lockPath)
 	if err != nil {
 		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
 		return exitIO
 	}
 	lf.Packages = append(lf.Packages, lp)
+	stampLockTarget(lf, targetID)
 	if err := genvfile.WriteLock(lockPath, lf); err != nil {
 		fprintf(os.Stderr, "genv: writing lock: %v\n", err)
 		return exitIO
@@ -565,11 +574,15 @@ func addCmd(args []string) int {
 	}
 
 	// 4. Update lock file.
+	targetID, code := resolveMutationTarget("add", *file, prepared, *targetFlag)
+	if code != exitOK {
+		return code
+	}
 	exit = appendLockEntry(lockPath, genvfile.LockedPackage{
 		ID:      action.Pkg.ID,
 		Manager: action.Manager,
 		PkgName: action.PkgName,
-	})
+	}, targetID)
 	if exit != exitOK || *noHooks {
 		return exit
 	}
@@ -718,6 +731,17 @@ func runRemove(opts removeOptions) int {
 	if exit != exitOK {
 		return exit
 	}
+	unlock, err := genvfile.LockMutation(lockPath)
+	if err != nil {
+		fprintf(os.Stderr, "genv: locking %s: %v\n", lockPath, err)
+		return exitIO
+	}
+	defer unlock()
+	lf, err = genvfile.ReadLock(lockPath)
+	if err != nil {
+		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
+		return exitIO
+	}
 
 	// 2. Find the package in the lock file to know which manager installed it.
 	var locked *genvfile.LockedPackage
@@ -749,7 +773,7 @@ func runRemove(opts removeOptions) int {
 	uninstallErr := runForegroundCommand(uninstallCmd)
 	if uninstallErr != nil {
 		fprintf(os.Stderr, "genv: uninstall failed: %v\n", uninstallErr)
-		// Still update the lock — the package is removed from the spec.
+		return exitLogic
 	}
 
 	// Cache clean.
@@ -760,15 +784,10 @@ func runRemove(opts removeOptions) int {
 		}
 	}
 
-	// 4. Update lock file (remove the entry regardless of uninstall success).
 	lf.Packages = remaining
 	if err := genvfile.WriteLock(lockPath, lf); err != nil {
 		fprintf(os.Stderr, "genv: writing lock: %v\n", err)
 		return exitIO
-	}
-
-	if uninstallErr != nil {
-		return exitLogic
 	}
 	if !opts.NoHooks {
 		hooksCfg, code := materializedHooks("remove", file, opts.Host, opts.Target)
@@ -873,11 +892,19 @@ func adoptCmd(args []string) int {
 	}
 
 	// 4. Update lock file.
+	targetID := ""
+	if prepared, err := genvfile.Read(*file); err == nil {
+		var code int
+		targetID, code = resolveMutationTarget("adopt", *file, prepared, *targetFlag)
+		if code != exitOK {
+			return code
+		}
+	}
 	if exit := appendLockEntry(lockPathForSpec(*file, *lockFile), genvfile.LockedPackage{
 		ID:      action.Pkg.ID,
 		Manager: action.Manager,
 		PkgName: action.PkgName,
-	}); exit != exitOK {
+	}, targetID); exit != exitOK {
 		return exit
 	}
 
@@ -1128,6 +1155,12 @@ func runApply(opts applyOptions) int {
 	}
 
 	lockPath := lockPathForSpec(opts.File, opts.LockFile)
+	unlock, err := genvfile.LockMutation(lockPath)
+	if err != nil {
+		fprintf(os.Stderr, "genv: locking %s: %v\n", lockPath, err)
+		return exitIO
+	}
+	defer unlock()
 	lf, err := genvfile.ReadLock(lockPath)
 	if err != nil {
 		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
@@ -1158,6 +1191,37 @@ func runApply(opts applyOptions) int {
 	return runApplyWithSpecAndLock(ctx, opts, f, lf, lockPath)
 }
 
+func applyLockGate(cmd, lockPath string, lf *genvfile.LockFile, activeTarget string, available map[string]bool, requireMeta, forceNew, dryRun bool, forceHint string) (*genvfile.LockFile, int) {
+	var decision lockgate.Decision
+	if requireMeta {
+		decision = lockgate.CheckStrict(lf, activeTarget, runtime.GOOS, available)
+	} else {
+		decision = lockgate.Check(lf, activeTarget, runtime.GOOS, available)
+	}
+	for _, mgr := range decision.Unavailable {
+		fprintf(os.Stderr, "genv %s: warning: lock uses unavailable manager %q; skipping its packages\n", cmd, mgr)
+	}
+	if !decision.Foreign {
+		return lf, exitOK
+	}
+	if !forceNew {
+		fprintf(os.Stderr, "genv %s: foreign lock refused: %s\n", cmd, decision.Reason)
+		if forceHint != "" {
+			fprintf(os.Stderr, "Back up or remove %s, or rerun with %s to move it aside and create a new local lock.\n", lockPath, forceHint)
+		} else {
+			fprintf(os.Stderr, "Back up or remove %s and rerun.\n", lockPath)
+		}
+		return lf, exitLogic
+	}
+	if !dryRun {
+		if err := genvfile.RotateBackup(lockPath); err != nil {
+			fprintf(os.Stderr, "genv %s: could not back up foreign lock %s: %v\n", cmd, lockPath, err)
+			return lf, exitIO
+		}
+	}
+	return &genvfile.LockFile{SchemaVersion: schema.Version8}, exitOK
+}
+
 func runApplyWithSpecAndLock(ctx context.Context, opts applyOptions, f *schema.GenvFile, lf *genvfile.LockFile, lockPath string) int {
 	available := resolver.Detect()
 	if lf == nil {
@@ -1169,21 +1233,11 @@ func runApplyWithSpecAndLock(ctx context.Context, opts applyOptions, f *schema.G
 		return code
 	}
 	if isV8 {
-		decision := lockgate.Check(lf, activeTarget, runtime.GOOS, available)
-		if decision.Foreign {
-			if !opts.ForceNewLock {
-				fprintf(os.Stderr, "genv apply: foreign lock refused: %s\n", decision.Reason)
-				fprintf(os.Stderr, "Back up or remove %s, or rerun with --force-new-lock to move it aside and create a new local lock.\n", lockPath)
-				return exitLogic
-			}
-			if !opts.DryRun {
-				backupPath := lockPath + ".bak-" + time.Now().UTC().Format("20060102T150405.000000000Z")
-				if err := os.Rename(lockPath, backupPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-					fprintf(os.Stderr, "genv apply: warning: could not back up foreign lock %s: %v\n", lockPath, err)
-				}
-			}
-			lf = &genvfile.LockFile{SchemaVersion: schema.Version8}
+		reset, code := applyLockGate("apply", lockPath, lf, activeTarget, available, true, opts.ForceNewLock, opts.DryRun, "--force-new-lock")
+		if code != exitOK {
+			return code
 		}
+		lf = reset
 	}
 	f = effective
 	opts.Target = activeTarget
@@ -1196,6 +1250,7 @@ func runApplyWithSpecAndLock(ctx context.Context, opts applyOptions, f *schema.G
 }
 
 func runApplyJSON(ctx context.Context, opts applyOptions, lockPath string, f *schema.GenvFile, lf *genvfile.LockFile, result resolver.ReconcileResult) int {
+	printReconcileWarnings(result)
 	planData := buildPlanResult(f, lf, result)
 	if opts.DryRun {
 		filePlan, filePlanErr := applyFiles(ctx, opts, f, lf)
@@ -1253,7 +1308,28 @@ func runApplyJSON(ctx context.Context, opts applyOptions, lockPath string, f *sc
 		}
 	}
 	success := len(errs) == 0
-	writeLockAfterApply(lockPath, lf, result, execResult, opts.TargetProfile, opts.Target, success)
+	if err := writeLockAfterApply(lockPath, lf, result, execResult, opts.TargetProfile, opts.Target, success); err != nil {
+		fprintf(os.Stderr, "genv: writing lock: %v\n", err)
+		errs = append(errs, err.Error())
+		installed := make([]string, len(execResult.Installed))
+		for i, lp := range execResult.Installed {
+			installed[i] = lp.ID
+		}
+		return writeJSON(os.Stdout, output.Envelope{
+			Version: output.SchemaVersion,
+			Command: "apply",
+			OK:      false,
+			Data: output.ApplyResult{
+				Installed:    installed,
+				Uninstalled:  execResult.Uninstalled,
+				EnvApplied:   envApplied,
+				EnvRemoved:   envRemoved,
+				ShellApplied: shellApplied,
+				ShellRemoved: shellRemoved,
+			},
+			Errors: errs,
+		})
+	}
 
 	installed := make([]string, len(execResult.Installed))
 	for i, lp := range execResult.Installed {
@@ -1280,6 +1356,7 @@ func runApplyJSON(ctx context.Context, opts applyOptions, lockPath string, f *sc
 }
 
 func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *schema.GenvFile, lf *genvfile.LockFile, result resolver.ReconcileResult) int {
+	printReconcileWarnings(result)
 	planOut := io.Writer(os.Stdout)
 	if opts.Quiet {
 		planOut = io.Discard
@@ -1328,7 +1405,10 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 					return exitLogic
 				}
 			}
-			writeLockAfterApply(lockPath, lf, result, resolver.ApplyExecution{}, opts.TargetProfile, opts.Target, true)
+			if err := writeLockAfterApply(lockPath, lf, result, resolver.ApplyExecution{}, opts.TargetProfile, opts.Target, true); err != nil {
+				fprintf(os.Stderr, "genv: writing lock: %v\n", err)
+				return exitIO
+			}
 		}
 		return exitOK
 	}
@@ -1412,7 +1492,10 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 		hookErrs = runApplyHookPhase(ctx, f, hookContext{Event: "apply", Phase: "post-apply", Host: hostName, Profile: lf.ActiveProfile, Yes: opts.Yes, Installed: lockedPackageIDs(execResult.Installed), Removed: execResult.Uninstalled, Failed: applyFailedIDs(execResult.Errors)}, opts.HookTimeout, false)
 	}
 	success := len(execResult.Errors) == 0 && len(svcErrs) == 0 && len(fileErrs) == 0 && len(hookErrs) == 0
-	writeLockAfterApply(lockPath, lf, result, execResult, opts.TargetProfile, opts.Target, success)
+	if err := writeLockAfterApply(lockPath, lf, result, execResult, opts.TargetProfile, opts.Target, success); err != nil {
+		fprintf(os.Stderr, "genv: writing lock: %v\n", err)
+		return exitIO
+	}
 
 	if !success {
 		for _, e := range execResult.Errors {
@@ -1433,9 +1516,15 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	return exitOK
 }
 
+func printReconcileWarnings(result resolver.ReconcileResult) {
+	for _, w := range result.Warnings {
+		fprintf(os.Stderr, "genv apply: warning: %s\n", w)
+	}
+}
+
 // writeLockAfterApply updates the lock file to reflect what actually succeeded.
 // Called from both the JSON and human-readable paths of applyCmd.
-func writeLockAfterApply(lockPath string, lf *genvfile.LockFile, result resolver.ReconcileResult, execResult resolver.ApplyExecution, targetProfile, activeTarget string, success bool) {
+func writeLockAfterApply(lockPath string, lf *genvfile.LockFile, result resolver.ReconcileResult, execResult resolver.ApplyExecution, targetProfile, activeTarget string, success bool) error {
 	if success && targetProfile != "" {
 		if targetProfile == "base" {
 			lf.ActiveProfile = ""
@@ -1451,23 +1540,43 @@ func writeLockAfterApply(lockPath string, lf *genvfile.LockFile, result resolver
 	for _, id := range execResult.Uninstalled {
 		uninstalledSet[id] = true
 	}
-	newPkgs := make([]genvfile.LockedPackage, 0, len(result.Unchanged)+len(execResult.Installed))
+	installedSet := make(map[string]bool, len(execResult.Installed))
+	for _, lp := range execResult.Installed {
+		installedSet[lp.ID] = true
+	}
+	prevByID := make(map[string]genvfile.LockedPackage, len(lf.Packages))
+	for _, lp := range lf.Packages {
+		prevByID[lp.ID] = lp
+	}
+	newPkgs := make([]genvfile.LockedPackage, 0, len(result.Unchanged)+len(execResult.Installed)+len(result.ToRemove)+len(result.ToInstall))
 	newPkgs = append(newPkgs, result.Unchanged...)
 	newPkgs = append(newPkgs, execResult.Installed...)
+	for _, a := range result.ToInstall {
+		if installedSet[a.Pkg.ID] {
+			continue
+		}
+		if prev, ok := prevByID[a.Pkg.ID]; ok {
+			newPkgs = append(newPkgs, prev)
+		}
+	}
 	for _, a := range result.ToRemove {
 		if !uninstalledSet[a.Pkg.ID] {
-			// Removal failed — keep in lock since it's still installed.
-			newPkgs = append(newPkgs, genvfile.LockedPackage{
-				ID:      a.Pkg.ID,
-				Manager: a.Manager,
-				PkgName: a.PkgName,
-			})
+			if prev, ok := prevByID[a.Pkg.ID]; ok {
+				newPkgs = append(newPkgs, prev)
+			} else {
+				newPkgs = append(newPkgs, genvfile.LockedPackage{
+					ID:      a.Pkg.ID,
+					Manager: a.Manager,
+					PkgName: a.PkgName,
+				})
+			}
 		}
 	}
 	lf.Packages = newPkgs
 	if err := genvfile.WriteLock(lockPath, lf); err != nil {
-		fprintf(os.Stderr, "genv: writing lock: %v\n", err)
+		return err
 	}
+	return nil
 }
 
 // applyEnvVars writes managed env fragments via selected profile backends,
@@ -2662,6 +2771,7 @@ func scanCmd(args []string) int {
 			fprintf(os.Stderr, "genv: writing spec: %v\n", err)
 			return exitIO
 		}
+		stampLockTarget(lf, targetID)
 		if err := genvfile.WriteLock(lockPath, lf); err != nil {
 			fprintf(os.Stderr, "genv: writing lock: %v\n", err)
 			return exitIO
@@ -3531,10 +3641,26 @@ func upgradeCmd(args []string) int {
 		}
 		return exitIO
 	}
-	f, _, code := materializeSpecForCommand("upgrade", *file, f, *hostFlag, *targetFlag)
+	f, activeTarget, code := materializeSpecForCommand("upgrade", *file, f, *hostFlag, *targetFlag)
 	if code != exitOK {
 		return code
 	}
+
+	unlock, err := genvfile.LockMutation(lockPath)
+	if err != nil {
+		if *jsonOut {
+			_ = writeJSON(os.Stdout, output.Envelope{
+				Version: output.SchemaVersion,
+				Command: "upgrade",
+				OK:      false,
+				Errors:  []string{err.Error()},
+			})
+			return exitIO
+		}
+		fprintf(os.Stderr, "genv upgrade: locking %s: %v\n", lockPath, err)
+		return exitIO
+	}
+	defer unlock()
 
 	lf, err := genvfile.ReadLock(lockPath)
 	if err != nil {
@@ -3549,6 +3675,21 @@ func upgradeCmd(args []string) int {
 		}
 		fprintf(os.Stderr, "genv upgrade: reading lock: %v\n", err)
 		return exitIO
+	}
+	if f.SchemaVersion == schema.Version8 {
+		available := resolver.Detect()
+		_, code := applyLockGate("upgrade", lockPath, lf, activeTarget, available, true, false, *dryRun, "")
+		if code != exitOK {
+			if *jsonOut {
+				_ = writeJSON(os.Stdout, output.Envelope{
+					Version: output.SchemaVersion,
+					Command: "upgrade",
+					OK:      false,
+					Errors:  []string{"foreign lock refused"},
+				})
+			}
+			return code
+		}
 	}
 	only := parseCommaList(*onlyFlag)
 	skip := parseCommaList(*skipFlag)

--- a/main_apply_portability_test.go
+++ b/main_apply_portability_test.go
@@ -111,6 +111,80 @@ func TestApply_LegacySuccessfulWriteDoesNotStampTargetMetadata(t *testing.T) {
 	}
 }
 
+func TestApply_MissingLockMetadataRefused(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+
+	writeTestFile(t, specPath, `{"schemaVersion":"8","targets":{"arch":{"packages":[{"id":"git","prefer":"mas"}]}}}`)
+	writeTestFile(t, lockPath, `{"schemaVersion":"1","packages":[{"id":"x","manager":"mas","pkgName":"1"}]}`)
+
+	var code int
+	errOut := captureStderr(t, func() {
+		code = run([]string{"apply", "--file", specPath, "--lock-file", lockPath, "--target", "arch", "--yes", "--dry-run"})
+	})
+
+	if code != exitLogic {
+		t.Fatalf("apply missing lock metadata: expected exitLogic (%d), got %d; stderr=%s", exitLogic, code, errOut)
+	}
+	if !strings.Contains(errOut, "foreign lock") || !strings.Contains(errOut, "target/goos") {
+		t.Fatalf("missing metadata message, got: %s", errOut)
+	}
+}
+
+func TestUpgrade_ForeignLockRefused(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+
+	writeTestFile(t, specPath, `{"schemaVersion":"8","targets":{"arch":{"packages":[{"id":"git","prefer":"pacman"}]}}}`)
+	writeTestFile(t, lockPath, `{"schemaVersion":"8","target":"macos","goos":"darwin","packages":[{"id":"git","manager":"brew","pkgName":"git"}]}`)
+
+	var code int
+	errOut := captureStderr(t, func() {
+		code = run([]string{"upgrade", "--file", specPath, "--lock-file", lockPath, "--target", "arch", "--dry-run"})
+	})
+
+	if code != exitLogic {
+		t.Fatalf("upgrade foreign lock: expected exitLogic (%d), got %d; stderr=%s", exitLogic, code, errOut)
+	}
+	if !strings.Contains(errOut, "foreign lock") {
+		t.Fatalf("upgrade foreign lock message missing, got: %s", errOut)
+	}
+	if strings.Contains(errOut, "--force-new-lock") {
+		t.Fatalf("upgrade should not suggest --force-new-lock, got: %s", errOut)
+	}
+}
+
+func TestRemove_UninstallFailureLeavesLock(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	registerLifecycleHookAdapter(t, lifecycleHookAdapter{failUninstall: true})
+
+	writeTestFile(t, specPath, `{"schemaVersion":"7","packages":[{"id":"alpha","prefer":"test-hook-manager"}]}`)
+	writeLock(t, lockPath, []genvfile.LockedPackage{{ID: "alpha", Manager: "test-hook-manager", PkgName: "alpha"}})
+
+	var code int
+	errOut := captureStderr(t, func() {
+		code = run([]string{"remove", "--file", specPath, "--lock-file", lockPath, "--no-hooks", "alpha"})
+	})
+	if code != exitLogic {
+		t.Fatalf("remove uninstall failure: expected exitLogic (%d), got %d; stderr=%s", exitLogic, code, errOut)
+	}
+
+	lf, err := genvfile.ReadLock(lockPath)
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+	if len(lf.Packages) != 1 || lf.Packages[0].ID != "alpha" {
+		t.Fatalf("lock packages = %+v, want alpha retained", lf.Packages)
+	}
+}
+
 func writeTestFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -1840,6 +1840,7 @@ type lifecycleHookAdapter struct {
 	installMarker   string
 	uninstallMarker string
 	upgradeMarker   string
+	failUninstall   bool
 }
 
 func (a lifecycleHookAdapter) Name() string    { return "test-hook-manager" }
@@ -1853,6 +1854,9 @@ func (a lifecycleHookAdapter) PlanInstall(pkgName string) []string {
 }
 
 func (a lifecycleHookAdapter) PlanUninstall(pkgName string) []string {
+	if a.failUninstall {
+		return []string{"sh", "-c", "exit 1"}
+	}
 	return shellAppendMarker("uninstall", a.uninstallMarker)
 }
 

--- a/main_updates_worker.go
+++ b/main_updates_worker.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ks1686/genv/internal/genvfile"
 	"github.com/ks1686/genv/internal/output"
+	"github.com/ks1686/genv/internal/resolver"
 	"github.com/ks1686/genv/internal/schema"
 	"github.com/ks1686/genv/internal/service"
 	"github.com/ks1686/genv/internal/upgrade"
@@ -74,7 +75,7 @@ func updatesRunOnceCmd(args []string) int {
 }
 
 func updatesRunOnceBody(ctx context.Context, logger *slog.Logger, f *schema.GenvFile, cfg *schema.UpdatesConfig, file, lockFile, hostFlag, targetFlag string) int {
-	f, _, code := materializeSpecForCommand("updates", file, f, hostFlag, targetFlag)
+	f, activeTarget, code := materializeSpecForCommand("updates", file, f, hostFlag, targetFlag)
 	if code != exitOK {
 		logger.Warn("updates.check.target", slog.Int("exit", code))
 		return code
@@ -84,6 +85,14 @@ func updatesRunOnceBody(ctx context.Context, logger *slog.Logger, f *schema.Genv
 	if err != nil {
 		logger.Warn("updates.check.lock", slog.Any("err", err))
 		return exitIO
+	}
+	if f.SchemaVersion == schema.Version8 {
+		available := resolver.Detect()
+		_, code := applyLockGate("updates", lockPath, lf, activeTarget, available, true, false, true, "")
+		if code != exitOK {
+			logger.Warn("updates.check.lock", slog.Int("exit", code), slog.String("reason", "foreign lock refused"))
+			return code
+		}
 	}
 	filters := output.UpgradeFilters{Only: cfg.Only, Skip: cfg.Skip, OnlyManager: cfg.OnlyManagers, SkipManager: cfg.SkipManagers, HooksSkipped: true}
 	planStarted := time.Now()

--- a/main_v8_status_upgrade_test.go
+++ b/main_v8_status_upgrade_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -120,9 +121,16 @@ func TestStatusUpgradeUpdates_V8TargetPackagesMatchLock(t *testing.T) {
 	upgradeMarker := filepath.Join(dir, "upgrade.log")
 
 	writeTestFile(t, specPath, `{"schemaVersion":"8","targets":{"macos":{"packages":[{"id":"alpha"}]}}}`)
-	writeLock(t, lockPath, []genvfile.LockedPackage{
-		{ID: "alpha", Manager: "test-upgrade-no-hooks", PkgName: pkgNameForTest, InstalledVersion: "1.0.0"},
-	})
+	if err := genvfile.WriteLock(lockPath, &genvfile.LockFile{
+		SchemaVersion: schema.Version8,
+		Target:        "macos",
+		GOOS:          runtime.GOOS,
+		Packages: []genvfile.LockedPackage{
+			{ID: "alpha", Manager: "test-upgrade-no-hooks", PkgName: pkgNameForTest, InstalledVersion: "1.0.0"},
+		},
+	}); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
 
 	originalAll := adapter.All
 	adapter.All = append([]adapter.Adapter{upgradeNoHooksAdapter{marker: upgradeMarker}}, originalAll...)


### PR DESCRIPTION
## Summary
- Treat unstamped or cross-host v8 locks as foreign; `--force-new-lock` backup failure is fatal.
- Keep lock rows when install/uninstall does not actually succeed, and warn instead of dropping lock-only packages whose adapter is missing.
- Serialize lock mutations with an exclusive mutex and write lock files mode `0600`.

## Test plan
- [x] lockgate / genvfile / apply portability tests
- [ ] CI Test + integration green on this layer