### PR TITLE
fix: unflake Windows spawn timeout and cut v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v4.1.0 - 2026-08-19
+
+### Added
+
+- Self-hosted Scoop install channel on stable tags: GoReleaser publishes
+  `genv.json` to `ks1686/scoop-bucket`. v4.0.13 shipped GitHub/Homebrew; this
+  release is the first tag that uploads the Scoop manifest from CI.
+
 ### Fixed
 
-- Scoop publisher uses the same env-token template as Homebrew. `envOrDefault`
-  is not a GoReleaser function, so the v4.0.13 scoop upload aborted after the
-  GitHub Release and Homebrew tap had already published.
+- Scoop publisher token template matches Homebrew (`{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}`).
+  GoReleaser 2.17 has no `envOrDefault`, which aborted the v4.0.13 scoop upload.
+- `TestRunSubcmd_PerSpawnTimeout` gives the follow-up spawn 2s (not 50ms) so
+  Windows CI does not fail `go env GOVERSION` after killing `sleep`.
 
 ## v4.0.13 - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Track, sync, and reproduce your software environment across **macOS**, **Windows
 
 `genv` is a thin layer over the package managers you already use. Desired state lives in one git-friendly `genv.json`. Applied state lives in a machine-local lock file. Run `genv apply` and the machine matches the spec.
 
-**Current release:** [latest](https://github.com/ks1686/genv/releases/latest) (v4.0.13+) — schema **v7** PowerShell parity, schema **v8** portable multi-target configs.
+**Current release:** [latest](https://github.com/ks1686/genv/releases/latest) (v4.1.0+) — schema **v7** PowerShell parity, schema **v8** portable multi-target configs.
 
 ```bash
 genv add git                          # track + install
@@ -31,7 +31,7 @@ genv map --target arch                # assist-only manager suggestions
 **Linux x86-64 example** (replace the version to match [Releases](https://github.com/ks1686/genv/releases/latest)):
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.0.13_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.1.0_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 genv version
@@ -51,7 +51,7 @@ Until then use the zip below.
 **Windows (PowerShell zip):**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.13_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.1.0_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .
 # put genv.exe on PATH, then:
 genv version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,6 +35,7 @@ handles GitHub releases, Homebrew, Scoop, AUR, and the Snap Store automatically
 | `v4.0.11` | Fail-closed `add`, schema v8 defaults, native apt/dnf/apk, Windows CI/test hardening (tag exists; GitHub Release aborted on Pro-only GoReleaser keys) |
 | `v4.0.12` | Drop Pro-only winget/chocolatey GoReleaser keys so OSS publish can succeed |
 | `v4.0.13` | Self-hosted Scoop bucket (`ks1686/scoop-bucket`) |
+| `v4.1.0` | First tagged Scoop upload from CI (token template matches Homebrew) |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew, Scoop,

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -15,7 +15,7 @@ scoop install genv
 first stable tag after merge uploads. Until then, use the zip:
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.0.13_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.1.0_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .\genv
 New-Item -ItemType Directory -Force $HOME\bin
 Copy-Item .\genv\genv.exe $HOME\bin\genv.exe

--- a/docs/wsl2-install.md
+++ b/docs/wsl2-install.md
@@ -31,7 +31,7 @@ wsl --install
 Download the latest Linux binary from the [Releases](https://github.com/ks1686/genv/releases/latest) page:
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.0.13_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.1.0_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 rm genv.tar.gz

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -29,13 +29,15 @@ func TestRunSubcmd_PerSpawnTimeout(t *testing.T) {
 	if _, err := exec.LookPath("sleep"); err != nil {
 		t.Skip("sleep not in PATH")
 	}
-	ctx := WithSubprocessTimeout(context.Background(), 50*time.Millisecond)
+	ctx := WithSubprocessTimeout(context.Background(), 2*time.Second)
 	err := runSubcmd(ctx, []string{"sleep", "5"}, nil, io.Discard, io.Discard)
 	if err == nil {
 		t.Fatal("expected sleep to hit per-spawn timeout")
 	}
 	// `true` is not reliable on Windows CI (LookPath can find a non-POSIX
 	// true.exe that exits 1). `go` is on PATH wherever these tests run.
+	// 50ms was too tight: after killing sleep, `go env GOVERSION` often
+	// exceeds 50ms on Windows runners and fails the reuse assertion.
 	if err := runSubcmd(ctx, []string{"go", "env", "GOVERSION"}, nil, io.Discard, io.Discard); err != nil {
 		t.Fatalf("later command after a timed-out spawn: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Main Windows CI fails `TestRunSubcmd_PerSpawnTimeout`: 50ms kills `sleep` but `go env GOVERSION` on the follow-up spawn often exceeds 50ms. Timeout is now 2s.
- Cut changelog/docs for **v4.1.0** (first tagged Scoop upload from CI after the token-template fix).

Do not tag until this PR's Windows job is green.

## Test plan
- [x] `go test -run TestRunSubcmd_PerSpawnTimeout ./internal/resolver`
- [ ] CI Test (Windows) on this PR
- [ ] After merge, tag `v4.1.0` and confirm `ks1686/scoop-bucket` has `genv.json` version 4.1.0