### PR TITLE
feat: publish genv to a self-hosted Scoop bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          SCOOP_BUCKET_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
           # Developer ID Application (.p12 base64) + App Store Connect API key.
           # When MACOS_SIGN_P12 is unset, GoReleaser skips notarize.macos.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -121,7 +121,7 @@ snapcrafts:
 
 # ── Scoop bucket ──────────────────────────────────────────────────────────────
 # Publishes a manifest to ks1686/scoop-bucket on every non-prerelease tag
-# when SCOOP_BUCKET_GITHUB_TOKEN is set. Empty secret → skip upload so the
+# Empty or unset SCOOP_BUCKET_GITHUB_TOKEN → skip upload so the
 # rest of the release (GitHub, Homebrew, Snap) still succeeds.
 # Requires secret: SCOOP_BUCKET_GITHUB_TOKEN (fine-grained PAT with
 # Contents: read+write on the scoop-bucket repo).
@@ -140,11 +140,11 @@ scoops:
     repository:
       owner: ks1686
       name: scoop-bucket
-      token: "{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}"
+      token: '{{ envOrDefault "SCOOP_BUCKET_GITHUB_TOKEN" "" }}'
     homepage: "https://github.com/ks1686/genv"
     description: "Track, sync, and reproduce your software environment across Linux, macOS, Windows, and WSL2."
     license: MIT
-    skip_upload: '{{ if .Env.SCOOP_BUCKET_GITHUB_TOKEN }}auto{{ else }}true{{ end }}'
+    skip_upload: '{{ if isEnvSet "SCOOP_BUCKET_GITHUB_TOKEN" }}{{ if .Env.SCOOP_BUCKET_GITHUB_TOKEN }}auto{{ else }}true{{ end }}{{ else }}true{{ end }}'
 
 changelog:
   sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -119,14 +119,32 @@ snapcrafts:
 
 
 
-# Scoop stays unpublished until a bucket token exists.
-# winget and Chocolatey publishers are GoReleaser Pro-only; do not declare them
-# here or OSS goreleaser check / CI fails to parse the config.
+# ── Scoop bucket ──────────────────────────────────────────────────────────────
+# Publishes a manifest to ks1686/scoop-bucket on every non-prerelease tag
+# when SCOOP_BUCKET_GITHUB_TOKEN is set. Empty secret → skip upload so the
+# rest of the release (GitHub, Homebrew, Snap) still succeeds.
+# Requires secret: SCOOP_BUCKET_GITHUB_TOKEN (fine-grained PAT with
+# Contents: read+write on the scoop-bucket repo).
+#
+# Manifests stay at the bucket root (do not set directory) so
+# `scoop bucket list` counts them.
+#
+# Install after setup:
+#   scoop bucket add ks1686 https://github.com/ks1686/scoop-bucket
+#   scoop install genv
+#
+# winget and Chocolatey publishers are GoReleaser Pro-only; do not declare
+# them here or OSS goreleaser check / CI fails to parse the config.
 scoops:
   - name: genv
-    description: Track, sync, and reproduce your software environment.
+    repository:
+      owner: ks1686
+      name: scoop-bucket
+      token: "{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}"
+    homepage: "https://github.com/ks1686/genv"
+    description: "Track, sync, and reproduce your software environment across Linux, macOS, Windows, and WSL2."
     license: MIT
-    skip_upload: true
+    skip_upload: '{{ if .Env.SCOOP_BUCKET_GITHUB_TOKEN }}auto{{ else }}true{{ end }}'
 
 changelog:
   sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -127,7 +127,7 @@ snapcrafts:
 # Contents: read+write on the scoop-bucket repo).
 #
 # Manifests stay at the bucket root (do not set directory) so
-# `scoop bucket list` counts them.
+# `scoop install genv` can find them.
 #
 # Install after setup:
 #   scoop bucket add ks1686 https://github.com/ks1686/scoop-bucket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v4.0.13 - 2026-08-19
+
 ### Added
 
 - Self-hosted Scoop install channel: GoReleaser publishes a manifest to
   `ks1686/scoop-bucket` when `SCOOP_BUCKET_GITHUB_TOKEN` is set, and skips that
-  upload (without failing the rest of the release) when the secret is empty.
+  upload (without failing the rest of the release) when the token is empty or
+  unset.
 
 ## v4.0.12 - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Self-hosted Scoop install channel: GoReleaser publishes a manifest to
+  `ks1686/scoop-bucket` when `SCOOP_BUCKET_GITHUB_TOKEN` is set, and skips that
+  upload (without failing the rest of the release) when the secret is empty.
+
 ## v4.0.12 - 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ genv map --target arch                # assist-only manager suggestions
 | macOS | `brew tap ks1686/tap && brew install --cask genv` |
 | Arch / Manjaro | `paru -S genv` or `yay -S genv` (or `genv-bin`) |
 | Other Linux | GitHub release tarball (see below) |
-| Windows | GitHub release zip (see below) |
+| Windows | Scoop (self-hosted bucket) or GitHub release zip (see below) |
 | Any (from source) | `go install github.com/ks1686/genv@latest` (Go 1.24+) |
 
 **Linux x86-64 example** (replace the version to match [Releases](https://github.com/ks1686/genv/releases/latest)):
@@ -37,7 +37,18 @@ sudo mv genv /usr/local/bin/
 genv version
 ```
 
-**Windows (PowerShell):**
+**Windows (Scoop, after Scoop itself is installed):**
+
+```powershell
+scoop bucket add ks1686 https://github.com/ks1686/scoop-bucket
+scoop install genv
+```
+
+The bucket is self-hosted (not Scoop extras). The first `scoop install genv` that
+succeeds is the release after `SCOOP_BUCKET_GITHUB_TOKEN` is configured; until
+then use the zip below.
+
+**Windows (PowerShell zip):**
 
 ```powershell
 Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_windows_amd64.zip -OutFile genv.zip
@@ -46,7 +57,9 @@ Expand-Archive genv.zip -DestinationPath .
 genv version
 ```
 
-Windows package-manager installers for the **genv binary** (winget / scoop / choco) are not published yet. Scoop is prepared in OSS GoReleaser with upload skipped; winget and Chocolatey need GoReleaser Pro. Once genv is on `PATH`, it still **manages packages** through those managers.
+winget and Chocolatey installers for the **genv binary** are not published
+(GoReleaser Pro). Once genv is on `PATH`, it still **manages packages** through
+winget, Scoop, and Chocolatey.
 
 Release archives ship cosign-signed checksums (keyless). Darwin binaries are also Developer ID signed and notarized when Apple secrets are configured — see [SECURITY.md](SECURITY.md).
 
@@ -288,7 +301,8 @@ File mismatches without `--force` no longer block packages/services: non-conflic
 | Schema v8 portable targets | Stable |
 | Background `updates` + profiles + hooks | Stable |
 | apt / dnf / apk adapters | Stable |
-| Publish genv to winget / scoop / choco | Not published; Scoop stub skipped in OSS, winget/choco need GoReleaser Pro |
+| Publish genv to Scoop | Self-hosted bucket `ks1686/scoop-bucket`; uploads when `SCOOP_BUCKET_GITHUB_TOKEN` is set |
+| Publish genv to winget / choco | Not published; publishers are GoReleaser Pro-only |
 
 Historical milestone checklists: [ROADMAP.md](ROADMAP.md). Release notes: [CHANGELOG.md](CHANGELOG.md). Tag-driven publishing: [RELEASING.md](RELEASING.md).
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ scoop bucket add ks1686 https://github.com/ks1686/scoop-bucket
 scoop install genv
 ```
 
-The bucket is self-hosted (not Scoop extras). The first `scoop install genv` that
-succeeds is the release after `SCOOP_BUCKET_GITHUB_TOKEN` is configured; until
-then use the zip below.
+The bucket is self-hosted (not Scoop extras). `scoop install genv` needs a root
+`genv.json` on that bucket, which the first stable tag after merge uploads.
+Until then use the zip below.
 
 **Windows (PowerShell zip):**
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Track, sync, and reproduce your software environment across **macOS**, **Windows
 
 `genv` is a thin layer over the package managers you already use. Desired state lives in one git-friendly `genv.json`. Applied state lives in a machine-local lock file. Run `genv apply` and the machine matches the spec.
 
-**Current release:** [latest](https://github.com/ks1686/genv/releases/latest) (v4.0.12+) — schema **v7** PowerShell parity, schema **v8** portable multi-target configs.
+**Current release:** [latest](https://github.com/ks1686/genv/releases/latest) (v4.0.13+) — schema **v7** PowerShell parity, schema **v8** portable multi-target configs.
 
 ```bash
 genv add git                          # track + install
@@ -31,7 +31,7 @@ genv map --target arch                # assist-only manager suggestions
 **Linux x86-64 example** (replace the version to match [Releases](https://github.com/ks1686/genv/releases/latest)):
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.0.13_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 genv version
@@ -51,7 +51,7 @@ Until then use the zip below.
 **Windows (PowerShell zip):**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.13_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .
 # put genv.exe on PATH, then:
 genv version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -146,7 +146,35 @@ brew tap ks1686/tap
 brew install --cask genv
 ```
 
-### 4. AUR (`genv-bin` and `genv`)
+### 4. Scoop bucket
+
+GoReleaser pushes a Scoop manifest to a separate `scoop-bucket` repo. It does
+not create that repo; create it first (`gh repo create`). The release workflow
+`GITHUB_TOKEN` cannot push to another repository.
+
+1. Create the repo **`ks1686/scoop-bucket`** on GitHub (public). Do **not** add
+   the `scoop-bucket` GitHub topic — that lists the bucket on scoop.sh.
+2. In the **`ks1686/genv`** repository settings → Secrets and variables → Actions,
+   add a repository secret named **`SCOOP_BUCKET_GITHUB_TOKEN`**.
+   - Generate a fine-grained PAT at GitHub Settings → Developer Settings → Personal access tokens → Fine-grained tokens.
+   - Grant it **Contents: Read and write** on the `ks1686/scoop-bucket` repository only.
+   - Do not reuse `HOMEBREW_TAP_GITHUB_TOKEN` unless that token is also granted
+     on `scoop-bucket`.
+   - Do not put a `gh` OAuth token (`gho_…`) into Actions secrets.
+3. Leave `scoops.directory` unset so manifests live at the bucket root
+   (`scoop bucket list` reports 0 otherwise).
+4. If the secret is missing, GoReleaser skips the Scoop upload (`skip_upload: true`)
+   and the rest of the release still publishes. With the secret set, `skip_upload`
+   is `auto` (stable tags upload; prereleases do not).
+
+Users install after a tagged release has pushed `genv.json`:
+
+```powershell
+scoop bucket add ks1686 https://github.com/ks1686/scoop-bucket
+scoop install genv
+```
+
+### 5. AUR (`genv-bin` and `genv`)
 
 Two AUR packages are published on every stable release. Both use the same `AUR_KEY` secret.
 
@@ -156,9 +184,9 @@ Two AUR packages are published on every stable release. Both use the same `AUR_K
 The two packages `conflict` with each other so users can only have one installed at a time.
 Each CI script updates an existing AUR package — it does not create a new one. The first publish of each must be done manually.
 
-**4a. Create an AUR account** at <https://aur.archlinux.org/> if you don't have one.
+**5a. Create an AUR account** at <https://aur.archlinux.org/> if you don't have one.
 
-**4b. Generate an SSH key** for AUR (use a dedicated key, not your main one):
+**5b. Generate an SSH key** for AUR (use a dedicated key, not your main one):
 
 ```bash
 ssh-keygen -t ed25519 -C "aur" -f ~/.ssh/aur
@@ -167,7 +195,7 @@ ssh-keygen -t ed25519 -C "aur" -f ~/.ssh/aur
 
 Add the public key to your AUR account: <https://aur.archlinux.org/account/> → SSH keys.
 
-**4c. Create the `genv-bin` package on AUR** (one-time manual step):
+**5c. Create the `genv-bin` package on AUR** (one-time manual step):
 
 ```bash
 # Clone the (empty) AUR repo — this creates the package namespace
@@ -211,7 +239,7 @@ git push
 > `checksums.txt` before pushing. AUR will flag the package as untrustworthy
 > if SKIP is left in place.
 
-**4c-2. Create the `genv` source package on AUR** (one-time manual step):
+**5c-2. Create the `genv` source package on AUR** (one-time manual step):
 
 ```bash
 git clone ssh://aur@aur.archlinux.org/genv.git /tmp/genv-src-aur
@@ -248,7 +276,7 @@ git commit -m "Initial release v0.2.0"
 git push
 ```
 
-**4d. Add the AUR SSH private key as a repository secret:**
+**5d. Add the AUR SSH private key as a repository secret:**
 
 In `ks1686/genv` → Settings → Secrets and variables → Actions, add a secret named
 **`AUR_KEY`** containing the contents of `~/.ssh/aur` (the private key).
@@ -361,14 +389,13 @@ Artifacts land in `./dist/`. Nothing is published.
 
 ## Future distribution channels
 
-The `genv` binary is **not** published to winget, Scoop, or Chocolatey as an
-install channel today — Windows users should download release archives from
-GitHub Releases (see README). Publishing those channels is deferred until there
-is clear demand; it is not tied to a specific version milestone.
+Scoop is a self-hosted bucket (`ks1686/scoop-bucket`), not Scoop extras.
+winget and Chocolatey stay unpublished (community review + GoReleaser Pro).
+GitHub Release zips remain a supported Windows path.
 
 | Channel | Status | Notes |
 | --- | --- | --- |
-| Scoop | Configured, unpublished | OSS GoReleaser `scoops` block is present with `skip_upload: true` until a token exists |
-| winget | Deferred | Publisher is GoReleaser Pro-only; not declared in OSS config |
-| Chocolatey | Deferred | Publisher is GoReleaser Pro-only; not declared in OSS config |
+| Scoop | Self-hosted bucket | Uploads from the release workflow when `SCOOP_BUCKET_GITHUB_TOKEN` is set |
+| winget | Deferred | Publisher is GoReleaser Pro-only; default source needs microsoft/winget-pkgs review |
+| Chocolatey | Deferred | Publisher is GoReleaser Pro-only; community repo has the same review gate |
 | apt PPA | Deferred | `.deb` artifacts already ship via GitHub Releases |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,6 +34,7 @@ handles GitHub releases, Homebrew, Scoop, AUR, and the Snap Store automatically
 | `v4.0.10` | Darwin GitHub Release / Homebrew binaries are Developer ID signed and notarized |
 | `v4.0.11` | Fail-closed `add`, schema v8 defaults, native apt/dnf/apk, Windows CI/test hardening (tag exists; GitHub Release aborted on Pro-only GoReleaser keys) |
 | `v4.0.12` | Drop Pro-only winget/chocolatey GoReleaser keys so OSS publish can succeed |
+| `v4.0.13` | Self-hosted Scoop bucket (`ks1686/scoop-bucket`) |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew, Scoop,

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # Releasing genv
 
-This repository publishes GitHub releases, a Homebrew cask, and an AUR package
-automatically when an annotated tag is pushed. GoReleaser handles GitHub releases,
-Homebrew, AUR, and the Snap Store automatically — no external reviewer sign-off required.
+This repository publishes GitHub releases, a Homebrew cask, a Scoop manifest,
+and an AUR package automatically when an annotated tag is pushed. GoReleaser
+handles GitHub releases, Homebrew, Scoop, AUR, and the Snap Store automatically
+— no external reviewer sign-off required.
 
 ---
 
@@ -35,9 +36,9 @@ Homebrew, AUR, and the Snap Store automatically — no external reviewer sign-of
 | `v4.0.12` | Drop Pro-only winget/chocolatey GoReleaser keys so OSS publish can succeed |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
-validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew and AUR
-publishers for pre-release tags automatically, so only stable tags reach those
-channels.
+validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew, Scoop,
+and AUR publishers for pre-release tags automatically, so only stable tags
+reach those channels.
 
 ---
 
@@ -162,7 +163,7 @@ not create that repo; create it first (`gh repo create`). The release workflow
      on `scoop-bucket`.
    - Do not put a `gh` OAuth token (`gho_…`) into Actions secrets.
 3. Leave `scoops.directory` unset so manifests live at the bucket root
-   (`scoop bucket list` reports 0 otherwise).
+   (`scoop install genv` cannot find the manifest otherwise).
 4. If the secret is missing, GoReleaser skips the Scoop upload (`skip_upload: true`)
    and the rest of the release still publishes. With the secret set, `skip_upload`
    is `auto` (stable tags upload; prereleases do not).
@@ -324,6 +325,7 @@ paru -S genv       # builds from source
    - Generate `checksums.txt`
    - Publish a GitHub Release with all artifacts
    - Push the Homebrew formula to `ks1686/homebrew-tap`
+   - Push `genv.json` to `ks1686/scoop-bucket` (Scoop pipe continues on error — confirm the file landed)
    - Push updated PKGBUILDs to AUR (`genv-bin` pre-compiled and `genv` source)
 
    If GitHub/Homebrew succeeded but AUR failed (transient `aur.archlinux.org` SSH),
@@ -349,7 +351,16 @@ paru -S genv       # builds from source
    genv version
    ```
 
-8. **Verify AUR** (on any Arch machine):
+8. **Verify Scoop** (on Windows, after the bucket has `genv.json`):
+
+   ```powershell
+   scoop bucket add ks1686 https://github.com/ks1686/scoop-bucket
+   scoop update
+   scoop install genv
+   genv version
+   ```
+
+9. **Verify AUR** (on any Arch machine):
 
    ```bash
    paru -Sy genv-bin && genv version   # pre-compiled
@@ -357,7 +368,7 @@ paru -S genv       # builds from source
    paru -Sy genv && genv version       # from source
    ```
 
-9. **Snap Store:** handled automatically by GoReleaser's `snapcrafts` section — no manual step needed.
+10. **Snap Store:** handled automatically by GoReleaser's `snapcrafts` section — no manual step needed.
 
 ---
 
@@ -389,13 +400,12 @@ Artifacts land in `./dist/`. Nothing is published.
 
 ## Future distribution channels
 
-Scoop is a self-hosted bucket (`ks1686/scoop-bucket`), not Scoop extras.
+Scoop is live as a self-hosted bucket (`ks1686/scoop-bucket`), not Scoop extras.
 winget and Chocolatey stay unpublished (community review + GoReleaser Pro).
 GitHub Release zips remain a supported Windows path.
 
 | Channel | Status | Notes |
 | --- | --- | --- |
-| Scoop | Self-hosted bucket | Uploads from the release workflow when `SCOOP_BUCKET_GITHUB_TOKEN` is set |
 | winget | Deferred | Publisher is GoReleaser Pro-only; default source needs microsoft/winget-pkgs review |
 | Chocolatey | Deferred | Publisher is GoReleaser Pro-only; community repo has the same review gate |
 | apt PPA | Deferred | `.deb` artifacts already ship via GitHub Releases |

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -2,7 +2,18 @@
 
 Native Windows is the `windows` target (not WSL). Use a separate Linux install inside WSL — see [wsl2-install.md](wsl2-install.md).
 
-## 1. Download genv
+## 1. Install genv
+
+**Scoop** (self-hosted bucket, not Scoop extras):
+
+```powershell
+scoop bucket add ks1686 https://github.com/ks1686/scoop-bucket
+scoop install genv
+```
+
+`scoop install genv` needs a `genv.json` manifest on that bucket, which the
+release workflow writes when `SCOOP_BUCKET_GITHUB_TOKEN` is set. Until then,
+use the zip:
 
 ```powershell
 Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_windows_amd64.zip -OutFile genv.zip
@@ -15,7 +26,9 @@ genv version
 
 Update the version segment when a newer release is current.
 
-Store installers for genv itself (`winget install ks1686.genv`, `scoop install genv`, `choco install genv`) are not published yet. Scoop is prepared in OSS GoReleaser with upload skipped; winget and Chocolatey need GoReleaser Pro. Those managers remain available for **packages** genv manages.
+winget and Chocolatey installers for genv itself (`winget install ks1686.genv`,
+`choco install genv`) are not published (GoReleaser Pro). Those managers remain
+available for **packages** genv manages.
 
 ## 2. Install a Windows package manager
 

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -15,7 +15,7 @@ scoop install genv
 first stable tag after merge uploads. Until then, use the zip:
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.13_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .\genv
 New-Item -ItemType Directory -Force $HOME\bin
 Copy-Item .\genv\genv.exe $HOME\bin\genv.exe

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -12,8 +12,7 @@ scoop install genv
 ```
 
 `scoop install genv` needs a `genv.json` manifest on that bucket, which the
-release workflow writes when `SCOOP_BUCKET_GITHUB_TOKEN` is set. Until then,
-use the zip:
+first stable tag after merge uploads. Until then, use the zip:
 
 ```powershell
 Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_windows_amd64.zip -OutFile genv.zip

--- a/docs/wsl2-install.md
+++ b/docs/wsl2-install.md
@@ -31,7 +31,7 @@ wsl --install
 Download the latest Linux binary from the [Releases](https://github.com/ks1686/genv/releases/latest) page:
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.0.12_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.0.13_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 rm genv.tar.gz


### PR DESCRIPTION
## Summary
- Wire GoReleaser to push a Scoop manifest to [ks1686/scoop-bucket](https://github.com/ks1686/scoop-bucket) on stable tags when `SCOOP_BUCKET_GITHUB_TOKEN` is set.
- Skip that upload (without failing GitHub/Homebrew/Snap) when the token env is empty or unset.
- Document the two-step install: `scoop bucket add ks1686 https://github.com/ks1686/scoop-bucket` then `scoop install genv`. Not Scoop extras; winget/Chocolatey stay unpublished.

Related: #80 (Scoop only; winget/choco remain deferred).

## Test plan
- [x] `goreleaser check`
- [x] `goreleaser release --snapshot --skip=publish,snapcraft,sign` writes `dist/scoop/genv.json` with `64bit` + `arm64` and `genv.exe`
- [x] Snapshot with token unset no longer aborts the scoop pipe
- [ ] After merge, next stable tag uploads root `genv.json` to the bucket
- [ ] Windows: `scoop bucket add ks1686 https://github.com/ks1686/scoop-bucket` then `scoop install genv`