### PR TITLE
fix: make Windows apply skip installed apps and survive hung installers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v4.2.0 - 2026-08-20
+
 ### Fixed
 
 - `genv apply` no longer treats an empty lock as “install everything”. Packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- `genv apply` no longer treats an empty lock as “install everything”. Packages
+  already present in winget/scoop are adopted into the lock (no upgrade).
+- `winget install` uses `--disable-interactivity --no-upgrade`. Apply’s
+  per-subprocess timeout defaults to 10m (`--timeout 0` disables).
+- A failed or hung package no longer skips env/files.
+- `genv adopt <id>` reads `managers.<mgr>` from the spec (e.g. `Anysphere.Cursor`)
+  and can lock a package that is already listed in the spec.
+- Windows status/apply no longer report zsh aliases or `HOMEBREW_*` as missing.
+- Scoop subprocesses find git via the versioned `scoop/apps/git/<ver>/cmd`
+  directory when the `current` junction is invisible (OpenSSH).
+
+### Added
+
+- `genv apply --skip-packages`
+- `genv status --offline` (lock-only). Default status probes live managers;
+  installed-but-unlocked packages are `present`.
+- `external` manager for apps genv tracks but does not install.
+
 ## v4.1.0 - 2026-08-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -258,9 +258,13 @@ Tab completion on `add` / `adopt` suggests package names from available managers
 ### Apply / portability flags worth knowing
 
 ```bash
+genv apply --target windows --yes                 # adopt live apps, install only the missing
+genv apply --skip-packages --yes                  # links + env only
 genv apply --target ubuntu --dry-run --json
 genv apply --force --backup --yes                 # overwrite mismatched files; keep *.backup.*
 genv apply --target ubuntu --force-new-lock --yes   # after a foreign lock refuse
+genv status --target windows                      # present vs missing vs ok
+genv adopt cursor --target windows                # lock Anysphere.Cursor if already installed
 genv export --target macos --out ./dist/macos --strict
 genv migrate --write
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,6 +36,7 @@ handles GitHub releases, Homebrew, Scoop, AUR, and the Snap Store automatically
 | `v4.0.12` | Drop Pro-only winget/chocolatey GoReleaser keys so OSS publish can succeed |
 | `v4.0.13` | Self-hosted Scoop bucket (`ks1686/scoop-bucket`) |
 | `v4.1.0` | First tagged Scoop upload from CI (token template matches Homebrew) |
+| `v4.2.0` | Windows apply skip-if-present, 10m timeout, live status, `--skip-packages`, `external` manager |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew, Scoop,

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -135,6 +135,12 @@ Map of name → `{ start, stop, restart, status }` argv arrays and/or `brew_form
 
 `prefer` and `managers` accept registered manager IDs (see README table). Without an explicit selection, fallback uses **system** package managers only. Language, toolchain, and plugin managers are explicit-only.
 
+`external` is a track-only manager for apps with an official installer (not winget/scoop). Apply records them when the binary is on PATH; it never installs them.
+
+`genv apply` consults a live inventory (`ListInstalled` per available manager) and adopts already-installed packages into the lock instead of reinstalling. `genv upgrade` remains the only upgrade path. Apply `--timeout` defaults to 10m. `--skip-packages` applies env/files without touching packages.
+
+`genv status` probes live managers by default (`--offline` is lock-only). Unlocked but installed packages are `present`.
+
 ## Profiles
 
 Named profiles live in `profiles/<name>.json` beside the base spec on schema v1–v7. `genv profile switch` merges the profile over the base, applies, and stores `activeProfile` in the lock. Schema v8 refuses named profiles — use `defaults` plus `targets.*` instead.

--- a/completions/genv.bash
+++ b/completions/genv.bash
@@ -113,7 +113,7 @@ _genv() {
 		fi
 		;;
 	apply)
-		opts="--file --lock-file --dry-run --force --backup --strict --yes --quiet --json --timeout --no-hooks --hook-timeout --debug --host --target --force-new-lock"
+		opts="--file --lock-file --dry-run --force --backup --strict --yes --quiet --json --timeout --no-hooks --skip-packages --hook-timeout --debug --host --target --force-new-lock"
 		;;
 	migrate)
 		opts="--file --write"

--- a/completions/genv.fish
+++ b/completions/genv.fish
@@ -210,6 +210,7 @@ complete -c genv -n '__fish_genv_using_command apply' -l quiet -d 'Suppress plan
 complete -c genv -n '__fish_genv_using_command apply' -l json -d 'Emit machine-readable JSON to stdout'
 complete -c genv -n '__fish_genv_using_command apply' -l timeout -d 'Per-subprocess timeout' -x
 complete -c genv -n '__fish_genv_using_command apply' -l no-hooks -d 'Skip pre-apply and post-apply hooks'
+complete -c genv -n '__fish_genv_using_command apply' -l skip-packages -d 'Skip package install/remove; still apply env, shell, files, and services'
 complete -c genv -n '__fish_genv_using_command apply' -l hook-timeout -d 'Per-hook timeout' -x
 complete -c genv -n '__fish_genv_using_command apply' -l debug -d 'Emit debug-level structured logs to stderr'
 complete -c genv -n '__fish_genv_using_command apply' -l host -d 'Host name for host-specific records' -x

--- a/completions/genv.ps1
+++ b/completions/genv.ps1
@@ -95,7 +95,7 @@ function script:Get-GenvCompletions {
 	switch ($cmd) {
 		{ $_ -in 'apply' } {
 			$flags = @('--file', '--lock-file', '--dry-run', '--force', '--backup', '--strict', '--yes',
-				'--quiet', '--json', '--timeout', '--no-hooks', '--hook-timeout', '--debug',
+				'--quiet', '--json', '--timeout', '--no-hooks', '--skip-packages', '--hook-timeout', '--debug',
 				'--host', '--target', '--force-new-lock')
 			return (& $completeCandidates -Candidates $flags)
 		}

--- a/completions/genv.zsh
+++ b/completions/genv.zsh
@@ -199,6 +199,7 @@ _genv() {
 				'--json[Emit machine-readable JSON to stdout]' \
 				'--timeout=[Per-subprocess timeout]:timeout:' \
 				'--no-hooks[Skip pre-apply and post-apply hooks]' \
+				'--skip-packages[Skip package install/remove; still apply env, shell, files, and services]' \
 				'--hook-timeout=[Per-hook timeout]:timeout:' \
 				'--debug[Emit debug-level structured logs to stderr]' \
 				'--host=[Host name for host-specific records]:host:' \

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -410,11 +410,11 @@ func runE2ESuite(t *testing.T, cfg suiteConfig) {
 		r.assertInSpec(t, cfg.testPkg)
 	})
 
-	// status on a spec with no lock entry should report "missing"
+	// status on a spec with no lock: missing when the package is not on the machine.
+	// Use a name no manager will have installed, so live probe cannot report present.
 	t.Run("status_package_in_spec_not_in_lock", func(t *testing.T) {
 		r2 := newRunner(t, cfg.preferFlag)
-		r2.writeSpec(t, cfg.testPkg)
-		// no lock written — package is in spec but not yet installed/tracked
+		r2.writeSpec(t, "genv-e2e-not-installed")
 		stdout, _, code := r2.genv("", "status")
 		if code != 0 {
 			t.Fatalf("genv status: exit %d, want 0", code)

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -76,6 +76,12 @@ type OutdatedLister interface {
 	ListOutdated(pkgNames []string) (map[string]string, error)
 }
 
+// TrackOnly is an optional marker for adapters that record a package in the
+// lock without spawning an installer (official/manual installers).
+type TrackOnly interface {
+	TrackOnly()
+}
+
 // Adapter is the capability contract every package manager must satisfy.
 // Each method maps to one of the four resolver operations: detect, query,
 // plan install, and normalize package IDs.
@@ -170,6 +176,7 @@ var All = []Adapter{
 	Winget{},
 	Scoop{},
 	Choco{},
+	External{},
 }
 
 // ByName returns the adapter whose Name() matches name, or nil if none match.

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/ks1686/genv/internal/schema"
 )
 
+func skipTrackOnly(t *testing.T, a Adapter) {
+	t.Helper()
+	if _, ok := a.(TrackOnly); ok {
+		t.Skip("track-only adapter has no install/upgrade argv")
+	}
+}
+
 // TestAllAdapterNames verifies that every adapter in the registry has a
 // non-empty, unique name and is reachable via ByName.
 func TestAllAdapterNames(t *testing.T) {
@@ -120,6 +127,7 @@ func TestNormalizeID_FallbackToID(t *testing.T) {
 func TestPlanInstall_NonEmpty(t *testing.T) {
 	for _, a := range All {
 		t.Run(a.Name(), func(t *testing.T) {
+			skipTrackOnly(t, a)
 			pkg := planTestPackage(a.Name())
 			args := a.PlanInstall(pkg)
 			if len(args) == 0 {
@@ -190,6 +198,7 @@ func TestPlanInstall_ExpectedBinaries(t *testing.T) {
 func TestPlanUninstall_NonEmpty(t *testing.T) {
 	for _, a := range All {
 		t.Run(a.Name(), func(t *testing.T) {
+			skipTrackOnly(t, a)
 			pkg := planTestPackage(a.Name())
 			args := a.PlanUninstall(pkg)
 			if len(args) == 0 {
@@ -287,6 +296,9 @@ func TestAvailable_AllAdapters_WithMockedLookPath(t *testing.T) {
 			}
 		})
 		t.Run(a.Name()+"/missing", func(t *testing.T) {
+			if _, ok := a.(TrackOnly); ok {
+				t.Skip("track-only is always available")
+			}
 			lookPath = func(string) (string, error) { return "", &os.PathError{Op: "lookpath", Err: os.ErrNotExist} }
 			krewProbe = func() error { return os.ErrNotExist }
 			if a.Available() {
@@ -743,6 +755,7 @@ func TestPlanUpgrade_ExpectedBinaries(t *testing.T) {
 func TestPlanUpgrade_PkgNamePresent(t *testing.T) {
 	for _, a := range All {
 		t.Run(a.Name(), func(t *testing.T) {
+			skipTrackOnly(t, a)
 			pkg := planTestPackage(a.Name())
 			assertContainsArg(t, a.PlanUpgrade(pkg), planTestPackageSuffix(a.Name(), pkg))
 		})

--- a/internal/adapter/external.go
+++ b/internal/adapter/external.go
@@ -1,0 +1,32 @@
+package adapter
+
+// External tracks packages genv does not install (official installers,
+// vendor downloads). Apply records them when the binary is on PATH.
+type External struct{}
+
+func (External) Name() string { return "external" }
+
+func (External) Available() bool { return true }
+
+func (External) TrackOnly() {}
+
+func (External) NormalizeID(id string, managers map[string]string) (string, bool) {
+	return normalizeID("external", id, managers)
+}
+
+func (External) PlanInstall(string) []string { return nil }
+
+func (External) PlanUninstall(string) []string { return nil }
+
+func (External) PlanUpgrade(string) []string { return nil }
+
+func (External) PlanClean() [][]string { return nil }
+
+func (External) Query(pkgName string) (bool, error) {
+	_, err := lookPath(pkgName)
+	return err == nil, nil
+}
+
+func (External) ListInstalled() ([]string, error) { return nil, nil }
+
+func (External) QueryVersion(string) (string, error) { return "", nil }

--- a/internal/adapter/external_test.go
+++ b/internal/adapter/external_test.go
@@ -1,0 +1,39 @@
+package adapter
+
+import "testing"
+
+func TestExternal_Name(t *testing.T) {
+	if got := (External{}).Name(); got != "external" {
+		t.Errorf("Name() = %q, want external", got)
+	}
+}
+
+func TestExternal_QueryUsesLookPath(t *testing.T) {
+	installFakeBinary(t, "hermes", "exit 0")
+	ok, err := (External{}).Query("hermes")
+	if err != nil || !ok {
+		t.Fatalf("Query(hermes)=%v %v, want true", ok, err)
+	}
+	ok, err = (External{}).Query("definitely-not-installed-xyz")
+	if err != nil || ok {
+		t.Fatalf("Query(missing)=%v %v, want false", ok, err)
+	}
+}
+
+func TestExternal_NotDefaultFallback(t *testing.T) {
+	if IsDefaultFallbackEligible(External{}) {
+		t.Fatal("external must not steal genv add git")
+	}
+}
+
+func TestExternal_AvailableAlways(t *testing.T) {
+	if !(External{}).Available() {
+		t.Fatal("external should always be available")
+	}
+}
+
+func TestExternal_PlanInstallEmpty(t *testing.T) {
+	if cmd := (External{}).PlanInstall("hermes"); len(cmd) != 0 {
+		t.Fatalf("PlanInstall = %v, want empty", cmd)
+	}
+}

--- a/internal/adapter/scoop.go
+++ b/internal/adapter/scoop.go
@@ -2,7 +2,9 @@ package adapter
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -199,4 +201,41 @@ func stripANSI(s string) string {
 		b.WriteByte(s[i])
 	}
 	return b.String()
+}
+
+// ScoopGitCmdDir returns the versioned scoop git cmd directory, skipping the
+// "current" junction which OpenSSH sessions often cannot follow.
+func ScoopGitCmdDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	if v := os.Getenv("USERPROFILE"); v != "" {
+		home = v
+	}
+	root := filepath.Join(home, "scoop", "apps", "git")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return ""
+	}
+	var best string
+	for _, e := range entries {
+		name := e.Name()
+		if name == "current" || !e.IsDir() {
+			continue
+		}
+		cmd := filepath.Join(root, name, "cmd")
+		if _, err := os.Stat(filepath.Join(cmd, "git.exe")); err != nil {
+			if _, err2 := os.Stat(filepath.Join(cmd, "git")); err2 != nil {
+				continue
+			}
+		}
+		if best == "" || name > best {
+			best = name
+		}
+	}
+	if best == "" {
+		return ""
+	}
+	return filepath.Join(root, best, "cmd")
 }

--- a/internal/adapter/scoop_test.go
+++ b/internal/adapter/scoop_test.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"maps"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -203,5 +204,38 @@ func TestScoop_Available(t *testing.T) {
 	}
 	if (Scoop{}).Available() {
 		t.Error("Available() = true when lookPath fails")
+	}
+}
+
+func TestScoopGitCmdDir_PrefersVersionedNotCurrent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOME", home)
+	base := filepath.Join(home, "scoop", "apps", "git")
+	if err := os.MkdirAll(filepath.Join(base, "current", "cmd"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ver := filepath.Join(base, "2.55.0.2", "cmd")
+	if err := os.MkdirAll(ver, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(p string) {
+		t.Helper()
+		if err := os.WriteFile(p, []byte(""), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(base, "current", "cmd", "git.exe"))
+	write(filepath.Join(ver, "git.exe"))
+	got := ScoopGitCmdDir()
+	if got != ver {
+		t.Fatalf("got %q, want %q", got, ver)
+	}
+}
+
+func TestScoopGitCmdDir_EmptyWhenMissing(t *testing.T) {
+	t.Setenv("USERPROFILE", t.TempDir())
+	if got := ScoopGitCmdDir(); got != "" {
+		t.Fatalf("got %q, want empty", got)
 	}
 }

--- a/internal/adapter/winget.go
+++ b/internal/adapter/winget.go
@@ -24,15 +24,15 @@ func (Winget) NormalizeID(id string, managers map[string]string) (string, bool) 
 }
 
 func (Winget) PlanInstall(pkgName string) []string {
-	return []string{"winget", "install", "--exact", "--silent", "--accept-package-agreements", "--accept-source-agreements", "--id", pkgName}
+	return []string{"winget", "install", "--exact", "--silent", "--disable-interactivity", "--no-upgrade", "--accept-package-agreements", "--accept-source-agreements", "--id", pkgName}
 }
 
 func (Winget) PlanUninstall(pkgName string) []string {
-	return []string{"winget", "uninstall", "--exact", "--silent", "--id", pkgName}
+	return []string{"winget", "uninstall", "--exact", "--silent", "--disable-interactivity", "--id", pkgName}
 }
 
 func (Winget) PlanUpgrade(pkgName string) []string {
-	return []string{"winget", "upgrade", "--exact", "--silent", "--accept-package-agreements", "--accept-source-agreements", "--id", pkgName}
+	return []string{"winget", "upgrade", "--exact", "--silent", "--disable-interactivity", "--accept-package-agreements", "--accept-source-agreements", "--id", pkgName}
 }
 
 // PlanClean returns nil: winget has no standalone cache-clean command.

--- a/internal/adapter/winget_test.go
+++ b/internal/adapter/winget_test.go
@@ -13,7 +13,7 @@ func TestWinget_Name(t *testing.T) {
 
 func TestWinget_PlanInstall(t *testing.T) {
 	args := Winget{}.PlanInstall("Neovim.Neovim")
-	want := []string{"winget", "install", "--exact", "--silent", "--accept-package-agreements", "--accept-source-agreements", "--id", "Neovim.Neovim"}
+	want := []string{"winget", "install", "--exact", "--silent", "--disable-interactivity", "--no-upgrade", "--accept-package-agreements", "--accept-source-agreements", "--id", "Neovim.Neovim"}
 	if len(args) != len(want) {
 		t.Fatalf("PlanInstall: got %v, want %v", args, want)
 	}
@@ -26,13 +26,31 @@ func TestWinget_PlanInstall(t *testing.T) {
 
 func TestWinget_PlanUninstall(t *testing.T) {
 	args := Winget{}.PlanUninstall("Neovim.Neovim")
-	want := []string{"winget", "uninstall", "--exact", "--silent", "--id", "Neovim.Neovim"}
+	want := []string{"winget", "uninstall", "--exact", "--silent", "--disable-interactivity", "--id", "Neovim.Neovim"}
 	if len(args) != len(want) {
 		t.Fatalf("PlanUninstall: got %v, want %v", args, want)
 	}
 	for i, w := range want {
 		if args[i] != w {
 			t.Errorf("PlanUninstall[%d] = %q, want %q", i, args[i], w)
+		}
+	}
+}
+
+func TestWinget_PlanUpgrade_DisableInteractivity(t *testing.T) {
+	args := Winget{}.PlanUpgrade("Neovim.Neovim")
+	want := []string{"winget", "upgrade", "--exact", "--silent", "--disable-interactivity", "--accept-package-agreements", "--accept-source-agreements", "--id", "Neovim.Neovim"}
+	if len(args) != len(want) {
+		t.Fatalf("PlanUpgrade: got %v, want %v", args, want)
+	}
+	for i, w := range want {
+		if args[i] != w {
+			t.Errorf("PlanUpgrade[%d] = %q, want %q", i, args[i], w)
+		}
+	}
+	for _, a := range args {
+		if a == "--no-upgrade" {
+			t.Fatal("PlanUpgrade must not pass --no-upgrade")
 		}
 	}
 }

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"strings"
+
+	"github.com/ks1686/genv/internal/adapter"
 	"github.com/ks1686/genv/internal/genvfile"
 	"github.com/ks1686/genv/internal/schema"
 	"github.com/ks1686/genv/internal/version"
@@ -18,9 +21,13 @@ const (
 	// InstalledVersion does not satisfy the spec version constraint.
 	StatusDrift StatusKind = "drift"
 
-	// StatusMissing means the package is in the spec but has no lock entry —
-	// it has never been installed by genv (run 'genv apply').
+	// StatusMissing means the package is in the spec but has no lock entry and
+	// is not installed on the live system (run 'genv apply').
 	StatusMissing StatusKind = "missing"
+
+	// StatusPresent means the package is in the spec, not in the lock, but
+	// already installed via its manager. Apply will adopt it without installing.
+	StatusPresent StatusKind = "present"
 
 	// StatusExtra means the package is in the lock but not in the spec —
 	// it was removed from the spec without being uninstalled (run 'genv apply').
@@ -40,13 +47,13 @@ type StatusEntry struct {
 // Status computes the three-way diff between the spec (genv.json) and the lock
 // file (genv.lock.json). It does not query the live system — the lock file is
 // the record of what genv last installed.
-//
-// Categories:
-//   - ok:      in spec and lock, version constraint satisfied (or unconstrained)
-//   - drift:   in spec and lock, but InstalledVersion fails the spec constraint
-//   - missing: in spec only (genv apply needed)
-//   - extra:   in lock only (removed from spec without genv remove / genv apply)
 func Status(f *schema.GenvFile, lf *genvfile.LockFile) []StatusEntry {
+	return StatusWithLive(f, lf, nil)
+}
+
+// StatusWithLive is Status plus a live inventory (manager → native names).
+// Unlocked spec packages that are live-installed are StatusPresent.
+func StatusWithLive(f *schema.GenvFile, lf *genvfile.LockFile, live map[string]map[string]bool) []StatusEntry {
 	lockByID := make(map[string]genvfile.LockedPackage, len(lf.Packages))
 	for _, lp := range lf.Packages {
 		lockByID[lp.ID] = lp
@@ -58,10 +65,19 @@ func Status(f *schema.GenvFile, lf *genvfile.LockFile) []StatusEntry {
 
 	var entries []StatusEntry
 
-	// Spec-side pass: ok, drift, or missing.
 	for _, pkg := range f.Packages {
 		lp, inLock := lockByID[pkg.ID]
 		if !inLock {
+			if mgr, name, ok := liveMatch(pkg, live); ok {
+				entries = append(entries, StatusEntry{
+					ID:          pkg.ID,
+					Manager:     mgr,
+					PkgName:     name,
+					Kind:        StatusPresent,
+					SpecVersion: pkg.Version,
+				})
+				continue
+			}
 			entries = append(entries, StatusEntry{
 				ID:          pkg.ID,
 				Kind:        StatusMissing,
@@ -70,7 +86,6 @@ func Status(f *schema.GenvFile, lf *genvfile.LockFile) []StatusEntry {
 			continue
 		}
 		kind := StatusOK
-		// Only report drift when an installed version is actually recorded.
 		if lp.InstalledVersion != "" && !version.Satisfies(pkg.Version, lp.InstalledVersion) {
 			kind = StatusDrift
 		}
@@ -84,7 +99,6 @@ func Status(f *schema.GenvFile, lf *genvfile.LockFile) []StatusEntry {
 		})
 	}
 
-	// Lock-side pass: extra entries not in spec.
 	for _, lp := range lf.Packages {
 		if !specByID[lp.ID] {
 			entries = append(entries, StatusEntry{
@@ -98,4 +112,47 @@ func Status(f *schema.GenvFile, lf *genvfile.LockFile) []StatusEntry {
 	}
 
 	return entries
+}
+
+func liveMatch(pkg schema.Package, live map[string]map[string]bool) (manager, pkgName string, ok bool) {
+	if live == nil {
+		return "", "", false
+	}
+	try := func(mgr string) (string, string, bool) {
+		if mgr == "" {
+			return "", "", false
+		}
+		name := pkg.ID
+		if a := adapter.ByName(mgr); a != nil {
+			name, _ = a.NormalizeID(pkg.ID, pkg.Managers)
+		} else if n, exists := pkg.Managers[mgr]; exists {
+			name = n
+		}
+		if liveHas(live, mgr, name) {
+			return mgr, name, true
+		}
+		return "", "", false
+	}
+	if mgr, name, ok := try(pkg.Prefer); ok {
+		return mgr, name, true
+	}
+	for mgr := range pkg.Managers {
+		if m, name, ok := try(mgr); ok {
+			return m, name, true
+		}
+	}
+	return "", "", false
+}
+
+func liveHas(live map[string]map[string]bool, manager, pkgName string) bool {
+	names := live[manager]
+	if names[pkgName] {
+		return true
+	}
+	for n := range names {
+		if strings.EqualFold(n, pkgName) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/commands/status_test.go
+++ b/internal/commands/status_test.go
@@ -144,3 +144,38 @@ func TestStatus_Mixed(t *testing.T) {
 		}
 	}
 }
+
+func TestStatus_PresentWhenLiveButUnlocked(t *testing.T) {
+	f := &schema.GenvFile{Packages: []schema.Package{{
+		ID: "cursor", Managers: map[string]string{"winget": "Anysphere.Cursor"},
+	}}}
+	lf := &genvfile.LockFile{}
+	live := map[string]map[string]bool{"winget": {"Anysphere.Cursor": true}}
+	entries := StatusWithLive(f, lf, live)
+	if len(entries) != 1 || entries[0].Kind != StatusPresent {
+		t.Fatalf("got %+v, want present", entries)
+	}
+	if entries[0].Manager != "winget" || entries[0].PkgName != "Anysphere.Cursor" {
+		t.Fatalf("got manager/name %+v", entries[0])
+	}
+}
+
+func TestStatus_MissingWhenNotLive(t *testing.T) {
+	f := &schema.GenvFile{Packages: []schema.Package{{
+		ID: "syncthing", Managers: map[string]string{"winget": "Syncthing.Syncthing"},
+	}}}
+	entries := StatusWithLive(f, &genvfile.LockFile{}, map[string]map[string]bool{"winget": {}})
+	if len(entries) != 1 || entries[0].Kind != StatusMissing {
+		t.Fatalf("got %+v, want missing", entries)
+	}
+}
+
+func TestStatus_NilLive_SameAsStatus(t *testing.T) {
+	f := &schema.GenvFile{Packages: []schema.Package{{ID: "curl"}}}
+	lf := &genvfile.LockFile{}
+	got := StatusWithLive(f, lf, nil)
+	want := Status(f, lf)
+	if len(got) != 1 || got[0].Kind != want[0].Kind {
+		t.Fatalf("nil live = %+v, want %+v", got, want)
+	}
+}

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -56,7 +56,7 @@ type PlanResult struct {
 type StatusEntry struct {
 	ID               string `json:"id"`
 	Manager          string `json:"manager,omitempty"`
-	Kind             string `json:"kind"` // "ok" | "drift" | "missing" | "extra"
+	Kind             string `json:"kind"` // "ok" | "drift" | "missing" | "present" | "extra"
 	SpecVersion      string `json:"specVersion,omitempty"`
 	InstalledVersion string `json:"installedVersion,omitempty"`
 }

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -44,6 +44,7 @@ type PlanResult struct {
 	ToInstall       []PlanPackage   `json:"toInstall"`
 	ToRemove        []PlanPackage   `json:"toRemove"`
 	Unchanged       []PlanPackage   `json:"unchanged"`
+	Adopted         []PlanPackage   `json:"adopted,omitempty"`
 	Unresolved      int             `json:"unresolved"`
 	ServicesToStart []string        `json:"servicesToStart,omitempty"`
 	ServicesToStop  []string        `json:"servicesToStop,omitempty"`

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -444,6 +444,33 @@ func (s LiveSet) has(manager, pkgName string) bool {
 	return false
 }
 
+// LoadLiveSet calls ListInstalled once per available manager. Listing errors
+// become warnings; they never fail the whole apply/status run.
+func LoadLiveSet(available map[string]bool) (LiveSet, []string) {
+	out := make(LiveSet)
+	var warns []string
+	for name, ok := range available {
+		if !ok {
+			continue
+		}
+		mgr := adapter.ByName(name)
+		if mgr == nil {
+			continue
+		}
+		list, err := mgr.ListInstalled()
+		if err != nil {
+			warns = append(warns, fmt.Sprintf("listing %s: %v", name, err))
+			continue
+		}
+		set := make(map[string]bool, len(list))
+		for _, pkgName := range list {
+			set[pkgName] = true
+		}
+		out[name] = set
+	}
+	return out, warns
+}
+
 // Reconcile computes the delta between the desired packages (from genv.json)
 // and the previously applied state (from genv.lock.json).
 //

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -683,6 +683,25 @@ func ExecuteApply(ctx context.Context, result ReconcileResult, stdin io.Reader, 
 		if !a.Resolved() {
 			continue
 		}
+		if mgr := getAdapter(a.Manager); mgr != nil {
+			if _, trackOnly := mgr.(adapter.TrackOnly); trackOnly {
+				installed, qerr := mgr.Query(a.PkgName)
+				if qerr != nil {
+					out.Errors = append(out.Errors, fmt.Errorf("query %q (via %s): %w", a.Pkg.ID, a.Manager, qerr))
+					continue
+				}
+				if !installed {
+					out.Errors = append(out.Errors, fmt.Errorf("install %q (via %s): not on PATH — install it with the official installer, then re-run apply", a.Pkg.ID, a.Manager))
+					continue
+				}
+				out.Installed = append(out.Installed, genvfile.LockedPackage{
+					ID:      a.Pkg.ID,
+					Manager: a.Manager,
+					PkgName: a.PkgName,
+				})
+				continue
+			}
+		}
 		if err := runSubcmd(ctx, a.Cmd, stdin, stdout, stderr); err != nil {
 			out.Errors = append(out.Errors, fmt.Errorf("install %q (via %s): %w", a.Pkg.ID, a.Manager, err))
 		} else {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -168,6 +169,13 @@ func runSubcmd(ctx context.Context, args []string, stdin io.Reader, stdout, stde
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	if runtime.GOOS == "windows" {
+		if _, err := exec.LookPath("git"); err != nil {
+			if dir := adapter.ScoopGitCmdDir(); dir != "" {
+				cmd.Env = append(os.Environ(), "PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			}
+		}
+	}
 	err := cmd.Run()
 	slog.Debug("done", "cmd", args[0], "duration", time.Since(start), "err", err)
 	return err

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -571,7 +571,8 @@ func PrintReconcilePlan(result ReconcileResult, w io.Writer) (toInstall, toRemov
 	toInstall = len(result.ToInstall)
 	toRemove = len(result.ToRemove)
 	unchanged := len(result.Unchanged)
-	total := toInstall + toRemove + unchanged
+	adopted := len(result.Adopted)
+	total := toInstall + toRemove + unchanged + adopted
 
 	fprintf(w, "Apply plan — %d package", total)
 	if total != 1 {
@@ -583,6 +584,9 @@ func PrintReconcilePlan(result ReconcileResult, w io.Writer) (toInstall, toRemov
 	}
 	if toRemove > 0 {
 		parts = append(parts, fmt.Sprintf("%d to remove", toRemove))
+	}
+	if adopted > 0 {
+		parts = append(parts, fmt.Sprintf("%d already installed", adopted))
 	}
 	if unchanged > 0 {
 		parts = append(parts, fmt.Sprintf("%d up to date", unchanged))
@@ -596,16 +600,19 @@ func PrintReconcilePlan(result ReconcileResult, w io.Writer) (toInstall, toRemov
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	for _, a := range result.ToInstall {
 		if a.Resolved() {
-			fprintf(tw, "  + %s\tvia %s\t%s\n", a.Pkg.ID, a.Manager, strings.Join(a.Cmd, " "))
+			fprintf(tw, "  + %s	via %s	%s\n", a.Pkg.ID, a.Manager, strings.Join(a.Cmd, " "))
 		} else {
-			fprintf(tw, "  + %s\tunresolved\t(no manager available)\n", a.Pkg.ID)
+			fprintf(tw, "  + %s	unresolved	(no manager available)\n", a.Pkg.ID)
 		}
 	}
 	for _, a := range result.ToRemove {
-		fprintf(tw, "  - %s\tvia %s\t%s\n", a.Pkg.ID, a.Manager, strings.Join(a.UninstallCmd, " "))
+		fprintf(tw, "  - %s	via %s	%s\n", a.Pkg.ID, a.Manager, strings.Join(a.UninstallCmd, " "))
+	}
+	for _, lp := range result.Adopted {
+		fprintf(tw, "  = %s	via %s	(already installed)\n", lp.ID, lp.Manager)
 	}
 	for _, lp := range result.Unchanged {
-		fprintf(tw, "    %s\tvia %s\t(up to date)\n", lp.ID, lp.Manager)
+		fprintf(tw, "    %s	via %s	(up to date)\n", lp.ID, lp.Manager)
 	}
 	_ = tw.Flush()
 	fPrintln(w)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -419,7 +419,29 @@ type ReconcileResult struct {
 	ToInstall []Action
 	ToRemove  []Action // UninstallCmd populated; Pkg.ID identifies the package
 	Unchanged []genvfile.LockedPackage
+	Adopted   []genvfile.LockedPackage // live-installed, not yet in the lock
 	Warnings  []string
+}
+
+// LiveSet is manager name → manager-native package name → installed.
+// Names are matched case-insensitively. A nil LiveSet means lock-only
+// (do not probe the live system).
+type LiveSet map[string]map[string]bool
+
+func (s LiveSet) has(manager, pkgName string) bool {
+	if s == nil || manager == "" || pkgName == "" {
+		return false
+	}
+	names := s[manager]
+	if names[pkgName] {
+		return true
+	}
+	for n := range names {
+		if strings.EqualFold(n, pkgName) {
+			return true
+		}
+	}
+	return false
 }
 
 // Reconcile computes the delta between the desired packages (from genv.json)
@@ -429,7 +451,16 @@ type ReconcileResult struct {
 //   - ToRemove:  in lock but not in desired → uninstall using the manager
 //     recorded in the lock (not re-resolved, preserving the original manager).
 //   - Unchanged: in both desired and lock → nothing to do.
+//
+// Reconcile is lock-only. Prefer ReconcileWith when a live inventory exists.
 func Reconcile(desired []schema.Package, managed []genvfile.LockedPackage, available map[string]bool) ReconcileResult {
+	return ReconcileWith(desired, managed, available, nil)
+}
+
+// ReconcileWith is Reconcile plus a live inventory. Packages in desired, not in
+// the lock, but already installed under the resolved manager are Adopted
+// instead of ToInstall so apply can lock them without spawning an installer.
+func ReconcileWith(desired []schema.Package, managed []genvfile.LockedPackage, available map[string]bool, live LiveSet) ReconcileResult {
 	adapters := make(map[string]adapter.Adapter)
 	getAdapter := func(name string) adapter.Adapter {
 		if mgr, ok := adapters[name]; ok {
@@ -452,10 +483,20 @@ func Reconcile(desired []schema.Package, managed []genvfile.LockedPackage, avail
 	}
 
 	var toInstall []Action
+	var adopted []genvfile.LockedPackage
 	for _, pkg := range desired {
 		lp, alreadyManaged := managedByID[pkg.ID]
 		if !alreadyManaged {
-			toInstall = append(toInstall, resolveOnGOOS(pkg, available, runtime.GOOS))
+			action := resolveOnGOOS(pkg, available, runtime.GOOS)
+			if action.Resolved() && live.has(action.Manager, action.PkgName) {
+				adopted = append(adopted, genvfile.LockedPackage{
+					ID:      pkg.ID,
+					Manager: action.Manager,
+					PkgName: action.PkgName,
+				})
+				continue
+			}
+			toInstall = append(toInstall, action)
 			continue
 		}
 		// Package is already in the lock. Check version constraint: if the lock
@@ -492,7 +533,7 @@ func Reconcile(desired []schema.Package, managed []genvfile.LockedPackage, avail
 		unchanged = append(unchanged, lp)
 	}
 
-	return ReconcileResult{ToInstall: toInstall, ToRemove: toRemove, Unchanged: unchanged, Warnings: warnings}
+	return ReconcileResult{ToInstall: toInstall, ToRemove: toRemove, Unchanged: unchanged, Adopted: adopted, Warnings: warnings}
 }
 
 // PrintReconcilePlan writes a human-readable apply plan to w. Each line is

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -955,6 +955,21 @@ func TestLoadLiveSet_FalseAvailabilitySkipped(t *testing.T) {
 	}
 }
 
+func TestPrintReconcilePlan_ShowsAdopted(t *testing.T) {
+	var buf bytes.Buffer
+	result := ReconcileResult{
+		Adopted: []genvfile.LockedPackage{{ID: "cursor", Manager: "winget", PkgName: "Anysphere.Cursor"}},
+	}
+	_, _, _ = PrintReconcilePlan(result, &buf)
+	out := buf.String()
+	if !strings.Contains(out, "already installed") || !strings.Contains(out, "cursor") {
+		t.Fatalf("plan = %q, want adopted cursor", out)
+	}
+	if !strings.Contains(out, "1 already installed") {
+		t.Fatalf("plan = %q, want summary count", out)
+	}
+}
+
 // TestReconcile_RemovedPackage_ToRemove verifies that a package in the lock
 // but absent from the spec ends up in ToRemove.
 func TestReconcile_RemovedPackage_ToRemove(t *testing.T) {

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -879,6 +879,61 @@ func TestReconcile_NewPackage_ToInstall(t *testing.T) {
 	}
 }
 
+func TestReconcileWith_NilLive_SameAsReconcile(t *testing.T) {
+	desired := []schema.Package{{ID: "git"}}
+	got := ReconcileWith(desired, nil, map[string]bool{"brew": true}, nil)
+	want := Reconcile(desired, nil, map[string]bool{"brew": true})
+	if len(got.ToInstall) != len(want.ToInstall) || len(got.Adopted) != 0 {
+		t.Fatalf("nil live: ToInstall=%d Adopted=%d, want ToInstall=%d Adopted=0",
+			len(got.ToInstall), len(got.Adopted), len(want.ToInstall))
+	}
+}
+
+func TestReconcileWith_LiveInstalled_NotInLock_Adopts(t *testing.T) {
+	desired := []schema.Package{{
+		ID:       "cursor",
+		Managers: map[string]string{"winget": "Anysphere.Cursor"},
+	}}
+	live := LiveSet{"winget": {"Anysphere.Cursor": true}}
+	got := ReconcileWith(desired, nil, map[string]bool{"winget": true}, live)
+	if len(got.ToInstall) != 0 {
+		t.Fatalf("ToInstall=%d, want 0 (already installed)", len(got.ToInstall))
+	}
+	if len(got.Adopted) != 1 {
+		t.Fatalf("Adopted=%d, want 1", len(got.Adopted))
+	}
+	if got.Adopted[0].ID != "cursor" || got.Adopted[0].Manager != "winget" || got.Adopted[0].PkgName != "Anysphere.Cursor" {
+		t.Fatalf("Adopted[0]=%+v, want cursor/winget/Anysphere.Cursor", got.Adopted[0])
+	}
+}
+
+func TestReconcileWith_LiveMissing_StillInstalls(t *testing.T) {
+	desired := []schema.Package{{
+		ID:       "syncthing",
+		Managers: map[string]string{"winget": "Syncthing.Syncthing"},
+	}}
+	live := LiveSet{"winget": {"Anysphere.Cursor": true}}
+	got := ReconcileWith(desired, nil, map[string]bool{"winget": true}, live)
+	if len(got.ToInstall) != 1 || got.ToInstall[0].Pkg.ID != "syncthing" {
+		t.Fatalf("ToInstall=%v, want syncthing", got.ToInstall)
+	}
+	if len(got.Adopted) != 0 {
+		t.Fatalf("Adopted=%d, want 0", len(got.Adopted))
+	}
+}
+
+func TestReconcileWith_LiveMatchIsCaseInsensitive(t *testing.T) {
+	desired := []schema.Package{{
+		ID:       "cursor",
+		Managers: map[string]string{"winget": "Anysphere.Cursor"},
+	}}
+	live := LiveSet{"winget": {"anysphere.cursor": true}}
+	got := ReconcileWith(desired, nil, map[string]bool{"winget": true}, live)
+	if len(got.Adopted) != 1 {
+		t.Fatalf("Adopted=%d, want 1 for case-insensitive live match", len(got.Adopted))
+	}
+}
+
 // TestReconcile_RemovedPackage_ToRemove verifies that a package in the lock
 // but absent from the spec ends up in ToRemove.
 func TestReconcile_RemovedPackage_ToRemove(t *testing.T) {

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -934,6 +934,27 @@ func TestReconcileWith_LiveMatchIsCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestLoadLiveSet_NoManagers(t *testing.T) {
+	got, warns := LoadLiveSet(nil)
+	if len(got) != 0 || len(warns) != 0 {
+		t.Fatalf("got %#v warns %v, want empty", got, warns)
+	}
+}
+
+func TestLoadLiveSet_UnavailableManagerSkipped(t *testing.T) {
+	got, _ := LoadLiveSet(map[string]bool{"not-a-manager": true})
+	if len(got) != 0 {
+		t.Fatalf("got %#v, want empty", got)
+	}
+}
+
+func TestLoadLiveSet_FalseAvailabilitySkipped(t *testing.T) {
+	got, warns := LoadLiveSet(map[string]bool{"brew": false})
+	if len(got) != 0 || len(warns) != 0 {
+		t.Fatalf("got %#v warns %v, want empty", got, warns)
+	}
+}
+
 // TestReconcile_RemovedPackage_ToRemove verifies that a package in the lock
 // but absent from the spec ends up in ToRemove.
 func TestReconcile_RemovedPackage_ToRemove(t *testing.T) {

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -43,6 +43,26 @@ func TestRunSubcmd_PerSpawnTimeout(t *testing.T) {
 	}
 }
 
+func TestExecuteApply_TimeoutDoesNotSkipLaterPackages(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not in PATH")
+	}
+	ctx := WithSubprocessTimeout(context.Background(), 2*time.Second)
+	result := ReconcileResult{
+		ToInstall: []Action{
+			{Pkg: schema.Package{ID: "hang"}, Manager: "test", PkgName: "hang", Cmd: []string{"sleep", "20"}},
+			{Pkg: schema.Package{ID: "ok"}, Manager: "test", PkgName: "ok", Cmd: []string{"go", "env", "GOVERSION"}},
+		},
+	}
+	got := ExecuteApply(ctx, result, nil, io.Discard, io.Discard)
+	if len(got.Errors) == 0 {
+		t.Fatal("expected hang to error")
+	}
+	if len(got.Installed) != 1 || got.Installed[0].ID != "ok" {
+		t.Fatalf("Installed=%+v, want ok after hang", got.Installed)
+	}
+}
+
 func TestPlan_PreferredManagerAvailable(t *testing.T) {
 	f := &schema.GenvFile{
 		Packages: []schema.Package{

--- a/internal/schema/filter.go
+++ b/internal/schema/filter.go
@@ -1,0 +1,46 @@
+package schema
+
+import "strings"
+
+// DropInapplicable removes desired-state entries that cannot apply on goos.
+// Homebrew env vars are macOS-only. On Windows, only powershell-targeted
+// aliases/functions are kept; unscoped and POSIX shell entries are dropped
+// so they do not show up as missing.
+func DropInapplicable(f *GenvFile, goos string) *GenvFile {
+	if f == nil {
+		return nil
+	}
+	out := *f
+	if goos != "darwin" && len(f.Env) > 0 {
+		env := make(map[string]EnvVar, len(f.Env))
+		for k, v := range f.Env {
+			if strings.HasPrefix(k, "HOMEBREW_") {
+				continue
+			}
+			env[k] = v
+		}
+		if len(env) == 0 {
+			env = nil
+		}
+		out.Env = env
+	}
+	if goos == "windows" && f.Shell != nil {
+		aliases := make(map[string]ShellAlias)
+		for k, a := range f.Shell.Aliases {
+			if a.Shell == "powershell" {
+				aliases[k] = a
+			}
+		}
+		funcs := make(map[string]ShellFunction)
+		for k, fn := range f.Shell.Functions {
+			if fn.Shell == "powershell" {
+				funcs[k] = fn
+			}
+		}
+		shell := *f.Shell
+		shell.Aliases = aliases
+		shell.Functions = funcs
+		out.Shell = normalizeShell(&shell)
+	}
+	return &out
+}

--- a/internal/schema/filter_test.go
+++ b/internal/schema/filter_test.go
@@ -1,0 +1,65 @@
+package schema
+
+import "testing"
+
+func TestDropInapplicable_WindowsDropsZshAndHomebrew(t *testing.T) {
+	in := &GenvFile{
+		Env: map[string]EnvVar{
+			"EDITOR":                {Value: "nvim"},
+			"HOMEBREW_NO_ENV_HINTS": {Value: "1"},
+		},
+		Shell: &ShellConfig{
+			Aliases: map[string]ShellAlias{
+				"ll": {Value: "ls -lh", Shell: "zsh"},
+				"vi": {Value: "nvim"},
+			},
+		},
+	}
+	got := DropInapplicable(in, "windows")
+	if _, ok := got.Env["HOMEBREW_NO_ENV_HINTS"]; ok {
+		t.Fatal("HOMEBREW_NO_ENV_HINTS leaked onto windows")
+	}
+	if got.Env["EDITOR"].Value != "nvim" {
+		t.Fatal("EDITOR should remain")
+	}
+	if got.Shell != nil {
+		if _, ok := got.Shell.Aliases["ll"]; ok {
+			t.Fatal("zsh alias leaked onto windows")
+		}
+		if _, ok := got.Shell.Aliases["vi"]; ok {
+			t.Fatal("unscoped POSIX alias leaked onto windows")
+		}
+	}
+}
+
+func TestDropInapplicable_DarwinKeepsHomebrewAndZsh(t *testing.T) {
+	in := &GenvFile{
+		Env:   map[string]EnvVar{"HOMEBREW_NO_ENV_HINTS": {Value: "1"}},
+		Shell: &ShellConfig{Aliases: map[string]ShellAlias{"ll": {Value: "ls -lh", Shell: "zsh"}}},
+	}
+	got := DropInapplicable(in, "darwin")
+	if _, ok := got.Env["HOMEBREW_NO_ENV_HINTS"]; !ok {
+		t.Fatal("expected HOMEBREW on darwin")
+	}
+	if _, ok := got.Shell.Aliases["ll"]; !ok {
+		t.Fatal("expected zsh alias on darwin")
+	}
+}
+
+func TestDropInapplicable_Nil(t *testing.T) {
+	if DropInapplicable(nil, "windows") != nil {
+		t.Fatal("nil in should stay nil")
+	}
+}
+
+func TestDropInapplicable_KeepsPowerShellAliasOnWindows(t *testing.T) {
+	in := &GenvFile{
+		Shell: &ShellConfig{Aliases: map[string]ShellAlias{
+			"ll": {Value: "Get-ChildItem", Shell: "powershell"},
+		}},
+	}
+	got := DropInapplicable(in, "windows")
+	if _, ok := got.Shell.Aliases["ll"]; !ok {
+		t.Fatal("powershell alias should remain on windows")
+	}
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -112,6 +112,7 @@ var KnownManagers = map[string]bool{
 	"winget":      true,
 	"scoop":       true,
 	"choco":       true,
+	"external":    true,
 }
 
 // KnownTargets is the set of canonical portable target IDs accepted in v8 specs.

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -539,6 +539,14 @@ func TestParseAndValidate_PackageWithAllKnownManagers(t *testing.T) {
 	}
 }
 
+func TestParseAndValidate_ExternalManagerAccepted(t *testing.T) {
+	input := `{"schemaVersion":"1","packages":[{"id":"hermes-desktop","prefer":"external","managers":{"external":"hermes"}}]}`
+	_, errs, err := ParseAndValidate([]byte(input))
+	if err != nil || len(errs) > 0 {
+		t.Fatalf("err=%v errs=%v", err, errs)
+	}
+}
+
 // TestParseAndValidate_EmptyInput verifies that completely empty input returns a
 // fatal parse error.
 func TestParseAndValidate_EmptyInput(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -283,6 +283,7 @@ func resolveEffectiveSpec(f *schema.GenvFile, hostName, targetFlag string) (*sch
 func materializeSpecForCommand(commandName, file string, f *schema.GenvFile, hostFlag, targetFlag string) (*schema.GenvFile, string, int) {
 	effective, targetID, err := resolveEffectiveSpec(f, hostForCommand(hostFlag), targetFlag)
 	if err == nil {
+		effective = schema.DropInapplicable(effective, runtime.GOOS)
 		return effective, targetID, exitOK
 	}
 	msg := err.Error()

--- a/main.go
+++ b/main.go
@@ -1288,37 +1288,30 @@ func runApplyJSON(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	failedHooks := []string(nil)
 	filePlan := &files.ApplyResult{}
 	filePlanErr := error(nil)
-	if len(errs) == 0 {
-		var envErr, shellErr error
-		envApplied, envRemoved, envErr = applyEnvVars(f, lf, false)
-		if envErr != nil {
-			errs = append(errs, envErr.Error())
-		} else {
-			shellApplied, shellRemoved, shellErr = applyShellCfg(f, lf, false)
-			if shellErr != nil {
-				errs = append(errs, shellErr.Error())
-			}
-		}
-		if len(errs) == 0 {
-			_, _, svcErrs := applyServices(ctx, f, lf, false)
-			if len(svcErrs) > 0 {
-				errs = append(errs, errStrings(svcErrs)...)
-			}
-		}
+	var envErr, shellErr error
+	envApplied, envRemoved, envErr = applyEnvVars(f, lf, false)
+	if envErr != nil {
+		errs = append(errs, envErr.Error())
 	}
-	if len(errs) == 0 {
-		filePlan, filePlanErr = applyFiles(ctx, opts, f, lf)
-		if filePlanErr != nil {
-			errs = append(errs, filePlanErr.Error())
-			if !opts.NoHooks && hasPostApplyHooks(f) {
-				skipMsg := "skipping post-apply hooks due to unresolved file mismatches"
-				errs = append(errs, skipMsg)
-				fprintf(os.Stderr, "genv apply: %s\n", skipMsg)
-			}
-		} else if !opts.NoHooks {
-			failedHooks = runApplyHookPhase(ctx, f, hookContext{Event: "apply", Phase: "post-apply", Host: hostName, Profile: lf.ActiveProfile, Yes: opts.Yes, Installed: lockedPackageIDs(execResult.Installed), Removed: execResult.Uninstalled, Failed: applyFailedIDs(execResult.Errors)}, opts.HookTimeout, true)
-			errs = append(errs, failedHooks...)
+	shellApplied, shellRemoved, shellErr = applyShellCfg(f, lf, false)
+	if shellErr != nil {
+		errs = append(errs, shellErr.Error())
+	}
+	_, _, svcErrs := applyServices(ctx, f, lf, false)
+	if len(svcErrs) > 0 {
+		errs = append(errs, errStrings(svcErrs)...)
+	}
+	filePlan, filePlanErr = applyFiles(ctx, opts, f, lf)
+	if filePlanErr != nil {
+		errs = append(errs, filePlanErr.Error())
+		if !opts.NoHooks && hasPostApplyHooks(f) {
+			skipMsg := "skipping post-apply hooks due to unresolved file mismatches"
+			errs = append(errs, skipMsg)
+			fprintf(os.Stderr, "genv apply: %s\n", skipMsg)
 		}
+	} else if !opts.NoHooks {
+		failedHooks = runApplyHookPhase(ctx, f, hookContext{Event: "apply", Phase: "post-apply", Host: hostName, Profile: lf.ActiveProfile, Yes: opts.Yes, Installed: lockedPackageIDs(execResult.Installed), Removed: execResult.Uninstalled, Failed: applyFailedIDs(execResult.Errors)}, opts.HookTimeout, true)
+		errs = append(errs, failedHooks...)
 	}
 	success := len(errs) == 0
 	if err := writeLockAfterApply(lockPath, lf, result, execResult, opts.TargetProfile, opts.Target, success); err != nil {
@@ -1484,26 +1477,22 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	var svcErrs []error
 	var fileErrs []error
 	var appliedFiles *files.ApplyResult
-	if len(execResult.Errors) == 0 {
-		if _, _, err := applyEnvVars(f, lf, !opts.Quiet); err != nil {
-			fileErrs = append(fileErrs, err)
-		} else if _, _, err := applyShellCfg(f, lf, !opts.Quiet); err != nil {
-			fileErrs = append(fileErrs, err)
-		} else {
-			_, _, svcErrs = applyServices(ctx, f, lf, !opts.Quiet)
-			if len(svcErrs) == 0 {
-				var filePlanErr error
-				appliedFiles, filePlanErr = applyFiles(ctx, opts, f, lf)
-				if filePlanErr != nil {
-					fileErrs = append(fileErrs, filePlanErr)
-				}
-				if appliedFiles != nil && len(appliedFiles.Mismatched) > 0 {
-					writeFileMismatchGuidance(os.Stderr, appliedFiles)
-					if !opts.NoHooks && hasPostApplyHooks(f) {
-						fPrintln(os.Stderr, "genv apply: skipping post-apply hooks due to unresolved file mismatches")
-					}
-				}
-			}
+	if _, _, err := applyEnvVars(f, lf, !opts.Quiet); err != nil {
+		fileErrs = append(fileErrs, err)
+	}
+	if _, _, err := applyShellCfg(f, lf, !opts.Quiet); err != nil {
+		fileErrs = append(fileErrs, err)
+	}
+	_, _, svcErrs = applyServices(ctx, f, lf, !opts.Quiet)
+	var filePlanErr error
+	appliedFiles, filePlanErr = applyFiles(ctx, opts, f, lf)
+	if filePlanErr != nil {
+		fileErrs = append(fileErrs, filePlanErr)
+	}
+	if appliedFiles != nil && len(appliedFiles.Mismatched) > 0 {
+		writeFileMismatchGuidance(os.Stderr, appliedFiles)
+		if !opts.NoHooks && hasPostApplyHooks(f) {
+			fPrintln(os.Stderr, "genv apply: skipping post-apply hooks due to unresolved file mismatches")
 		}
 	}
 	var hookErrs []string

--- a/main.go
+++ b/main.go
@@ -865,16 +865,47 @@ func adoptCmd(args []string) int {
 	hostName := hostForCommand(*hostFlag)
 	slog.Debug("adopt host", "host", hostName)
 
-	// 1. Resolve to find which manager handles this package.
+	specPkg := schema.Package{ID: id, Version: *version, Prefer: *prefer, Managers: managers}
+	inSpec := false
+	f, err := genvfile.Read(*file)
+	if err != nil {
+		if !errors.Is(err, genvfile.ErrNotFound) {
+			fprintf(os.Stderr, "genv: %v\n", err)
+			if errors.Is(err, genvfile.ErrInvalidFile) {
+				return exitValidation
+			}
+			return exitIO
+		}
+	} else {
+		effective, _, code := materializeSpecForCommand("adopt", *file, f, *hostFlag, *targetFlag)
+		if code != exitOK {
+			return code
+		}
+		for _, p := range effective.Packages {
+			if p.ID != id {
+				continue
+			}
+			inSpec = true
+			if *version == "" {
+				specPkg.Version = p.Version
+			}
+			if *prefer == "" {
+				specPkg.Prefer = p.Prefer
+			}
+			if len(managers) == 0 {
+				specPkg.Managers = p.Managers
+			}
+			break
+		}
+	}
+
 	available := resolver.Detect()
-	pkg := schema.Package{ID: id, Version: *version, Prefer: *prefer, Managers: managers}
-	action := resolver.ResolveOne(pkg, available)
+	action := resolver.ResolveOne(specPkg, available)
 	if !action.Resolved() {
 		fprintf(os.Stderr, "genv adopt: no available manager for %q — install a compatible package manager first\n", id)
 		return exitLogic
 	}
 
-	// 2. Verify the package is actually installed.
 	mgr := adapter.ByName(action.Manager)
 	installed, err := mgr.Query(action.PkgName)
 	if err != nil {
@@ -886,12 +917,25 @@ func adoptCmd(args []string) int {
 		return exitLogic
 	}
 
-	// 3. Update genv.json.
-	if exit := addToSpec(*file, id, *version, *prefer, managers, *targetFlag); exit != exitOK {
-		return exit
+	lockPath := lockPathForSpec(*file, *lockFile)
+	lf, err := genvfile.ReadLock(lockPath)
+	if err != nil {
+		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
+		return exitIO
+	}
+	for i := range lf.Packages {
+		if lf.Packages[i].ID == id {
+			fprintf(os.Stderr, "genv: package already tracked: %q\n", id)
+			return exitLogic
+		}
 	}
 
-	// 4. Update lock file.
+	if !inSpec {
+		if exit := addToSpec(*file, id, *version, *prefer, managers, *targetFlag); exit != exitOK {
+			return exit
+		}
+	}
+
 	targetID := ""
 	if prepared, err := genvfile.Read(*file); err == nil {
 		var code int
@@ -900,7 +944,7 @@ func adoptCmd(args []string) int {
 			return code
 		}
 	}
-	if exit := appendLockEntry(lockPathForSpec(*file, *lockFile), genvfile.LockedPackage{
+	if exit := appendLockEntry(lockPath, genvfile.LockedPackage{
 		ID:      action.Pkg.ID,
 		Manager: action.Manager,
 		PkgName: action.PkgName,

--- a/main.go
+++ b/main.go
@@ -1147,6 +1147,7 @@ type applyOptions struct {
 	ForceNewLock  bool
 	NoHooks       bool
 	HookTimeout   time.Duration
+	SkipPackages  bool
 }
 
 func applyCmd(args []string) int {
@@ -1171,6 +1172,7 @@ func applyCmd(args []string) int {
 	fs.DurationVar(&opts.Timeout, "timeout", 10*time.Minute, "per-subprocess timeout, e.g. 5m or 30s (0 means no timeout; default 10m)")
 	fs.DurationVar(&opts.HookTimeout, "hook-timeout", 0, "per-hook timeout, e.g. 5m or 30s (0 means no timeout)")
 	fs.BoolVar(&opts.NoHooks, "no-hooks", false, "skip lifecycle hooks without skipping apply")
+	fs.BoolVar(&opts.SkipPackages, "skip-packages", false, "skip package install/remove; still apply env, shell, files, and services")
 	fs.BoolVar(&opts.Debug, "debug", false, "emit debug-level structured logs to stderr")
 	fs.StringVar(&opts.Host, "host", "", "host name for host-specific records (defaults to $GENV_HOST or os.Hostname())")
 	fs.StringVar(&opts.Target, "target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
@@ -1289,6 +1291,11 @@ func runApplyWithSpecAndLock(ctx context.Context, opts applyOptions, f *schema.G
 		fprintf(os.Stderr, "genv apply: warning: %s\n", w)
 	}
 	result := resolver.ReconcileWith(f.Packages, lf.Packages, available, live)
+	if opts.SkipPackages {
+		result.ToInstall = nil
+		result.ToRemove = nil
+		result.Adopted = nil
+	}
 
 	if opts.JSONOut {
 		return runApplyJSON(ctx, opts, lockPath, f, lf, result)
@@ -4394,8 +4401,9 @@ Apply-specific flags:
   --yes                Skip the confirmation prompt (for CI and scripts)
   --quiet              Suppress plan output (useful in scripts)
   --json               Emit machine-readable JSON to stdout
-  --timeout <duration> Per-subprocess timeout, e.g. 5m or 30s (0 = none)
+  --timeout <duration> Per-subprocess timeout, e.g. 5m or 30s (0 = none; default 10m)
   --no-hooks           Skip apply lifecycle hooks without skipping apply
+  --skip-packages      Skip package install/remove; still apply env, shell, files, services
   --hook-timeout <duration> Per-hook timeout, e.g. 5m or 30s
   --debug              Emit debug-level structured logs to stderr
   --target <id>        Portable target id for schemaVersion 8 specs

--- a/main.go
+++ b/main.go
@@ -1123,7 +1123,7 @@ func applyCmd(args []string) int {
 	fs.BoolVar(&opts.Yes, "yes", false, "skip the confirmation prompt (for CI and scripts)")
 	fs.BoolVar(&opts.Quiet, "quiet", false, "suppress plan output (useful in scripts)")
 	fs.BoolVar(&opts.JSONOut, "json", false, "emit machine-readable JSON to stdout instead of human-readable text")
-	fs.DurationVar(&opts.Timeout, "timeout", 0, "per-subprocess timeout, e.g. 5m or 30s (0 means no timeout)")
+	fs.DurationVar(&opts.Timeout, "timeout", 10*time.Minute, "per-subprocess timeout, e.g. 5m or 30s (0 means no timeout; default 10m)")
 	fs.DurationVar(&opts.HookTimeout, "hook-timeout", 0, "per-hook timeout, e.g. 5m or 30s (0 means no timeout)")
 	fs.BoolVar(&opts.NoHooks, "no-hooks", false, "skip lifecycle hooks without skipping apply")
 	fs.BoolVar(&opts.Debug, "debug", false, "emit debug-level structured logs to stderr")

--- a/main.go
+++ b/main.go
@@ -1239,7 +1239,11 @@ func runApplyWithSpecAndLock(ctx context.Context, opts applyOptions, f *schema.G
 	}
 	f = effective
 	opts.Target = activeTarget
-	result := resolver.Reconcile(f.Packages, lf.Packages, available)
+	live, liveWarns := resolver.LoadLiveSet(available)
+	for _, w := range liveWarns {
+		fprintf(os.Stderr, "genv apply: warning: %s\n", w)
+	}
+	result := resolver.ReconcileWith(f.Packages, lf.Packages, available, live)
 
 	if opts.JSONOut {
 		return runApplyJSON(ctx, opts, lockPath, f, lf, result)
@@ -1563,8 +1567,9 @@ func writeLockAfterApply(lockPath string, lf *genvfile.LockFile, result resolver
 	for _, lp := range lf.Packages {
 		prevByID[lp.ID] = lp
 	}
-	newPkgs := make([]genvfile.LockedPackage, 0, len(result.Unchanged)+len(execResult.Installed)+len(result.ToRemove)+len(result.ToInstall))
+	newPkgs := make([]genvfile.LockedPackage, 0, len(result.Unchanged)+len(result.Adopted)+len(execResult.Installed)+len(result.ToRemove)+len(result.ToInstall))
 	newPkgs = append(newPkgs, result.Unchanged...)
+	newPkgs = append(newPkgs, result.Adopted...)
 	newPkgs = append(newPkgs, execResult.Installed...)
 	for _, a := range result.ToInstall {
 		if installedSet[a.Pkg.ID] {
@@ -1688,6 +1693,10 @@ func buildPlanResult(f *schema.GenvFile, lf *genvfile.LockFile, result resolver.
 	for _, lp := range result.Unchanged {
 		unchanged = append(unchanged, output.PlanPackage{ID: lp.ID, Manager: lp.Manager})
 	}
+	adopted := make([]output.PlanPackage, 0, len(result.Adopted))
+	for _, lp := range result.Adopted {
+		adopted = append(adopted, output.PlanPackage{ID: lp.ID, Manager: lp.Manager})
+	}
 
 	var toStart, toStop []string
 	for _, e := range service.ServiceStatus(f.Services, lf.Services, false) {
@@ -1703,6 +1712,7 @@ func buildPlanResult(f *schema.GenvFile, lf *genvfile.LockFile, result resolver.
 		ToInstall:       toInstall,
 		ToRemove:        toRemove,
 		Unchanged:       unchanged,
+		Adopted:         adopted,
 		Unresolved:      unresolved,
 		ServicesToStart: toStart,
 		ServicesToStop:  toStop,

--- a/main.go
+++ b/main.go
@@ -2877,8 +2877,9 @@ func statusCmd(args []string) int {
 	fs.Usage = func() {
 		fPrintln(os.Stderr, "usage: genv status [flags]")
 		fPrintln(os.Stderr)
-		fPrintln(os.Stderr, "Show the diff between genv.json, the lock file, and recorded versions.")
-		fPrintln(os.Stderr, "Note: status compares spec vs lock data — it does not query the live system.")
+		fPrintln(os.Stderr, "Show the diff between genv.json, the lock file, and the live system.")
+		fPrintln(os.Stderr, "Unlocked packages that are already installed are reported as present.")
+		fPrintln(os.Stderr, "Use --offline to compare spec vs lock only.")
 		fPrintln(os.Stderr, "Run 'genv apply' to reconcile any differences shown.")
 		fPrintln(os.Stderr)
 		fPrintln(os.Stderr, "flags:")
@@ -2890,6 +2891,7 @@ func statusCmd(args []string) int {
 	jsonOut := fs.Bool("json", false, "emit machine-readable JSON to stdout instead of human-readable text")
 	debug := fs.Bool("debug", false, "emit debug-level structured logs to stderr")
 	filesOnly := fs.Bool("files", false, "check files block against the live filesystem only")
+	offline := fs.Bool("offline", false, "compare spec vs lock only (skip live manager probe)")
 	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to $GENV_HOST or os.Hostname())")
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
 
@@ -2962,6 +2964,14 @@ func statusCmd(args []string) int {
 	}
 
 	entries := commands.Status(f, lf)
+	if !*offline {
+		available := resolver.Detect()
+		live, liveWarns := resolver.LoadLiveSet(available)
+		for _, w := range liveWarns {
+			fprintf(os.Stderr, "genv status: warning: %s\n", w)
+		}
+		entries = commands.StatusWithLive(f, lf, live)
+	}
 	envEntries := genvenv.EnvStatus(f.Env, lf.Env)
 	shellEntries := shellcfg.ShellStatus(f.Shell, lf.Shell)
 	serviceEntries := service.ServiceStatus(f.Services, lf.Services, true)
@@ -3031,6 +3041,9 @@ func statusCmd(args []string) int {
 	if n := counts[commands.StatusOK]; n > 0 {
 		parts = append(parts, fmt.Sprintf("%d ok", n))
 	}
+	if n := counts[commands.StatusPresent]; n > 0 {
+		parts = append(parts, fmt.Sprintf("%d present", n))
+	}
 	if n := counts[commands.StatusDrift]; n > 0 {
 		parts = append(parts, fmt.Sprintf("%d drift", n))
 	}
@@ -3058,7 +3071,10 @@ func statusCmd(args []string) int {
 			if v == "" {
 				v = "*"
 			}
-			fprintf(tw, "  ok\t%s\t%s\t%s\n", e.ID, mgr, v)
+			fprintf(tw, "  ok	%s	%s	%s\n", e.ID, mgr, v)
+		case commands.StatusPresent:
+			note := "(installed, not in lock — apply will adopt)"
+			fprintf(tw, "  present	%s	%s	%s\n", e.ID, mgr, note)
 		case commands.StatusDrift:
 			fprintf(tw, "  drift\t%s\t%s\t(spec: %s, installed: %s)\n",
 				e.ID, mgr, e.SpecVersion, e.InstalledVersion)

--- a/main_apply_files_test.go
+++ b/main_apply_files_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ks1686/genv/internal/genvfile"
 	"github.com/ks1686/genv/internal/testutil"
 )
 
@@ -93,6 +94,40 @@ func TestApply_PackageFailureStillAppliesFiles(t *testing.T) {
 	}
 	if fi.Mode()&os.ModeSymlink == 0 {
 		t.Fatal("expected dst to be a symlink")
+	}
+}
+
+func TestApply_SkipPackagesStillAppliesFiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.SetHome(t, dir)
+	spec := filepath.Join(dir, "genv.json")
+	lock := filepath.Join(dir, "genv.lock.json")
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	writeTestFile(t, src, "hello\n")
+	writeTestFile(t, spec, `{`+
+		`"schemaVersion":"6",`+
+		`"packages":[{"id":"cursor","prefer":"brew"}],`+
+		`"files":{"links":[{"source":`+jsonString(src)+`,"target":`+jsonString(dst)+`,"mode":"link"}]}`+
+		`}`)
+	writeLock(t, lock, nil)
+
+	code := run([]string{"apply", "--file", spec, "--lock-file", lock, "--yes", "--no-hooks", "--skip-packages"})
+	if code != exitOK {
+		t.Fatalf("exit %d", code)
+	}
+	if _, err := os.Lstat(dst); err != nil {
+		t.Fatalf("link not applied: %v", err)
+	}
+	lf, err := genvfile.ReadLock(lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range lf.Packages {
+		if p.ID == "cursor" {
+			t.Fatal("skip-packages must not lock/install cursor")
+		}
 	}
 }
 

--- a/main_apply_files_test.go
+++ b/main_apply_files_test.go
@@ -66,6 +66,36 @@ func TestApply_FileMismatchDoesNotAbortPackages(t *testing.T) {
 	}
 }
 
+func TestApply_PackageFailureStillAppliesFiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.SetHome(t, dir)
+	withFailingBrewInstall(t)
+	spec := filepath.Join(dir, "genv.json")
+	lock := filepath.Join(dir, "genv.lock.json")
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	writeTestFile(t, src, "hello\n")
+	writeTestFile(t, spec, `{`+
+		`"schemaVersion":"6",`+
+		`"packages":[{"id":"git","prefer":"brew"}],`+
+		`"files":{"links":[{"source":`+jsonString(src)+`,"target":`+jsonString(dst)+`,"mode":"link"}]}`+
+		`}`)
+	writeLock(t, lock, nil)
+
+	code := run([]string{"apply", "--file", spec, "--lock-file", lock, "--yes", "--no-hooks"})
+	if code == exitOK {
+		t.Fatal("expected apply to fail when brew install fails")
+	}
+	fi, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatalf("file not applied after package error (exit %d): %v", code, err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected dst to be a symlink")
+	}
+}
+
 func TestApply_DryRunTextShowsFilePaths(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))

--- a/main_coverage_extra_test.go
+++ b/main_coverage_extra_test.go
@@ -239,6 +239,7 @@ func runGitCommand(t *testing.T, args ...string) {
 	cmd := exec.Command("git", append([]string{
 		"-c", "commit.gpgsign=false",
 		"-c", "tag.gpgsign=false",
+		"-c", "core.hooksPath=",
 	}, args...)...)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)

--- a/main_env_shell_test.go
+++ b/main_env_shell_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -174,7 +175,13 @@ func TestShellStatusReportsMatchingAndDrift(t *testing.T) {
 	path := filepath.Join(dir, "genv.json")
 	writeEmptyV1Spec(t, path)
 
-	if code := run([]string{"shell", "alias", "set", "--file", path, "ll", "ls -la"}); code != exitOK {
+	setArgs := []string{"shell", "alias", "set", "--file", path, "ll", "ls -la"}
+	shellName := ""
+	if runtime.GOOS == "windows" {
+		shellName = "powershell"
+		setArgs = append(setArgs, "--shell", shellName)
+	}
+	if code := run(setArgs); code != exitOK {
 		t.Fatalf("shell alias set: expected exitOK, got %d", code)
 	}
 	lockPath := genvfile.LockPathFrom(path)
@@ -184,7 +191,7 @@ func TestShellStatusReportsMatchingAndDrift(t *testing.T) {
 		t.Fatalf("read lock: %v", err)
 	}
 	lock.Shell = &genvfile.LockedShellConfig{
-		Aliases: []genvfile.LockedShellAlias{{Name: "ll", Value: "ls -la"}},
+		Aliases: []genvfile.LockedShellAlias{{Name: "ll", Value: "ls -la", Shell: shellName}},
 	}
 	if err := genvfile.WriteLock(lockPath, lock); err != nil {
 		t.Fatalf("write matching lock: %v", err)
@@ -193,7 +200,11 @@ func TestShellStatusReportsMatchingAndDrift(t *testing.T) {
 	if code := run([]string{"shell", "status", "--file", path}); code != exitOK {
 		t.Fatalf("matching shell status: expected exitOK, got %d", code)
 	}
-	if code := run([]string{"shell", "alias", "set", "--file", path, "ll", "ls -lh"}); code != exitOK {
+	changeArgs := []string{"shell", "alias", "set", "--file", path, "ll", "ls -lh"}
+	if shellName != "" {
+		changeArgs = append(changeArgs, "--shell", shellName)
+	}
+	if code := run(changeArgs); code != exitOK {
 		t.Fatalf("change shell alias: expected exitOK, got %d", code)
 	}
 	if code := run([]string{"shell", "status", "--file", path}); code != exitLogic {

--- a/main_env_shell_test.go
+++ b/main_env_shell_test.go
@@ -179,7 +179,7 @@ func TestShellStatusReportsMatchingAndDrift(t *testing.T) {
 	shellName := ""
 	if runtime.GOOS == "windows" {
 		shellName = "powershell"
-		setArgs = append(setArgs, "--shell", shellName)
+		setArgs = []string{"shell", "alias", "set", "--file", path, "--shell", shellName, "ll", "ls -la"}
 	}
 	if code := run(setArgs); code != exitOK {
 		t.Fatalf("shell alias set: expected exitOK, got %d", code)
@@ -202,7 +202,7 @@ func TestShellStatusReportsMatchingAndDrift(t *testing.T) {
 	}
 	changeArgs := []string{"shell", "alias", "set", "--file", path, "ll", "ls -lh"}
 	if shellName != "" {
-		changeArgs = append(changeArgs, "--shell", shellName)
+		changeArgs = []string{"shell", "alias", "set", "--file", path, "--shell", shellName, "ll", "ls -lh"}
 	}
 	if code := run(changeArgs); code != exitOK {
 		t.Fatalf("change shell alias: expected exitOK, got %d", code)

--- a/main_test.go
+++ b/main_test.go
@@ -1865,7 +1865,7 @@ func (a lifecycleHookAdapter) PlanUpgrade(pkgName string) []string {
 }
 func (a lifecycleHookAdapter) PlanClean() [][]string              { return nil }
 func (a lifecycleHookAdapter) Query(pkgName string) (bool, error) { return true, nil }
-func (a lifecycleHookAdapter) ListInstalled() ([]string, error)   { return []string{pkgNameForTest}, nil }
+func (a lifecycleHookAdapter) ListInstalled() ([]string, error)   { return nil, nil }
 
 func (a lifecycleHookAdapter) QueryVersion(pkgName string) (string, error) {
 	return "2.0.0", nil

--- a/main_test.go
+++ b/main_test.go
@@ -739,6 +739,67 @@ func TestAdoptCmd_V8TargetFlagWritesSelectedTarget(t *testing.T) {
 	}
 }
 
+func TestAdoptCmd_UsesSpecManagerName(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	writeTestFile(t, path, `{
+	  "schemaVersion":"8",
+	  "targets":{
+	    "macos":{},
+	    "windows":{
+	      "packages":[{"id":"cursor","managers":{"winget":"Anysphere.Cursor"}}]
+	    }
+	  }
+	}`)
+	writeLock(t, lockPath, nil)
+	testutil.InstallFakeBinary(t, "winget", `if [ "$1" = "list" ] && echo "$*" | grep -q Anysphere.Cursor; then exit 0; fi
+exit 20`)
+
+	code := run([]string{"adopt", "--file", path, "--lock-file", lockPath, "--target", "windows", "cursor"})
+	if code != exitOK {
+		t.Fatalf("adopt cursor: got %d, want 0", code)
+	}
+	lf, err := genvfile.ReadLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lf.Packages) != 1 || lf.Packages[0].PkgName != "Anysphere.Cursor" {
+		t.Fatalf("lock = %+v, want Anysphere.Cursor", lf.Packages)
+	}
+	f, err := genvfile.Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Targets["windows"].Packages) != 1 {
+		t.Fatalf("spec packages mutated: %+v", f.Targets["windows"].Packages)
+	}
+}
+
+func TestAdoptCmd_AlreadyInLock_StillFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	writeTestFile(t, path, `{
+	  "schemaVersion":"8",
+	  "targets":{
+	    "macos":{},
+	    "windows":{
+	      "packages":[{"id":"cursor","managers":{"winget":"Anysphere.Cursor"}}]
+	    }
+	  }
+	}`)
+	writeLock(t, lockPath, []genvfile.LockedPackage{{ID: "cursor", Manager: "winget", PkgName: "Anysphere.Cursor"}})
+	testutil.InstallFakeBinary(t, "winget", `exit 0`)
+
+	code := run([]string{"adopt", "--file", path, "--lock-file", lockPath, "--target", "windows", "cursor"})
+	if code != exitLogic {
+		t.Fatalf("adopt already locked: got %d, want %d", code, exitLogic)
+	}
+}
+
 // ---- genv disown -------------------------------------------------------------
 // disown removes the package from genv.json and the lock file without uninstalling.
 

--- a/main_test.go
+++ b/main_test.go
@@ -3370,7 +3370,7 @@ func TestApplyCmd_HelpMentionsTenMinuteTimeout(t *testing.T) {
 	}
 }
 
-func TestApplyCmd_PackageFailure_DoesNotApplyEnv(t *testing.T) {
+func TestApplyCmd_PackageFailure_StillAppliesEnv(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	testutil.SetHome(t, dir)
@@ -3388,16 +3388,16 @@ func TestApplyCmd_PackageFailure_DoesNotApplyEnv(t *testing.T) {
 	}
 
 	frag := filepath.Join(dir, "genv", "env.sh")
-	if _, err := os.Stat(frag); err == nil {
-		t.Fatalf("env fragment %s written despite package failure", frag)
+	if _, err := os.Stat(frag); err != nil {
+		t.Fatalf("env fragment %s missing after package failure: %v", frag, err)
 	}
 
 	lf, err := genvfile.ReadLock(genvfile.LockPathFrom(path))
-	if err != nil && !errors.Is(err, genvfile.ErrNotFound) {
+	if err != nil {
 		t.Fatalf("ReadLock: %v", err)
 	}
-	if lf != nil && len(lf.Env) != 0 {
-		t.Fatalf("lock env = %#v, want empty after package failure", lf.Env)
+	if lf == nil || len(lf.Env) == 0 {
+		t.Fatalf("lock env empty after package failure, want FOO recorded")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -3361,6 +3361,15 @@ func TestApplyCmd_Timeout_DryRun_NoCrash(t *testing.T) {
 	}
 }
 
+func TestApplyCmd_HelpMentionsTenMinuteTimeout(t *testing.T) {
+	errOut := captureStderr(t, func() {
+		_ = run([]string{"apply", "--help"})
+	})
+	if !strings.Contains(errOut, "10m") && !strings.Contains(errOut, "default 10m") {
+		t.Fatalf("apply --help = %q, want default 10m", errOut)
+	}
+}
+
 func TestApplyCmd_PackageFailure_DoesNotApplyEnv(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)

--- a/main_test.go
+++ b/main_test.go
@@ -4016,7 +4016,7 @@ func TestPull_CopiesRelativeFileAssets(t *testing.T) {
 
 func runGitForTest(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", append([]string{"-c", "core.hooksPath="}, args...)...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -3448,7 +3448,11 @@ func TestApplyCmd_PackageFailure_StillAppliesEnv(t *testing.T) {
 		t.Fatal("expected apply to fail when brew install fails")
 	}
 
-	frag := filepath.Join(dir, "genv", "env.sh")
+	fragName := "env.sh"
+	if runtime.GOOS == "windows" {
+		fragName = "env.ps1"
+	}
+	frag := filepath.Join(dir, "genv", fragName)
 	if _, err := os.Stat(frag); err != nil {
 		t.Fatalf("env fragment %s missing after package failure: %v", frag, err)
 	}


### PR DESCRIPTION
## Summary

First apply on a used Windows box was a hanging mass-upgrade. This makes apply adopt what is already installed, time out hung installers, keep going with links/env, and stop leaking Mac-only defaults.

## Motivation

Copying the spec to gaming-pc and running apply tried to reinstall Cursor/Discord/Steam, launched GUI setups, hung, and never wrote links. Adopt looked up `cursor` instead of `Anysphere.Cursor`. Status always said missing.

## Changes

- Apply consults winget/scoop inventory and locks already-installed packages without upgrading them
- Default per-package timeout is 10m (`--timeout 0` disables)
- Package failure no longer skips env/files
- `winget install` is `--disable-interactivity --no-upgrade`
- `genv adopt` uses spec `managers.<mgr>` names and can lock a package already in the spec
- Windows drops `HOMEBREW_*` env and non-powershell aliases after merge
- `genv status` probes live managers (`present` vs missing); `--offline` is lock-only
- `genv apply --skip-packages` for links + env only
- `external` manager for official-installer apps (Hermes)
- Scoop git uses the versioned `cmd` dir when `current` is invisible over OpenSSH

## Test Plan

- [x] Unit tests for live skip, adopt manager names, winget argv, POSIX filter, status present, skip-packages, external, scoop git dir
- [x] `go test ./...` locally (review gate)
- [ ] CI green

## Notes for Reviewers

`genv upgrade` remains the only upgrade path. Apply must not upgrade as a side effect of install.