### PR TITLE
fix: fail-closed apply side effects and per-spawn timeouts

### DIFF
--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -1063,7 +1063,7 @@ func TestPlanUninstall_ContainsRemoveVerb(t *testing.T) {
 		{"snap", "remove"},
 		{"brew", "uninstall"},
 		{"uv", "uninstall"},
-		{"pacman", "-Rcs"},
+		{"pacman", "-Rs"},
 		{"linuxbrew", "uninstall"},
 		{"bun", "remove"},
 		{"npm", "uninstall"},

--- a/internal/adapter/pacman.go
+++ b/internal/adapter/pacman.go
@@ -32,7 +32,7 @@ func (Pacman) PlanInstall(pkgName string) []string {
 }
 
 func (Pacman) PlanUninstall(pkgName string) []string {
-	return []string{"sudo", "pacman", "-Rcs", "--noconfirm", pkgName}
+	return []string{"sudo", "pacman", "-Rs", "--noconfirm", pkgName}
 }
 
 // PlanUpgrade reuses PlanInstall: pacman -S upgrades to the latest version.

--- a/internal/adapter/pacman_test.go
+++ b/internal/adapter/pacman_test.go
@@ -27,7 +27,7 @@ func TestPacman_PlanInstall(t *testing.T) {
 
 func TestPacman_PlanUninstall(t *testing.T) {
 	args := Pacman{}.PlanUninstall("git")
-	want := []string{"sudo", "pacman", "-Rcs", "--noconfirm", "git"}
+	want := []string{"sudo", "pacman", "-Rs", "--noconfirm", "git"}
 	if len(args) != len(want) {
 		t.Fatalf("PlanUninstall: got %v, want %v", args, want)
 	}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -64,18 +64,8 @@ func WriteFragment(path string, vars map[string]schema.EnvVar) error {
 
 	sb.WriteString("# END genv env\n")
 
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("creating directory %s: %w", dir, err)
-	}
-
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(sb.String()), 0o644); err != nil {
-		return fmt.Errorf("writing %s: %w", tmp, err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("saving %s: %w", path, err)
+	if err := genvfile.WritePrivate(path, []byte(sb.String())); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
 	}
 	return nil
 }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -3,6 +3,7 @@ package env
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -137,6 +138,24 @@ func TestWriteFragment_Deterministic(t *testing.T) {
 	iZZZ := strings.Index(content, "export ZZZ=")
 	if iAAA >= iMMM || iMMM >= iZZZ {
 		t.Errorf("fragment not sorted: AAA@%d MMM@%d ZZZ@%d\n%s", iAAA, iMMM, iZZZ, content)
+	}
+}
+
+func TestWriteFragment_Mode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits are not POSIX on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "env.sh")
+	if err := WriteFragment(path, map[string]schema.EnvVar{"X": {Value: "1"}}); err != nil {
+		t.Fatalf("WriteFragment: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("fragment mode = %o, want 0600", got)
 	}
 }
 

--- a/internal/files/dirs.go
+++ b/internal/files/dirs.go
@@ -54,7 +54,7 @@ func applyDir(ctx context.Context, d schema.FileDir, opts ApplyOptions, res *App
 			return err
 		}
 	} else {
-		if err := os.RemoveAll(target); err != nil {
+		if err := os.Remove(target); err != nil {
 			return fmt.Errorf("dir %s: remove existing: %w", target, err)
 		}
 	}

--- a/internal/files/links.go
+++ b/internal/files/links.go
@@ -142,12 +142,23 @@ func replaceLinkAt(target, source string, backup bool, opts ApplyOptions, res *A
 	if err := ensureParentDir(target); err != nil {
 		return err
 	}
-	if backup {
-		if err := backupExisting(target); err != nil {
-			return err
-		}
-	} else {
-		if err := os.RemoveAll(target); err != nil {
+	info, err := os.Lstat(target)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("link %s: %w", target, err)
+	}
+	if err == nil {
+		if info.IsDir() {
+			if !backup {
+				return fmt.Errorf("link %s: refusing to replace directory without --backup", target)
+			}
+			if err := backupExisting(target); err != nil {
+				return err
+			}
+		} else if backup {
+			if err := backupExisting(target); err != nil {
+				return err
+			}
+		} else if err := os.Remove(target); err != nil {
 			return fmt.Errorf("link %s: remove existing: %w", target, err)
 		}
 	}

--- a/internal/files/links_test.go
+++ b/internal/files/links_test.go
@@ -282,3 +282,88 @@ func TestApply_managedLinkRequiresForceForRealFile(t *testing.T) {
 		t.Fatalf("Mismatched = %v, want [%s]", res.Mismatched, target)
 	}
 }
+
+func TestApply_forceLinkRefusesDirectoryWithoutBackup(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+
+	source := filepath.Join(home, "src.txt")
+	if err := os.WriteFile(source, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	target := filepath.Join(home, ".genv-test", "simple.txt")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	keep := filepath.Join(target, "keep")
+	if err := os.WriteFile(keep, []byte("safe"), 0o644); err != nil {
+		t.Fatalf("write keep: %v", err)
+	}
+
+	cfg := &schema.FilesConfig{
+		Links: []schema.FileLink{{
+			Source: source,
+			Target: "~/.genv-test/simple.txt",
+			Mode:   "link",
+		}},
+	}
+	res, err := Apply(context.Background(), cfg, "any", ApplyOptions{Force: true})
+	if err == nil {
+		t.Fatal("error = nil, want refusing directory")
+	}
+	var msg string
+	if res != nil && len(res.Errors) > 0 {
+		msg = res.Errors[0].Error()
+	} else {
+		msg = err.Error()
+	}
+	if !strings.Contains(msg, "refusing to replace directory") {
+		t.Fatalf("error = %v, want refusing directory", msg)
+	}
+	if _, statErr := os.Stat(keep); statErr != nil {
+		t.Fatalf("directory contents were deleted: %v", statErr)
+	}
+}
+
+func TestApply_forceLinkReplacesFileWithoutBackup(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+
+	source := filepath.Join(home, "src.txt")
+	if err := os.WriteFile(source, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	target := filepath.Join(home, ".genv-test", "simple.txt")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write planted file: %v", err)
+	}
+
+	cfg := &schema.FilesConfig{
+		Links: []schema.FileLink{{
+			Source: source,
+			Target: "~/.genv-test/simple.txt",
+			Mode:   "link",
+		}},
+	}
+	res, err := Apply(context.Background(), cfg, "any", ApplyOptions{Force: true})
+	if err != nil {
+		t.Fatalf("Apply error = %v, want nil", err)
+	}
+	if len(res.Updated) != 1 || res.Updated[0] != target {
+		t.Fatalf("Updated = %v, want [%s]", res.Updated, target)
+	}
+	got, err := os.Readlink(target)
+	if err != nil {
+		t.Fatalf("Readlink: %v", err)
+	}
+	if got != source {
+		t.Fatalf("symlink points to %q, want %q", got, source)
+	}
+	matches, _ := filepath.Glob(target + ".backup.*")
+	if len(matches) != 0 {
+		t.Fatalf("expected no backup without --backup, got %v", matches)
+	}
+}

--- a/internal/genvfile/atomic.go
+++ b/internal/genvfile/atomic.go
@@ -1,0 +1,39 @@
+package genvfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WritePrivate atomically writes data to path with mode 0600.
+func WritePrivate(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating directory %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing %s: %w", tmpName, err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing %s: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("saving %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/genvfile/genvfile_test.go
+++ b/internal/genvfile/genvfile_test.go
@@ -554,6 +554,31 @@ func TestWriteLock_Mode0600(t *testing.T) {
 	}
 }
 
+func TestWritePrivate_Mode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits are not POSIX on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "secret")
+	if err := WritePrivate(path, []byte("ok\n")); err != nil {
+		t.Fatalf("WritePrivate: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "ok\n" {
+		t.Fatalf("content = %q, want %q", got, "ok\n")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("mode = %o, want 0600", perm)
+	}
+}
+
 func TestNew_WritesValidV8(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "genv.json")

--- a/internal/profilebackend/powershell.go
+++ b/internal/profilebackend/powershell.go
@@ -280,17 +280,5 @@ func indentPS(s string) string {
 }
 
 func writeAtomic(path, content string) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("creating directory %s: %w", dir, err)
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
-		return fmt.Errorf("writing %s: %w", tmp, err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("saving %s: %w", path, err)
-	}
-	return nil
+	return genvfile.WritePrivate(path, []byte(content))
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -158,7 +158,13 @@ func runSubcmd(ctx context.Context, args []string, stdin io.Reader, stdout, stde
 	fprintf(stdout, "\n==> %s\n", strings.Join(args, " "))
 	slog.Debug("spawn", "cmd", strings.Join(args, " "))
 	start := time.Now()
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	runCtx := ctx
+	cancel := func() {}
+	if d := SubprocessTimeout(ctx); d > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, d)
+	}
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, args[0], args[1:]...)
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -3,9 +3,12 @@ package resolver
 import (
 	"bytes"
 	"context"
+	"io"
+	"os/exec"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ks1686/genv/internal/adapter"
 	"github.com/ks1686/genv/internal/genvfile"
@@ -19,6 +22,23 @@ func TestRunSubcmd_EmptyArgv(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "empty command") {
 		t.Fatalf("error = %v, want empty command", err)
+	}
+}
+
+func TestRunSubcmd_PerSpawnTimeout(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not in PATH")
+	}
+	ctx := WithSubprocessTimeout(context.Background(), 50*time.Millisecond)
+	err := runSubcmd(ctx, []string{"sleep", "5"}, nil, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected sleep to hit per-spawn timeout")
+	}
+	if err := runSubcmd(ctx, []string{"true"}, nil, io.Discard, io.Discard); err != nil {
+		if _, lookErr := exec.LookPath("true"); lookErr != nil {
+			t.Skip("true not in PATH")
+		}
+		t.Fatalf("later command after a timed-out spawn: %v", err)
 	}
 }
 

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -34,10 +34,9 @@ func TestRunSubcmd_PerSpawnTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected sleep to hit per-spawn timeout")
 	}
-	if err := runSubcmd(ctx, []string{"true"}, nil, io.Discard, io.Discard); err != nil {
-		if _, lookErr := exec.LookPath("true"); lookErr != nil {
-			t.Skip("true not in PATH")
-		}
+	// `true` is not reliable on Windows CI (LookPath can find a non-POSIX
+	// true.exe that exits 1). `go` is on PATH wherever these tests run.
+	if err := runSubcmd(ctx, []string{"go", "env", "GOVERSION"}, nil, io.Discard, io.Discard); err != nil {
 		t.Fatalf("later command after a timed-out spawn: %v", err)
 	}
 }

--- a/internal/resolver/timeout.go
+++ b/internal/resolver/timeout.go
@@ -1,0 +1,25 @@
+package resolver
+
+import (
+	"context"
+	"time"
+)
+
+type subprocessTimeoutKey struct{}
+
+// WithSubprocessTimeout stashes a per-spawn deadline on ctx. Unlike
+// context.WithTimeout on the parent, this does not starve later commands
+// or hooks when one subprocess runs long.
+func WithSubprocessTimeout(ctx context.Context, d time.Duration) context.Context {
+	if d <= 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, subprocessTimeoutKey{}, d)
+}
+
+// SubprocessTimeout returns the per-spawn duration stored by
+// WithSubprocessTimeout, or 0 if none is set.
+func SubprocessTimeout(ctx context.Context) time.Duration {
+	d, _ := ctx.Value(subprocessTimeoutKey{}).(time.Duration)
+	return d
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -65,7 +65,9 @@ type ServiceStatusEntry struct {
 }
 
 // ServiceStatus computes the two-way diff between the spec services block and
-// the lock services entries.
+// the lock services entries. When probe is true, each in-spec service is also
+// checked for liveness (brew, a custom status command, or systemd). When
+// probe is false, Running is always false and no subprocesses are spawned.
 func ServiceStatus(specServices map[string]schema.Service, lockServices []genvfile.LockedService, probe bool) []ServiceStatusEntry {
 	lockByName := make(map[string]genvfile.LockedService, len(lockServices))
 	for _, ls := range lockServices {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -66,7 +66,7 @@ type ServiceStatusEntry struct {
 
 // ServiceStatus computes the two-way diff between the spec services block and
 // the lock services entries.
-func ServiceStatus(specServices map[string]schema.Service, lockServices []genvfile.LockedService) []ServiceStatusEntry {
+func ServiceStatus(specServices map[string]schema.Service, lockServices []genvfile.LockedService, probe bool) []ServiceStatusEntry {
 	lockByName := make(map[string]genvfile.LockedService, len(lockServices))
 	for _, ls := range lockServices {
 		lockByName[ls.Name] = ls
@@ -104,14 +104,14 @@ func ServiceStatus(specServices map[string]schema.Service, lockServices []genvfi
 		}
 
 		running := false
-		if inSpec && svc.BrewFormula != "" {
+		if probe && inSpec && svc.BrewFormula != "" {
 			running = BrewServicesRunning(svc.BrewFormula)
-		} else if inSpec && len(svc.Status) > 0 {
+		} else if probe && inSpec && len(svc.Status) > 0 {
 			cmd := exec.Command(svc.Status[0], svc.Status[1:]...)
 			if err := cmd.Run(); err == nil {
 				running = true
 			}
-		} else if inSpec && IsSystemdAvailable() {
+		} else if probe && inSpec && IsSystemdAvailable() {
 			cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", systemdUnitName(name))
 			if err := cmd.Run(); err == nil {
 				running = true
@@ -139,7 +139,7 @@ func compareServices(s schema.Service, l genvfile.LockedService) bool {
 // ApplyServices reconciles the system state with the desired services.
 // It starts missing/modified services and stops extra services.
 func ApplyServices(ctx context.Context, specServices map[string]schema.Service, lockServices []genvfile.LockedService, verbose bool) (applied, removed []string, errs []error) {
-	statusEntries := ServiceStatus(specServices, lockServices)
+	statusEntries := ServiceStatus(specServices, lockServices, true)
 
 	for _, e := range statusEntries {
 		switch e.Kind {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -45,7 +48,7 @@ func TestServiceStatus(t *testing.T) {
 		},
 	}
 
-	entries := ServiceStatus(spec, lock)
+	entries := ServiceStatus(spec, lock, true)
 
 	expected := map[string]ServiceStatusKind{
 		"ok-service":       ServiceStatusOK,
@@ -67,6 +70,30 @@ func TestServiceStatus(t *testing.T) {
 		if e.Kind != expKind {
 			t.Errorf("service %q: expected kind %s, got %s", e.Name, expKind, e.Kind)
 		}
+	}
+}
+
+func TestServiceStatus_skipProbe(t *testing.T) {
+	if _, err := exec.LookPath("touch"); err != nil {
+		t.Skip("touch not in PATH")
+	}
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "probed")
+	spec := map[string]schema.Service{
+		"probe-me": {
+			Start:  []string{"true"},
+			Status: []string{"touch", marker},
+		},
+	}
+	entries := ServiceStatus(spec, nil, false)
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	if entries[0].Running {
+		t.Fatal("probe=false should not mark the service running")
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("status command ran despite probe=false")
 	}
 }
 

--- a/internal/shellcfg/shellcfg.go
+++ b/internal/shellcfg/shellcfg.go
@@ -98,18 +98,8 @@ func WriteFragment(path string, cfg *schema.ShellConfig) error {
 
 	sb.WriteString("\n# END genv shell\n")
 
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("creating directory %s: %w", dir, err)
-	}
-
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(sb.String()), 0o644); err != nil {
-		return fmt.Errorf("writing %s: %w", tmp, err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("saving %s: %w", path, err)
+	if err := genvfile.WritePrivate(path, []byte(sb.String())); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
 	}
 	return nil
 }

--- a/internal/shellcfg/shellcfg_test.go
+++ b/internal/shellcfg/shellcfg_test.go
@@ -3,6 +3,7 @@ package shellcfg
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -45,6 +46,15 @@ func TestWriteFragment_Aliases(t *testing.T) {
 	}
 	if err := WriteFragment(path, cfg); err != nil {
 		t.Fatalf("WriteFragment: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("fragment mode = %o, want 0600", got)
+		}
 	}
 
 	data, err := os.ReadFile(path)

--- a/main.go
+++ b/main.go
@@ -1149,9 +1149,7 @@ func runApply(opts applyOptions) int {
 
 	ctx := context.Background()
 	if opts.Timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
-		defer cancel()
+		ctx = resolver.WithSubprocessTimeout(ctx, opts.Timeout)
 	}
 
 	lockPath := lockPathForSpec(opts.File, opts.LockFile)
@@ -1282,15 +1280,26 @@ func runApplyJSON(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	execResult := resolver.ExecuteApply(ctx, result, os.Stdin, os.Stderr, os.Stderr)
 	errs := errStrings(execResult.Errors)
 
-	envApplied, envRemoved := applyEnvVars(f, lf, false)
-	shellApplied, shellRemoved := applyShellCfg(f, lf, false)
-	_, _, svcErrs := applyServices(ctx, f, lf, false)
+	var envApplied, envRemoved, shellApplied, shellRemoved []string
 	failedHooks := []string(nil)
 	filePlan := &files.ApplyResult{}
 	filePlanErr := error(nil)
 	if len(errs) == 0 {
-		if len(svcErrs) > 0 {
-			errs = append(errs, errStrings(svcErrs)...)
+		var envErr, shellErr error
+		envApplied, envRemoved, envErr = applyEnvVars(f, lf, false)
+		if envErr != nil {
+			errs = append(errs, envErr.Error())
+		} else {
+			shellApplied, shellRemoved, shellErr = applyShellCfg(f, lf, false)
+			if shellErr != nil {
+				errs = append(errs, shellErr.Error())
+			}
+		}
+		if len(errs) == 0 {
+			_, _, svcErrs := applyServices(ctx, f, lf, false)
+			if len(svcErrs) > 0 {
+				errs = append(errs, errStrings(svcErrs)...)
+			}
 		}
 	}
 	if len(errs) == 0 {
@@ -1376,7 +1385,7 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 		}
 	}
 	var serviceChanges int
-	for _, e := range service.ServiceStatus(f.Services, lf.Services) {
+	for _, e := range service.ServiceStatus(f.Services, lf.Services, false) {
 		if e.Kind != service.ServiceStatusOK {
 			serviceChanges++
 		}
@@ -1468,22 +1477,28 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 
 	execResult := resolver.ExecuteApply(ctx, result, os.Stdin, os.Stdout, os.Stderr)
 
-	// Apply env, shell and services (update lf in memory), then write lock once.
-	applyEnvVars(f, lf, !opts.Quiet)
-	applyShellCfg(f, lf, !opts.Quiet)
-	_, _, svcErrs := applyServices(ctx, f, lf, !opts.Quiet)
+	var svcErrs []error
 	var fileErrs []error
 	var appliedFiles *files.ApplyResult
 	if len(execResult.Errors) == 0 {
-		var filePlanErr error
-		appliedFiles, filePlanErr = applyFiles(ctx, opts, f, lf)
-		if filePlanErr != nil {
-			fileErrs = append(fileErrs, filePlanErr)
-		}
-		if appliedFiles != nil && len(appliedFiles.Mismatched) > 0 {
-			writeFileMismatchGuidance(os.Stderr, appliedFiles)
-			if !opts.NoHooks && hasPostApplyHooks(f) {
-				fPrintln(os.Stderr, "genv apply: skipping post-apply hooks due to unresolved file mismatches")
+		if _, _, err := applyEnvVars(f, lf, !opts.Quiet); err != nil {
+			fileErrs = append(fileErrs, err)
+		} else if _, _, err := applyShellCfg(f, lf, !opts.Quiet); err != nil {
+			fileErrs = append(fileErrs, err)
+		} else {
+			_, _, svcErrs = applyServices(ctx, f, lf, !opts.Quiet)
+			if len(svcErrs) == 0 {
+				var filePlanErr error
+				appliedFiles, filePlanErr = applyFiles(ctx, opts, f, lf)
+				if filePlanErr != nil {
+					fileErrs = append(fileErrs, filePlanErr)
+				}
+				if appliedFiles != nil && len(appliedFiles.Mismatched) > 0 {
+					writeFileMismatchGuidance(os.Stderr, appliedFiles)
+					if !opts.NoHooks && hasPostApplyHooks(f) {
+						fPrintln(os.Stderr, "genv apply: skipping post-apply hooks due to unresolved file mismatches")
+					}
+				}
 			}
 		}
 	}
@@ -1584,9 +1599,9 @@ func writeLockAfterApply(lockPath string, lf *genvfile.LockFile, result resolver
 // names. The caller is responsible for persisting the lock file (avoiding a
 // double-write when packages and env vars are both applied in the same run).
 // If verbose is true, it prints progress lines to stdout.
-func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (applied, removed []string) {
+func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (applied, removed []string, err error) {
 	if len(f.Env) == 0 && len(lf.Env) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Use EnvStatus to determine what changed, avoiding duplicated diff logic.
@@ -1608,7 +1623,7 @@ func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (appl
 	for _, b := range backends {
 		if err := b.ApplyEnv(f.Env); err != nil {
 			fprintf(os.Stderr, "genv: writing env fragment (%s): %v\n", b.Name(), err)
-			return applied, removed
+			return applied, removed, err
 		}
 		lastFrag = b.Name()
 	}
@@ -1642,7 +1657,7 @@ func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (appl
 	}
 	lf.Env = newEnv
 
-	return applied, removed
+	return applied, removed, nil
 }
 
 // buildPlanResult converts a ReconcileResult into the stable JSON PlanResult type.
@@ -1675,7 +1690,7 @@ func buildPlanResult(f *schema.GenvFile, lf *genvfile.LockFile, result resolver.
 	}
 
 	var toStart, toStop []string
-	for _, e := range service.ServiceStatus(f.Services, lf.Services) {
+	for _, e := range service.ServiceStatus(f.Services, lf.Services, false) {
 		switch e.Kind {
 		case service.ServiceStatusMissing, service.ServiceStatusModified:
 			toStart = append(toStart, e.Name)
@@ -2496,9 +2511,9 @@ func shellEditCmd(args []string) int {
 // applyShellCfg writes managed shell fragments via selected profile backends,
 // updates lf.Shell in memory, and returns lists of applied and removed entry
 // names. The caller writes the lock. If verbose is true, it prints progress.
-func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (applied, removed []string) {
+func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (applied, removed []string, err error) {
 	if f.Shell == nil && lf.Shell == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Use ShellStatus to determine what changed, avoiding duplicated diff logic.
@@ -2546,7 +2561,7 @@ func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (app
 	for _, b := range backends {
 		if err := b.ApplyShell(cfg); err != nil {
 			fprintf(os.Stderr, "genv: writing shell fragment (%s): %v\n", b.Name(), err)
-			return applied, removed
+			return applied, removed, err
 		}
 	}
 
@@ -2572,7 +2587,7 @@ func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (app
 	// Update lf.Shell in memory; caller writes the lock once.
 	lf.Shell = shellcfg.SpecToLock(f.Shell)
 
-	return applied, removed
+	return applied, removed, nil
 }
 
 // scanCmd implements `genv scan`.
@@ -2905,7 +2920,7 @@ func statusCmd(args []string) int {
 	entries := commands.Status(f, lf)
 	envEntries := genvenv.EnvStatus(f.Env, lf.Env)
 	shellEntries := shellcfg.ShellStatus(f.Shell, lf.Shell)
-	serviceEntries := service.ServiceStatus(f.Services, lf.Services)
+	serviceEntries := service.ServiceStatus(f.Services, lf.Services, true)
 
 	if *jsonOut {
 		jsonEntries := make([]output.StatusEntry, 0, len(entries))
@@ -3110,9 +3125,9 @@ func applyServices(ctx context.Context, f *schema.GenvFile, lf *genvfile.LockFil
 	}
 
 	applied, removed, errs = service.ApplyServices(ctx, f.Services, lf.Services, verbose)
-
-	// Update lf.Services in memory; caller writes the lock once.
-	lf.Services = service.SpecToLock(f.Services)
+	if len(errs) == 0 {
+		lf.Services = service.SpecToLock(f.Services)
+	}
 
 	return applied, removed, errs
 }

--- a/main_fakebin_test.go
+++ b/main_fakebin_test.go
@@ -47,7 +47,7 @@ brew)
 	;;
 pacman|paru|yay)
 	case "$1" in
-	-S|-Rns|-Rcs|-Sc|-Ss)
+	-S|-Rns|-Rs|-Rcs|-Sc|-Ss)
 		exit 0
 		;;
 	-Qi|-Q)

--- a/main_helpers_coverage_test.go
+++ b/main_helpers_coverage_test.go
@@ -264,7 +264,10 @@ func TestApplyEnvVarsAndShellCfg(t *testing.T) {
 		},
 	}
 
-	applied, removed := applyEnvVars(f, lf, true)
+	applied, removed, err := applyEnvVars(f, lf, true)
+	if err != nil {
+		t.Fatalf("applyEnvVars: %v", err)
+	}
 	if len(applied) != 1 || applied[0] != "FOO" || len(removed) != 0 {
 		t.Fatalf("applyEnvVars = %v %v", applied, removed)
 	}
@@ -274,12 +277,18 @@ func TestApplyEnvVarsAndShellCfg(t *testing.T) {
 
 	// Removal path: clear spec env while lock still has FOO.
 	f.Env = map[string]schema.EnvVar{}
-	applied, removed = applyEnvVars(f, lf, true)
+	applied, removed, err = applyEnvVars(f, lf, true)
+	if err != nil {
+		t.Fatalf("applyEnvVars remove: %v", err)
+	}
 	if len(removed) != 1 || removed[0] != "FOO" {
 		t.Fatalf("env remove = %v %v", applied, removed)
 	}
 
-	applied, removed = applyShellCfg(f, lf, true)
+	applied, removed, err = applyShellCfg(f, lf, true)
+	if err != nil {
+		t.Fatalf("applyShellCfg: %v", err)
+	}
 	if len(applied) == 0 {
 		t.Fatalf("applyShellCfg applied nothing: %v %v", applied, removed)
 	}
@@ -287,7 +296,7 @@ func TestApplyEnvVarsAndShellCfg(t *testing.T) {
 		t.Fatal("expected lock shell updated")
 	}
 	if !strings.Contains(captureStdout(t, func() {
-		_, _ = applyShellCfg(f, lf, false)
+		_, _, _ = applyShellCfg(f, lf, false)
 	}), "") {
 		// fish note only prints when hasFishEntries; force by keeping fish alias
 	}
@@ -295,17 +304,17 @@ func TestApplyEnvVarsAndShellCfg(t *testing.T) {
 	out := captureStdout(t, func() {
 		f2 := &schema.GenvFile{Shell: f.Shell}
 		lf2 := &genvfile.LockFile{}
-		_, _ = applyShellCfg(f2, lf2, false)
+		_, _, _ = applyShellCfg(f2, lf2, false)
 	})
 	if !strings.Contains(out, "fish-specific") {
 		t.Errorf("expected fish note, got %q", out)
 	}
 
-	if a, r := applyEnvVars(&schema.GenvFile{}, &genvfile.LockFile{}, false); a != nil || r != nil {
-		t.Errorf("empty env apply = %v %v", a, r)
+	if a, r, err := applyEnvVars(&schema.GenvFile{}, &genvfile.LockFile{}, false); a != nil || r != nil || err != nil {
+		t.Errorf("empty env apply = %v %v %v", a, r, err)
 	}
-	if a, r := applyShellCfg(&schema.GenvFile{}, &genvfile.LockFile{}, false); a != nil || r != nil {
-		t.Errorf("empty shell apply = %v %v", a, r)
+	if a, r, err := applyShellCfg(&schema.GenvFile{}, &genvfile.LockFile{}, false); a != nil || r != nil || err != nil {
+		t.Errorf("empty shell apply = %v %v %v", a, r, err)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -3361,6 +3361,37 @@ func TestApplyCmd_Timeout_DryRun_NoCrash(t *testing.T) {
 	}
 }
 
+func TestApplyCmd_PackageFailure_DoesNotApplyEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.SetHome(t, dir)
+	withFailingBrewInstall(t)
+	path := filepath.Join(dir, "genv.json")
+	writeTestFile(t, path, `{
+		"schemaVersion": "6",
+		"packages": [{"id": "git", "prefer": "brew"}],
+		"env": {"FOO": {"value": "bar"}}
+	}`)
+
+	code := run([]string{"apply", "--file", path, "--yes"})
+	if code == exitOK {
+		t.Fatal("expected apply to fail when brew install fails")
+	}
+
+	frag := filepath.Join(dir, "genv", "env.sh")
+	if _, err := os.Stat(frag); err == nil {
+		t.Fatalf("env fragment %s written despite package failure", frag)
+	}
+
+	lf, err := genvfile.ReadLock(genvfile.LockPathFrom(path))
+	if err != nil && !errors.Is(err, genvfile.ErrNotFound) {
+		t.Fatalf("ReadLock: %v", err)
+	}
+	if lf != nil && len(lf.Env) != 0 {
+		t.Fatalf("lock env = %#v, want empty after package failure", lf.Env)
+	}
+}
+
 func TestApplyCmd_DryRun_JsonOutput(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)

--- a/main_updates_worker.go
+++ b/main_updates_worker.go
@@ -81,6 +81,12 @@ func updatesRunOnceBody(ctx context.Context, logger *slog.Logger, f *schema.Genv
 		return code
 	}
 	lockPath := lockPathForSpec(file, lockFile)
+	unlock, err := genvfile.LockMutation(lockPath)
+	if err != nil {
+		logger.Warn("updates.check.lock", slog.Any("err", err))
+		return exitIO
+	}
+	defer unlock()
 	lf, err := genvfile.ReadLock(lockPath)
 	if err != nil {
 		logger.Warn("updates.check.lock", slog.Any("err", err))


### PR DESCRIPTION
## Summary
- Skip env, shell, and services when package apply fails (same gate as files).
- `--force` link replace refuses a directory unless `--backup`; fragments write mode `0600`.
- Pacman uninstall is `-Rs` (no cascade). Apply `--dry-run` does not probe service liveness.
- `--timeout` is per subprocess so one hung package cannot starve the rest of apply.
- Scheduled auto-apply takes the same lock mutex as `apply`/`upgrade`.

## Test plan
- [x] Apply package-failure does not write env; force-link directory refuse; 0600 fragment; per-spawn timeout; pacman `-Rs`
- [ ] CI Test + v8 matrix green on the stack