### PR TITLE
fix: stop Windows CI hanging on live manager listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- `genv apply` / `genv status` only inventory managers needed by unlocked spec
+  packages, and each listing times out after 30s. A hung `composer global show`
+  no longer stalls Windows CI or a real apply.
+
 ## v4.2.0 - 2026-08-20
 
 ### Fixed

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -452,20 +452,86 @@ func (s LiveSet) has(manager, pkgName string) bool {
 	return false
 }
 
+// defaultLiveListTimeout caps each manager inventory so a hung
+// `composer global show` (or similar) cannot stall apply/status.
+const defaultLiveListTimeout = 30 * time.Second
+
+func listInstalledTimed(list func() ([]string, error), d time.Duration) ([]string, error) {
+	if d <= 0 {
+		return list()
+	}
+	type result struct {
+		names []string
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		names, err := list()
+		ch <- result{names, err}
+	}()
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case r := <-ch:
+		return r.names, r.err
+	case <-timer.C:
+		return nil, fmt.Errorf("timed out after %s", d)
+	}
+}
+
+// ManagersToList is the set of managers apply/status actually need to
+// inventory: unlocked spec packages only. An empty spec yields an empty
+// set, so live listing is skipped entirely.
+func ManagersToList(packages []schema.Package, locked []genvfile.LockedPackage, available map[string]bool) map[string]bool {
+	lockedIDs := make(map[string]bool, len(locked))
+	for _, lp := range locked {
+		lockedIDs[lp.ID] = true
+	}
+	need := make(map[string]bool)
+	for _, pkg := range packages {
+		if lockedIDs[pkg.ID] {
+			continue
+		}
+		if pkg.Prefer != "" {
+			need[pkg.Prefer] = true
+		}
+		for m := range pkg.Managers {
+			need[m] = true
+		}
+		action := resolveOnGOOS(pkg, available, runtime.GOOS)
+		if action.Resolved() {
+			need[action.Manager] = true
+		}
+	}
+	return need
+}
+
 // LoadLiveSet calls ListInstalled once per available manager. Listing errors
 // become warnings; they never fail the whole apply/status run.
 func LoadLiveSet(available map[string]bool) (LiveSet, []string) {
+	return LoadLiveSetOnly(available, nil)
+}
+
+// LoadLiveSetOnly is LoadLiveSet restricted to `only`. A nil `only` lists
+// every available manager (same as LoadLiveSet). An empty `only` lists none.
+func LoadLiveSetOnly(available, only map[string]bool) (LiveSet, []string) {
 	out := make(LiveSet)
 	var warns []string
+	if only != nil && len(only) == 0 {
+		return out, warns
+	}
 	for name, ok := range available {
 		if !ok {
+			continue
+		}
+		if only != nil && !only[name] {
 			continue
 		}
 		mgr := adapter.ByName(name)
 		if mgr == nil {
 			continue
 		}
-		list, err := mgr.ListInstalled()
+		list, err := listInstalledTimed(mgr.ListInstalled, defaultLiveListTimeout)
 		if err != nil {
 			warns = append(warns, fmt.Sprintf("listing %s: %v", name, err))
 			continue

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -975,6 +975,54 @@ func TestLoadLiveSet_FalseAvailabilitySkipped(t *testing.T) {
 	}
 }
 
+func TestLoadLiveSetOnly_EmptyOnlyListsNothing(t *testing.T) {
+	got, warns := LoadLiveSetOnly(map[string]bool{"brew": true}, map[string]bool{})
+	if len(got) != 0 || len(warns) != 0 {
+		t.Fatalf("got %#v warns %v, want empty when no managers were requested", got, warns)
+	}
+}
+
+func TestManagersToList_EmptyPackages(t *testing.T) {
+	got := ManagersToList(nil, nil, map[string]bool{"brew": true, "composer": true})
+	if len(got) != 0 {
+		t.Fatalf("got %v, want no managers for an empty spec", got)
+	}
+}
+
+func TestManagersToList_UnlockedPrefer(t *testing.T) {
+	pkgs := []schema.Package{{ID: "git", Prefer: "brew"}}
+	got := ManagersToList(pkgs, nil, map[string]bool{"brew": true})
+	if !got["brew"] {
+		t.Fatalf("got %v, want brew for an unlocked preferred package", got)
+	}
+}
+
+func TestManagersToList_SkipsLocked(t *testing.T) {
+	pkgs := []schema.Package{{ID: "git", Prefer: "brew"}}
+	locked := []genvfile.LockedPackage{{ID: "git", Manager: "brew", PkgName: "git"}}
+	got := ManagersToList(pkgs, locked, map[string]bool{"brew": true})
+	if len(got) != 0 {
+		t.Fatalf("got %v, want none for a package already in the lock", got)
+	}
+}
+
+func TestListInstalledTimed_Timeout(t *testing.T) {
+	started := time.Now()
+	_, err := listInstalledTimed(func() ([]string, error) {
+		time.Sleep(time.Hour)
+		return []string{"x"}, nil
+	}, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %v, want timed out", err)
+	}
+	if time.Since(started) > 2*time.Second {
+		t.Fatalf("timeout took %s, want well under 2s", time.Since(started))
+	}
+}
+
 func TestPrintReconcilePlan_ShowsAdopted(t *testing.T) {
 	var buf bytes.Buffer
 	result := ReconcileResult{

--- a/main.go
+++ b/main.go
@@ -1286,7 +1286,7 @@ func runApplyWithSpecAndLock(ctx context.Context, opts applyOptions, f *schema.G
 	}
 	f = effective
 	opts.Target = activeTarget
-	live, liveWarns := resolver.LoadLiveSet(available)
+	live, liveWarns := resolver.LoadLiveSetOnly(available, resolver.ManagersToList(f.Packages, lf.Packages, available))
 	for _, w := range liveWarns {
 		fprintf(os.Stderr, "genv apply: warning: %s\n", w)
 	}
@@ -2973,7 +2973,7 @@ func statusCmd(args []string) int {
 	entries := commands.Status(f, lf)
 	if !*offline {
 		available := resolver.Detect()
-		live, liveWarns := resolver.LoadLiveSet(available)
+		live, liveWarns := resolver.LoadLiveSetOnly(available, resolver.ManagersToList(f.Packages, lf.Packages, available))
 		for _, w := range liveWarns {
 			fprintf(os.Stderr, "genv status: warning: %s\n", w)
 		}


### PR DESCRIPTION
## Summary

Main Windows tests hit the 8-minute deadline because apply/status listed every available manager with no timeout. GitHub's Windows runner has Composer; `composer global show` never returned.

- Only inventory managers needed by unlocked spec packages (empty spec lists nothing)
- Each listing times out after 30s and becomes a warning

## Test Plan

- [x] Resolver tests for empty need-set, locked skip, and listing timeout
- [ ] Windows CI Test (Windows) green on this PR
