### PR TITLE
fix: validate pull remotes before copying specs or following assets

### DIFF
--- a/internal/pull/assets.go
+++ b/internal/pull/assets.go
@@ -128,9 +128,12 @@ func isASCIIAlpha(b byte) bool {
 func copyBundleAsset(cacheDir, destDir, rel string) error {
 	src := filepath.Join(cacheDir, filepath.FromSlash(rel))
 	dst := filepath.Join(destDir, filepath.FromSlash(rel))
-	info, err := os.Stat(src)
+	info, err := os.Lstat(src)
 	if err != nil {
 		return fmt.Errorf("copying bundle asset %s: %w", rel, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("copying bundle asset %s: symlinks are not allowed", rel)
 	}
 	if info.IsDir() {
 		return copyBundleDir(src, dst, rel)
@@ -147,14 +150,18 @@ func copyBundleDir(srcRoot, dstRoot, relRoot string) error {
 		if err != nil {
 			return err
 		}
+		nestedRel := relRoot
 		if rel != "." {
-			nestedRel := path.Join(relRoot, filepath.ToSlash(rel))
+			nestedRel = path.Join(relRoot, filepath.ToSlash(rel))
 			if shouldSkipBundlePath(nestedRel) {
 				if d.IsDir() {
 					return filepath.SkipDir
 				}
 				return nil
 			}
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("copying bundle asset %s: symlinks are not allowed", nestedRel)
 		}
 		dst := filepath.Join(dstRoot, rel)
 		if d.IsDir() {

--- a/internal/pull/assets_test.go
+++ b/internal/pull/assets_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/ks1686/genv/internal/schema"
@@ -44,6 +45,37 @@ func TestCopyBundleAssetsV7CopiesRelativeFileAssets(t *testing.T) {
 	assertFileContent(t, filepath.Join(destDir, "templates", "app.tmpl"), "template")
 	assertNotExists(t, filepath.Join(destDir, "secrets", "token"))
 	assertNotExists(t, filepath.Join(destDir, "genv.lock.json"))
+}
+
+func TestCopyBundleAssets_RejectsSymlink(t *testing.T) {
+	cacheDir := t.TempDir()
+	destDir := t.TempDir()
+	target := filepath.Join(cacheDir, "real")
+	if err := os.WriteFile(target, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	link := filepath.Join(cacheDir, "assets", "profile")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	f := &schema.GenvFile{
+		SchemaVersion: schema.Version7,
+		Files: &schema.FilesConfig{
+			Links: []schema.FileLink{{Source: "assets/profile", Target: "~/.profile"}},
+		},
+	}
+	_, err := CopyBundleAssets(cacheDir, destDir, f)
+	if err == nil {
+		t.Fatal("expected symlink copy to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error = %v, want symlink mention", err)
+	}
+	assertNotExists(t, filepath.Join(destDir, "assets", "profile"))
 }
 
 func TestCopyBundleAssetsV8UnionsDefaultsAndTargets(t *testing.T) {

--- a/internal/schema/repo.go
+++ b/internal/schema/repo.go
@@ -1,0 +1,65 @@
+package schema
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+// ValidRepoURL reports whether raw is a git remote genv will clone or fetch.
+// Allowed: https://, ssh://, file://, git@scp-syntax, absolute paths, and ~/ paths.
+func ValidRepoURL(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("repository URL is empty")
+	}
+	if strings.HasPrefix(raw, "-") {
+		return fmt.Errorf("repository URL must not start with '-'")
+	}
+	if strings.HasPrefix(strings.ToLower(raw), "ext::") {
+		return fmt.Errorf("ext:: repository URLs are not allowed")
+	}
+	switch {
+	case strings.HasPrefix(strings.ToLower(raw), "https://"),
+		strings.HasPrefix(strings.ToLower(raw), "ssh://"),
+		strings.HasPrefix(strings.ToLower(raw), "file://"),
+		strings.HasPrefix(raw, "git@"),
+		strings.HasPrefix(raw, "~/"),
+		strings.HasPrefix(raw, `~\`),
+		filepath.IsAbs(raw),
+		isWindowsAbsPath(raw):
+		return nil
+	default:
+		return fmt.Errorf("unsupported repository URL %q", raw)
+	}
+}
+
+// ValidGitRef reports whether ref is safe to pass as a git checkout/merge operand.
+func ValidGitRef(ref string) error {
+	if ref == "" {
+		return fmt.Errorf("git ref is empty")
+	}
+	if strings.HasPrefix(ref, "-") {
+		return fmt.Errorf("git ref must not start with '-'")
+	}
+	for _, r := range ref {
+		if r <= 0x1f || r == 0x7f || unicode.IsSpace(r) {
+			return fmt.Errorf("git ref contains invalid characters")
+		}
+	}
+	return nil
+}
+
+func isWindowsAbsPath(raw string) bool {
+	if len(raw) < 3 {
+		return false
+	}
+	drive := raw[0]
+	if (drive < 'A' || drive > 'Z') && (drive < 'a' || drive > 'z') {
+		return false
+	}
+	if raw[1] != ':' {
+		return false
+	}
+	return raw[2] == '\\' || raw[2] == '/'
+}

--- a/internal/schema/repo_test.go
+++ b/internal/schema/repo_test.go
@@ -1,0 +1,49 @@
+package schema
+
+import "testing"
+
+func TestValidRepoURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "https", url: "https://github.com/example/dotfiles.git"},
+		{name: "ssh scheme", url: "ssh://git@github.com/example/dotfiles.git"},
+		{name: "scp git@", url: "git@github.com:example/dotfiles.git"},
+		{name: "file scheme", url: "file:///tmp/dotfiles.git"},
+		{name: "tilde path", url: "~/terminal-config"},
+		{name: "windows drive", url: `C:\Users\me\dotfiles.git`},
+		{name: "empty", url: "", wantErr: true},
+		{name: "leading dash", url: "-u", wantErr: true},
+		{name: "ext helper", url: "ext::sh -c evil", wantErr: true},
+		{name: "http", url: "http://example.com/repo.git", wantErr: true},
+		{name: "relative", url: "local", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidRepoURL(tc.url)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidGitRef(t *testing.T) {
+	if err := ValidGitRef("main"); err != nil {
+		t.Fatalf("main: %v", err)
+	}
+	if err := ValidGitRef("-evil"); err == nil {
+		t.Fatal("expected error for leading dash")
+	}
+	if err := ValidGitRef("feat branch"); err == nil {
+		t.Fatal("expected error for whitespace")
+	}
+}

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -845,12 +845,21 @@ func validateRepo(f *GenvFile, raw map[string]json.RawMessage, positions map[str
 				Field:    "repo",
 				Message:  "repo block must be an object with a url field",
 			})
-		} else if f.Repo.URL == "" {
+		} else if err := ValidRepoURL(f.Repo.URL); err != nil {
 			errs = append(errs, ValidationError{
 				Position: positions["repo.url"],
 				Field:    "repo.url",
-				Message:  "required field is missing or empty",
+				Message:  err.Error(),
 			})
+		}
+		if f.Repo != nil && f.Repo.Ref != "" {
+			if err := ValidGitRef(f.Repo.Ref); err != nil {
+				errs = append(errs, ValidationError{
+					Position: positions["repo.ref"],
+					Field:    "repo.ref",
+					Message:  err.Error(),
+				})
+			}
 		}
 	}
 	return errs

--- a/main_coverage_extra_test.go
+++ b/main_coverage_extra_test.go
@@ -151,7 +151,7 @@ func TestPullCmd_ClonesLocalRepositoryAndCopiesSpec(t *testing.T) {
 	runGitCommand(t, "-C", work, "config", "commit.gpgsign", "false")
 	runGitCommand(t, "-C", work, "config", "tag.gpgsign", "false")
 
-	remoteSpec := `{"schemaVersion":"6","packages":[],"repo":{"url":"local","ref":"main"}}`
+	remoteSpec := `{"schemaVersion":"6","packages":[],"repo":{"url":"https://example.com/spec.git","ref":"main"}}`
 	if err := os.WriteFile(filepath.Join(work, "genv.json"), []byte(remoteSpec), 0o644); err != nil {
 		t.Fatalf("write remote spec: %v", err)
 	}

--- a/main_pull.go
+++ b/main_pull.go
@@ -95,17 +95,16 @@ func pullCmd(args []string) int {
 	}
 
 	src := filepath.Join(cacheDir, "genv.json")
-	if err := copyFile(src, *file); err != nil {
-		fprintf(os.Stderr, "genv pull: writing spec: %v\n", err)
-		return exitIO
-	}
-
 	remote, err := genvfile.Read(src)
 	if err != nil {
 		fprintf(os.Stderr, "genv pull: reading remote spec: %v\n", err)
 		if errors.Is(err, genvfile.ErrInvalidFile) {
 			return exitValidation
 		}
+		return exitIO
+	}
+	if err := copyFile(src, *file); err != nil {
+		fprintf(os.Stderr, "genv pull: writing spec: %v\n", err)
 		return exitIO
 	}
 	copiedAssets, err := pullassets.CopyBundleAssets(cacheDir, filepath.Dir(*file), remote)
@@ -142,6 +141,13 @@ func resolvePullSource(repo *schema.Repo, urlFlag, refFlag string) (url, ref str
 		ref = repo.Ref
 	} else {
 		ref = "main"
+	}
+
+	if err := schema.ValidRepoURL(url); err != nil {
+		return "", "", err
+	}
+	if err := schema.ValidGitRef(ref); err != nil {
+		return "", "", err
 	}
 
 	return url, ref, nil
@@ -202,7 +208,7 @@ func updateRepoCache(cacheDir, url, ref string) error {
 		if err := os.MkdirAll(filepath.Dir(cacheDir), 0o700); err != nil {
 			return fmt.Errorf("creating cache directory: %w", err)
 		}
-		if err := runGit("clone", url, cacheDir); err != nil {
+		if err := runGit("clone", "--", url, cacheDir); err != nil {
 			return fmt.Errorf("cloning repo: %w", err)
 		}
 		return runGit("-C", cacheDir, "checkout", ref)

--- a/main_test.go
+++ b/main_test.go
@@ -3582,6 +3582,22 @@ func TestResolvePullSource(t *testing.T) {
 			name:    "empty repo and no flags errors",
 			wantErr: true,
 		},
+		{
+			name:    "ext helper url is rejected",
+			urlFlag: "ext::sh -c evil",
+			wantErr: true,
+		},
+		{
+			name:    "leading dash url is rejected",
+			urlFlag: "-u",
+			wantErr: true,
+		},
+		{
+			name:    "leading dash ref is rejected",
+			urlFlag: "https://example.com/repo.git",
+			refFlag: "-evil",
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -3625,6 +3641,66 @@ func TestPullCmd_NoURLError(t *testing.T) {
 	code := run([]string{"pull", "--file", path})
 	if code != exitUsage {
 		t.Errorf("no url: expected exitUsage (%d), got %d", exitUsage, code)
+	}
+}
+
+func TestPullCmd_RejectsExtURL(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	if err := os.WriteFile(path, []byte(`{"schemaVersion":"5","packages":[]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var code int
+	errOut := captureStderr(t, func() {
+		code = run([]string{"pull", "--file", path, "--url", "ext::sh -c evil"})
+	})
+	if code != exitUsage {
+		t.Fatalf("ext url: expected exitUsage (%d), got %d; stderr=%s", exitUsage, code, errOut)
+	}
+	if !strings.Contains(errOut, "ext::") {
+		t.Fatalf("stderr = %q, want ext:: mention", errOut)
+	}
+}
+
+func TestPullCmd_InvalidRemoteSpecLeavesLocal(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "remote")
+	destDir := filepath.Join(dir, "dest")
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(dir, "cache"))
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runGitForTest(t, repoDir, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repoDir, "genv.json"), []byte(`{"schemaVersion":"99"}`), 0o644); err != nil {
+		t.Fatalf("write remote spec: %v", err)
+	}
+	runGitForTest(t, repoDir, "add", ".")
+	runGitForTest(t, repoDir, "-c", "user.name=genv test", "-c", "user.email=test@example.com", "commit", "-m", "bad spec")
+
+	specPath := filepath.Join(destDir, "genv.json")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+	localSpec := fmt.Sprintf(`{"schemaVersion":"7","packages":[{"id":"keep-me"}],"repo":{"url":%q,"ref":"main"}}`, repoDir)
+	if err := os.WriteFile(specPath, []byte(localSpec), 0o644); err != nil {
+		t.Fatalf("write local spec: %v", err)
+	}
+
+	code := run([]string{"pull", "--file", specPath})
+	if code != exitValidation {
+		t.Fatalf("pull invalid remote: expected exitValidation (%d), got %d", exitValidation, code)
+	}
+	got, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read local spec: %v", err)
+	}
+	if !strings.Contains(string(got), "keep-me") {
+		t.Fatalf("local spec was overwritten: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Validate pull remotes before copying the spec: allow `https`/`ssh`/`file`/`git@`/absolute/`~/` URLs, reject `ext::`, leading-dash operands, and relative names.
- Parse the remote spec first so an invalid remote cannot overwrite a local `genv.json`.
- Refuse to follow symlink assets.

## Test plan
- [x] `ValidRepoURL` / `ValidGitRef` unit tests, symlink asset test, invalid-remote-leaves-local test
- [ ] CI Test green on this layer