### PR TITLE
fix: use Homebrew-style env token for Scoop upload

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -140,7 +140,7 @@ scoops:
     repository:
       owner: ks1686
       name: scoop-bucket
-      token: '{{ envOrDefault "SCOOP_BUCKET_GITHUB_TOKEN" "" }}'
+      token: "{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}"
     homepage: "https://github.com/ks1686/genv"
     description: "Track, sync, and reproduce your software environment across Linux, macOS, Windows, and WSL2."
     license: MIT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Scoop publisher uses the same env-token template as Homebrew. `envOrDefault`
+  is not a GoReleaser function, so the v4.0.13 scoop upload aborted after the
+  GitHub Release and Homebrew tap had already published.
+
 ## v4.0.13 - 2026-08-19
 
 ### Added


### PR DESCRIPTION
## Summary
- Replace the Scoop `envOrDefault` token template with `{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}`, matching Homebrew. GoReleaser 2.17 does not define `envOrDefault`, which aborted the v4.0.13 scoop upload after GitHub and Homebrew had already published.

v4.0.13 `genv.json` was written to [ks1686/scoop-bucket](https://github.com/ks1686/scoop-bucket/blob/main/genv.json) by hand. AUR-only repair is running separately.

## Test plan
- [x] `goreleaser check`
- [ ] Next stable tag uploads Scoop without that template error