### PR TITLE
fix: bound every package-manager probe so a hung manager cannot wedge genv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Every package-manager probe is now bounded. `genv scan`, `genv search`,
+  upgrade version capture, the outdated check, and service status probes cap
+  each manager subprocess (30s default), so a hung manager — winget's
+  first-run source sync can stall for minutes on fresh profiles — can no
+  longer wedge the command. Timed-out probes surface as errors or
+  conservative fallbacks: a timed-out outdated query keeps all packages, so
+  real upgrades are never silently skipped.
+
+### Changed
+
+- `internal/resolver`: exported `DefaultLiveListTimeout` and added `CallTimed`
+  / `RunTimed` helpers so commands that inventory managers directly share the
+  same per-spawn deadline machinery as apply/status.
+- Adapter probes (`ListInstalled`, `QueryVersion`, `Query`, `ListOutdated`,
+  availability checks) run under a shared deadline and set `WaitDelay`, so a
+  killed manager's orphaned children cannot hold output pipes open.
+
 ## v4.2.1 - 2026-08-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ WSL2 does **not** inherit native `arch` automatically. Put shared bits in `defau
 
 **Also available** (explicit `prefer` / `managers`): `bun`, `npm`, `pnpm`, `yarn`, `deno`, `volta`, `uv`, `pipx`, `pip-user`, `poetry`, `conda`, `mamba`, `pixi`, `cargo`, `go`, `rustup`, `gem`, `composer`, `dotnet-tool`, `ghcup`, `stack`, `opam`, `juliaup`, `sdkman`, `asdf`, `mise`, `krew`, `helm`, `vscode`.
 
+`external` is a track-only pseudo-manager: packages installed outside any manager (official installers, vendor downloads). Apply records them in the lock when the binary is on PATH; genv never installs or removes them itself.
+
 Native `apt`, `dnf`, and `apk` adapters are registered system managers (`prefer: apt|dnf|apk`). Use `genv map` / `genv export` when moving a spec across Linux families.
 
 ---
@@ -260,6 +262,7 @@ Tab completion on `add` / `adopt` suggests package names from available managers
 ```bash
 genv apply --target windows --yes                 # adopt live apps, install only the missing
 genv apply --skip-packages --yes                  # links + env only
+genv apply --timeout 30m --hook-timeout 2m        # cap each subprocess / hook (default 10m; 0 disables)
 genv apply --target ubuntu --dry-run --json
 genv apply --force --backup --yes                 # overwrite mismatched files; keep *.backup.*
 genv apply --target ubuntu --force-new-lock --yes   # after a foreign lock refuse

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -5,10 +5,12 @@ package adapter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Searchable is an optional extension of Adapter for managers that support
@@ -221,11 +223,96 @@ func normalizeID(key, id string, managers map[string]string) (string, bool) {
 	return id, false
 }
 
+// probeTimeout bounds every read-only inventory subprocess (list, query,
+// version, outdated, availability probes). Package managers are external
+// programs that can block indefinitely — winget famously stalls for minutes
+// on fresh profiles while it initializes its sources — and genv must stay
+// responsive instead of wedging behind them. Mutating commands (install,
+// uninstall, upgrade) are deliberately NOT bounded by this constant: they
+// legitimately run long and are governed by the caller-supplied context.
+// Var so tests can shorten the deadline.
+var probeTimeout = 30 * time.Second
+
+// probeWaitDelay bounds how long a probe waits for inherited output pipes to
+// close after the process itself is gone. Without it, a killed manager's
+// grandchildren (shims, `sh -c` wrappers, .cmd→bash chains on Windows) keep
+// the stdout pipe open and the probe still blocks until they exit.
+var probeWaitDelay = 2 * time.Second
+
+// runProbe runs cmd with args under probeTimeout and returns raw stdout.
+// A non-zero child exit code is reported as *exec.ExitError so callers can
+// apply their usual exit-code conventions; a deadline overrun is reported as
+// a distinct timeout error that is never an *exec.ExitError.
+func runProbe(cmd string, args ...string) ([]byte, error) {
+	return runProbeContext(context.Background(), cmd, args...)
+}
+
+// runProbeCombined is runProbe but returns combined stdout+stderr, for
+// managers that print their inventory on stderr (e.g. dnf check-update).
+func runProbeCombined(cmd string, args ...string) ([]byte, error) {
+	return runProbeCombinedContext(context.Background(), cmd, args...)
+}
+
+// runProbeContext is runProbe under a caller-owned context. When that context
+// carries no deadline, probeTimeout is applied — every probe gets SOME bound,
+// whichever entry point it arrives through.
+func runProbeContext(parent context.Context, cmd string, args ...string) ([]byte, error) {
+	ctx, cancel, budget := boundProbe(parent)
+	defer cancel()
+	cmdEx := exec.CommandContext(ctx, cmd, args...)
+	cmdEx.WaitDelay = probeWaitDelay
+	out, err := cmdEx.Output()
+	return checkProbeErr(ctx, budget, cmd, args, out, err)
+}
+
+// runProbeCombinedContext is runProbeCombined under a caller-owned context,
+// with the same no-deadline-means-probeTimeout rule.
+func runProbeCombinedContext(parent context.Context, cmd string, args ...string) ([]byte, error) {
+	ctx, cancel, budget := boundProbe(parent)
+	defer cancel()
+	cmdEx := exec.CommandContext(ctx, cmd, args...)
+	cmdEx.WaitDelay = probeWaitDelay
+	out, err := cmdEx.CombinedOutput()
+	return checkProbeErr(ctx, budget, cmd, args, out, err)
+}
+
+// boundProbe applies probeTimeout when parent has no deadline. It returns the
+// context to run under, a cancel the caller must defer, and the effective
+// budget for error messages. The cancel is a no-op when parent already had a
+// deadline — cancelling an inherited parent is never the probe's call.
+func boundProbe(parent context.Context) (context.Context, context.CancelFunc, time.Duration) {
+	if dl, ok := parent.Deadline(); ok {
+		budget := probeTimeout
+		if remaining := time.Until(dl); remaining > 0 {
+			budget = remaining
+		}
+		return parent, func() {}, budget
+	}
+	ctx, cancel := context.WithTimeout(parent, probeTimeout)
+	return ctx, cancel, probeTimeout
+}
+
+// checkProbeErr reclassifies a context-driven kill as a timeout error.
+// CommandContext kills the child on deadline, which surfaces as an
+// ExitError ("signal: killed") rather than context.DeadlineExceeded, so the
+// owning context is the only reliable signal. Without this reclassification,
+// a hung manager would be indistinguishable from "not installed".
+func checkProbeErr(ctx context.Context, budget time.Duration, cmd string, args []string, out []byte, err error) ([]byte, error) {
+	if err == nil {
+		return out, nil
+	}
+	if ctx.Err() != nil || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return nil, fmt.Errorf("%s %s: timed out after %s", cmd, strings.Join(args, " "), budget)
+	}
+	return out, err
+}
+
 // runQuery executes cmd with args and interprets the exit status as an
 // installed/absent signal. A non-zero exit code means "not installed"
 // (false, nil). Only an OS-level execution failure is returned as an error.
+// Bounded by probeTimeout so a hung manager cannot stall detection.
 func runQuery(cmd string, args ...string) (bool, error) {
-	err := exec.Command(cmd, args...).Run()
+	_, err := runProbe(cmd, args...)
 	if err == nil {
 		return true, nil
 	}
@@ -242,9 +329,10 @@ func runListOutput(cmd string, args ...string) ([]string, error) {
 	return runListOutputContext(context.Background(), cmd, args...)
 }
 
-// runListOutputContext is runListOutput with subprocess cancellation.
+// runListOutputContext is runListOutput with subprocess cancellation. When the
+// caller supplies no deadline, probeTimeout still applies.
 func runListOutputContext(ctx context.Context, cmd string, args ...string) ([]string, error) {
-	out, err := exec.CommandContext(ctx, cmd, args...).Output()
+	out, err := runProbeContext(ctx, cmd, args...)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
@@ -261,7 +349,7 @@ func runListOutputContext(ctx context.Context, cmd string, args ...string) ([]st
 // runVersionOutput runs cmd and returns trimmed stdout as the version string.
 // A non-zero exit code is treated as "not installed" ("", nil), not an error.
 func runVersionOutput(cmd string, args ...string) (string, error) {
-	out, err := exec.Command(cmd, args...).Output()
+	out, err := runProbe(cmd, args...)
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/adapter/apk.go
+++ b/internal/adapter/apk.go
@@ -2,7 +2,6 @@ package adapter
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 )
 
@@ -116,7 +115,7 @@ func (Apk) ListInstalled() ([]string, error) {
 }
 
 func (Apk) ListInstalledVersions() (map[string]string, error) {
-	out, err := exec.Command("apk", "info", "-v").Output()
+	out, err := runProbe("apk", "info", "-v")
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +161,7 @@ func (Apk) QueryVersion(pkgName string) (string, error) {
 }
 
 func (Apk) ListOutdated(pkgNames []string) (map[string]string, error) {
-	out, err := exec.Command("apk", "version", "-l", "<").Output()
+	out, err := runProbe("apk", "version", "-l", "<")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/apt.go
+++ b/internal/adapter/apt.go
@@ -2,7 +2,6 @@ package adapter
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 )
 
@@ -107,7 +106,7 @@ func (Apt) QueryVersion(pkgName string) (string, error) {
 }
 
 func (Apt) ListOutdated(pkgNames []string) (map[string]string, error) {
-	out, err := exec.Command("apt-get", "-s", "upgrade").Output()
+	out, err := runProbe("apt-get", "-s", "upgrade")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/choco.go
+++ b/internal/adapter/choco.go
@@ -123,7 +123,7 @@ func (Choco) ListInstalledVersions() (map[string]string, error) {
 // ListOutdated reports Chocolatey packages whose available version differs
 // from the installed one, keyed by package name -> target version.
 func (Choco) ListOutdated(pkgNames []string) (map[string]string, error) {
-	out, err := exec.Command("choco", "outdated", "-r").Output()
+	out, err := runProbe("choco", "outdated", "-r")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 2 {

--- a/internal/adapter/composer.go
+++ b/internal/adapter/composer.go
@@ -90,7 +90,7 @@ type composerEntry struct {
 }
 
 func (Composer) listEntries() ([]composerEntry, error) {
-	out, err := exec.Command("composer", "global", "show", "--format=json").Output()
+	out, err := runProbe("composer", "global", "show", "--format=json")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/adapter/conda.go
+++ b/internal/adapter/conda.go
@@ -105,7 +105,7 @@ func (Conda) QueryVersion(pkgName string) (string, error) {
 }
 
 func listCondaVersions(bin, env string) ([]pythonEntry, error) {
-	out, err := exec.Command(bin, "list", "-n", env, "--json").Output()
+	out, err := runProbe(bin, "list", "-n", env, "--json")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/adapter/dnf.go
+++ b/internal/adapter/dnf.go
@@ -104,7 +104,7 @@ func (Dnf) QueryVersion(pkgName string) (string, error) {
 }
 
 func (Dnf) ListOutdated(pkgNames []string) (map[string]string, error) {
-	out, err := exec.Command("dnf", "check-update", "-q").CombinedOutput()
+	out, err := runProbeCombined("dnf", "check-update", "-q")
 	if err != nil {
 		var exitErr *exec.ExitError
 		// dnf check-update exits 100 when updates are available.

--- a/internal/adapter/dotnet_tool.go
+++ b/internal/adapter/dotnet_tool.go
@@ -86,7 +86,7 @@ type dotnetEntry struct {
 }
 
 func (DotnetTool) listEntries() ([]dotnetEntry, error) {
-	out, err := exec.Command("dotnet", "tool", "list", "--global").Output()
+	out, err := runProbe("dotnet", "tool", "list", "--global")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/adapter/gem.go
+++ b/internal/adapter/gem.go
@@ -99,7 +99,7 @@ func (Gem) listEntries() ([]gemEntry, error) {
 	if !gemManageable() {
 		return nil, nil
 	}
-	out, err := exec.Command("gem", "list", "--local").Output()
+	out, err := runProbe("gem", "list", "--local")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -115,7 +115,7 @@ func (Gem) listEntries() ([]gemEntry, error) {
 // When the directory cannot be determined it returns true, preserving the
 // default "list everything" behavior rather than hiding a writable install.
 var gemManageable = func() bool {
-	out, err := exec.Command("gem", "environment", "gemdir").Output()
+	out, err := runProbe("gem", "environment", "gemdir")
 	if err != nil {
 		return true
 	}

--- a/internal/adapter/go.go
+++ b/internal/adapter/go.go
@@ -3,7 +3,6 @@ package adapter
 import (
 	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -107,7 +106,7 @@ func isGoSemanticImportSuffix(part string) bool {
 }
 
 func goBinDir() (string, bool) {
-	out, err := exec.Command("go", "env", "GOBIN", "GOPATH").Output()
+	out, err := runProbe("go", "env", "GOBIN", "GOPATH")
 	if err != nil {
 		return "", false
 	}

--- a/internal/adapter/js_json.go
+++ b/internal/adapter/js_json.go
@@ -18,7 +18,7 @@ type jsListPackage struct {
 }
 
 func runJSONPackageList(cmd string, args ...string) ([]jsPackageEntry, error) {
-	out, err := exec.Command(cmd, args...).Output()
+	out, err := runProbe(cmd, args...)
 	if err != nil {
 		return nil, commandOutputError(err)
 	}

--- a/internal/adapter/krew.go
+++ b/internal/adapter/krew.go
@@ -1,7 +1,6 @@
 package adapter
 
 import (
-	"os/exec"
 	"slices"
 	"strings"
 )
@@ -14,7 +13,10 @@ type Krew struct{}
 func (Krew) Name() string { return "krew" }
 
 var krewProbe = func() error {
-	return exec.Command("kubectl", "krew", "version").Run()
+	// Bounded probe: an ExitError (krew missing) and a timeout both mean
+	// "not usable", so the raw error is enough here.
+	_, err := runProbe("kubectl", "krew", "version")
+	return err
 }
 
 func (Krew) Available() bool {

--- a/internal/adapter/pacman.go
+++ b/internal/adapter/pacman.go
@@ -140,7 +140,7 @@ func listPacmanQuOutdated(cmd string, pkgNames []string) (map[string]string, err
 
 // runPacmanQuOutput runs cmd -Qu. Exit code 1 means the system is up to date.
 func runPacmanQuOutput(cmd string) ([]string, error) {
-	out, err := exec.Command(cmd, "-Qu").Output()
+	out, err := runProbe(cmd, "-Qu")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {

--- a/internal/adapter/pip_user.go
+++ b/internal/adapter/pip_user.go
@@ -18,7 +18,10 @@ func (PipUser) Available() bool {
 }
 
 var pipUserProbe = func() error {
-	return exec.Command("python3", "-m", "pip", "--version").Run()
+	// Bounded probe: an ExitError (pip missing) and a timeout both mean
+	// "not usable", so the raw error is enough here.
+	_, err := runProbe("python3", "-m", "pip", "--version")
+	return err
 }
 
 func (PipUser) NormalizeID(id string, managers map[string]string) (string, bool) {
@@ -104,7 +107,7 @@ func (PipUser) ListOutdated(pkgNames []string) (map[string]string, error) {
 }
 
 func (PipUser) listEntries() ([]pythonEntry, error) {
-	out, err := exec.Command("python3", "-m", "pip", "list", "--user", "--format=json").Output()
+	out, err := runProbe("python3", "-m", "pip", "list", "--user", "--format=json")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/adapter/pipx.go
+++ b/internal/adapter/pipx.go
@@ -101,7 +101,7 @@ func (Pipx) ListOutdated(pkgNames []string) (map[string]string, error) {
 }
 
 func (Pipx) listEntries() ([]pythonEntry, error) {
-	out, err := exec.Command("pipx", "list", "--json").Output()
+	out, err := runProbe("pipx", "list", "--json")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/adapter/pixi.go
+++ b/internal/adapter/pixi.go
@@ -88,7 +88,7 @@ func (Pixi) ListInstalledVersions() (map[string]string, error) {
 }
 
 func (Pixi) listEntries() ([]pythonEntry, error) {
-	out, err := exec.Command("pixi", "global", "list").Output()
+	out, err := runProbe("pixi", "global", "list")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/adapter/poetry.go
+++ b/internal/adapter/poetry.go
@@ -88,7 +88,7 @@ func (Poetry) ListInstalledVersions() (map[string]string, error) {
 }
 
 func (Poetry) listEntries() ([]pythonEntry, error) {
-	out, err := exec.Command("poetry", "self", "show", "plugins").Output()
+	out, err := runProbe("poetry", "self", "show", "plugins")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/adapter/probe_timeout_test.go
+++ b/internal/adapter/probe_timeout_test.go
@@ -1,0 +1,134 @@
+package adapter
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// swapProbeTimeout shortens the probe deadline (and the post-exit pipe-drain
+// grace, so killed grandchildren don't pad the test) for the test's duration.
+func swapProbeTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	origTimeout := probeTimeout
+	origWait := probeWaitDelay
+	probeTimeout = d
+	probeWaitDelay = d
+	t.Cleanup(func() {
+		probeTimeout = origTimeout
+		probeWaitDelay = origWait
+	})
+}
+
+// TestRunProbe_TimeoutReclassified is the regression test for the Windows CI
+// scan hang: a manager subprocess that blocks past the deadline must surface
+// as a timeout error, NOT as a plain *exec.ExitError (CommandContext kills the
+// child, which used to look identical to "manager exited with an error").
+func TestRunProbe_TimeoutReclassified(t *testing.T) {
+	swapProbeTimeout(t, 80*time.Millisecond)
+	installFakeBinary(t, "sleep", "sleep 30")
+
+	out, err := runProbe("sleep", "30")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %v, want it to mention the timeout", err)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		t.Fatalf("timeout must not be an *exec.ExitError (callers treat that as a manager verdict), got %v", err)
+	}
+	if out != nil {
+		t.Fatalf("expected nil output on timeout, got %q", out)
+	}
+}
+
+// TestRunProbe_ExitCodeStillSurfaces guards the other side of the contract:
+// real manager exit codes (e.g. choco's "2 means outdated found") must still
+// arrive as *exec.ExitError so callers can apply their exit-code conventions.
+func TestRunProbe_ExitCodeStillSurfaces(t *testing.T) {
+	installFakeBinary(t, "fakeprobe", "echo out; exit 3")
+
+	out, err := runProbe("fakeprobe")
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %v", err)
+	}
+	if exitErr.ExitCode() != 3 {
+		t.Fatalf("exit code = %d, want 3", exitErr.ExitCode())
+	}
+	if string(out) != "out\n" {
+		t.Fatalf("output = %q, want %q", out, "out\n")
+	}
+}
+
+// TestRunQuery_TimeoutIsError pins the scan-hang fix at the helper level:
+// a timed-out Query must return an error (so callers warn and move on)
+// instead of (false, nil), which would silently mean "not installed".
+func TestRunQuery_TimeoutIsError(t *testing.T) {
+	swapProbeTimeout(t, 80*time.Millisecond)
+	installFakeBinary(t, "sleepquery", "sleep 30")
+
+	ok, err := runQuery("sleepquery")
+	if ok {
+		t.Fatal("ok = true, want false")
+	}
+	if err == nil {
+		t.Fatal("a hung manager must return an error, not a silent not-installed")
+	}
+}
+
+// TestRunQuery_NonZeroStillMeansAbsent keeps the pre-existing convention.
+func TestRunQuery_NonZeroStillMeansAbsent(t *testing.T) {
+	installFakeBinary(t, "absentquery", "exit 1")
+
+	ok, err := runQuery("absentquery")
+	if ok || err != nil {
+		t.Fatalf("got (%v, %v), want (false, nil)", ok, err)
+	}
+}
+
+// TestRunListOutput_TimeoutIsError covers the ListInstalled path.
+func TestRunListOutput_TimeoutIsError(t *testing.T) {
+	swapProbeTimeout(t, 80*time.Millisecond)
+	installFakeBinary(t, "sleeplist", "sleep 30")
+
+	lines, err := runListOutput("sleeplist")
+	if err == nil {
+		t.Fatal("expected timeout error from list")
+	}
+	if lines != nil {
+		t.Fatalf("expected nil lines, got %v", lines)
+	}
+}
+
+// TestRunVersionOutput_TimeoutIsError covers the QueryVersion path.
+func TestRunVersionOutput_TimeoutIsError(t *testing.T) {
+	swapProbeTimeout(t, 80*time.Millisecond)
+	installFakeBinary(t, "sleepver", "sleep 30")
+
+	ver, err := runVersionOutput("sleepver")
+	if err == nil {
+		t.Fatal("expected timeout error from version probe")
+	}
+	if ver != "" {
+		t.Fatalf("expected empty version, got %q", ver)
+	}
+}
+
+// TestRunListOutput_FastPathUnchanged makes sure the capping did not disturb
+// normal parsing: a manager that prints lines still parses as before.
+func TestRunListOutput_FastPathUnchanged(t *testing.T) {
+	installFakeBinary(t, "fastlist", "echo one; echo; echo two")
+
+	lines, err := runListOutput("fastlist")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 2 || lines[0] != "one" || lines[1] != "two" {
+		t.Fatalf("lines = %v, want [one two]", lines)
+	}
+}

--- a/internal/adapter/scoop.go
+++ b/internal/adapter/scoop.go
@@ -3,7 +3,6 @@ package adapter
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -125,7 +124,7 @@ func (Scoop) ListInstalledVersions() (map[string]string, error) {
 // ListOutdated reports Scoop apps with an available update, keyed by app name
 // -> target version, intersected with pkgNames.
 func (Scoop) ListOutdated(pkgNames []string) (map[string]string, error) {
-	out, err := exec.Command("scoop", "status").Output()
+	out, err := runProbe("scoop", "status")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/snap.go
+++ b/internal/adapter/snap.go
@@ -2,7 +2,6 @@ package adapter
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 )
 
@@ -133,7 +132,7 @@ func (Snap) QueryVersion(pkgName string) (string, error) {
 // ListOutdated reports snaps with an available refresh, keyed by snap name
 // -> target version, intersected with pkgNames.
 func (Snap) ListOutdated(pkgNames []string) (map[string]string, error) {
-	out, err := exec.Command("snap", "refresh", "--list").Output()
+	out, err := runProbe("snap", "refresh", "--list")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/uv.go
+++ b/internal/adapter/uv.go
@@ -143,7 +143,7 @@ func (Uv) listEntries() ([]uvEntry, error) {
 // preserving leading whitespace so indented entrypoint lines can be detected.
 // A non-zero exit code is treated as "no tools" (nil, nil), not an error.
 func runUvToolList() ([]string, error) {
-	out, err := exec.Command("uv", "tool", "list").Output()
+	out, err := runProbe("uv", "tool", "list")
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/adapter/winget.go
+++ b/internal/adapter/winget.go
@@ -2,7 +2,6 @@ package adapter
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 )
 
@@ -100,7 +99,7 @@ func (Winget) QueryVersion(pkgName string) (string, error) {
 // ListOutdated reports winget package IDs with an available upgrade, keyed by
 // ID -> target version, intersected with pkgNames.
 func (Winget) ListOutdated(pkgNames []string) (map[string]string, error) {
-	out, err := exec.Command("winget", "upgrade").Output()
+	out, err := runProbe("winget", "upgrade")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -313,11 +313,11 @@ func FilterOutdated(packages []genvfile.LockedPackage) (kept []genvfile.LockedPa
 			continue
 		}
 		started := time.Now()
-		outdated, err := lister.ListOutdated(g.pkgNames)
+		outdated, err := CallTimed(func() (map[string]string, error) { return lister.ListOutdated(g.pkgNames) }, DefaultLiveListTimeout)
 		elapsed := time.Since(started).Round(time.Millisecond)
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf("could not determine outdated packages for %s after %s (%v) — keeping all", name, elapsed, err))
-			keep[name] = nil // query failed: keep all conservatively
+			keep[name] = nil // query failed or timed out: keep all conservatively
 			continue
 		}
 		// Timing is logged as a warning so scheduled updates.log and CLI stderr
@@ -373,10 +373,13 @@ func ExecuteUpgrade(ctx context.Context, plan []UpgradeAction, stdin io.Reader, 
 
 		// Collect current versions for every package in the action. Use a single
 		// ListInstalledVersions call when the adapter supports it, then fall back
-		// to per-package QueryVersion for anything missing.
+		// to per-package QueryVersion for anything missing. Both probes are
+		// capped so a hung manager cannot stall the lock update indefinitely;
+		// a timed-out probe is skipped (version stays empty) rather than
+		// treated as a real version.
 		versions := make(map[string]string, len(a.LPs))
 		if versionLister, ok := a.Mgr.(adapter.VersionLister); ok {
-			if listedVersions, err := versionLister.ListInstalledVersions(); err == nil {
+			if listedVersions, err := CallTimed(versionLister.ListInstalledVersions, DefaultLiveListTimeout); err == nil {
 				for _, lp := range a.LPs {
 					if v, ok := listedVersions[lp.PkgName]; ok {
 						versions[lp.ID] = v
@@ -388,7 +391,7 @@ func ExecuteUpgrade(ctx context.Context, plan []UpgradeAction, stdin io.Reader, 
 			if _, ok := versions[lp.ID]; ok {
 				continue
 			}
-			if v, err := a.Mgr.QueryVersion(lp.PkgName); err == nil && v != "" {
+			if v, err := CallTimed(func() (string, error) { return a.Mgr.QueryVersion(lp.PkgName) }, DefaultLiveListTimeout); err == nil && v != "" {
 				versions[lp.ID] = v
 			}
 		}
@@ -452,31 +455,44 @@ func (s LiveSet) has(manager, pkgName string) bool {
 	return false
 }
 
-// defaultLiveListTimeout caps each manager inventory so a hung
+// DefaultLiveListTimeout caps each manager inventory so a hung
 // `composer global show` (or similar) cannot stall apply/status.
-const defaultLiveListTimeout = 30 * time.Second
+// Exported so commands that inventory managers directly (scan) share it.
+// Var so tests can shorten the deadline.
+var DefaultLiveListTimeout = 30 * time.Second
 
-func listInstalledTimed(list func() ([]string, error), d time.Duration) ([]string, error) {
+// CallTimed runs f under a wall-clock deadline d. If f has not returned by
+// then, CallTimed returns a timeout error; f keeps running in the background
+// and its eventual result is dropped. Use it to bound calls into adapters,
+// which spawn external package managers that can block indefinitely.
+func CallTimed[T any](f func() (T, error), d time.Duration) (T, error) {
 	if d <= 0 {
-		return list()
+		return f()
 	}
 	type result struct {
-		names []string
+		value T
 		err   error
 	}
 	ch := make(chan result, 1)
 	go func() {
-		names, err := list()
-		ch <- result{names, err}
+		v, err := f()
+		ch <- result{v, err}
 	}()
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {
 	case r := <-ch:
-		return r.names, r.err
+		return r.value, r.err
 	case <-timer.C:
-		return nil, fmt.Errorf("timed out after %s", d)
+		var zero T
+		return zero, fmt.Errorf("timed out after %s", d)
 	}
+}
+
+// RunTimed is CallTimed for probes that only report success or failure.
+func RunTimed(f func() error, d time.Duration) error {
+	_, err := CallTimed(func() (struct{}, error) { return struct{}{}, f() }, d)
+	return err
 }
 
 // ManagersToList is the set of managers apply/status actually need to
@@ -531,7 +547,7 @@ func LoadLiveSetOnly(available, only map[string]bool) (LiveSet, []string) {
 		if mgr == nil {
 			continue
 		}
-		list, err := listInstalledTimed(mgr.ListInstalled, defaultLiveListTimeout)
+		list, err := CallTimed(mgr.ListInstalled, DefaultLiveListTimeout)
 		if err != nil {
 			warns = append(warns, fmt.Sprintf("listing %s: %v", name, err))
 			continue

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1006,9 +1006,9 @@ func TestManagersToList_SkipsLocked(t *testing.T) {
 	}
 }
 
-func TestListInstalledTimed_Timeout(t *testing.T) {
+func TestCallTimed_Timeout(t *testing.T) {
 	started := time.Now()
-	_, err := listInstalledTimed(func() ([]string, error) {
+	_, err := CallTimed(func() ([]string, error) {
 		time.Sleep(time.Hour)
 		return []string{"x"}, nil
 	}, 50*time.Millisecond)

--- a/internal/resolver/timeout_test.go
+++ b/internal/resolver/timeout_test.go
@@ -1,0 +1,131 @@
+package resolver
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ks1686/genv/internal/adapter"
+	"github.com/ks1686/genv/internal/genvfile"
+)
+
+// swapLiveListTimeout shortens the inventory deadline for the test.
+func swapLiveListTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := DefaultLiveListTimeout
+	DefaultLiveListTimeout = d
+	t.Cleanup(func() { DefaultLiveListTimeout = orig })
+}
+
+// hangingOutdatedMgr is an OutdatedLister whose query blocks forever, standing
+// in for a wedged `winget upgrade` / `composer global show`.
+type hangingOutdatedMgr struct {
+	outdatedTestMgr
+}
+
+func (m *hangingOutdatedMgr) ListOutdated([]string) (map[string]string, error) {
+	select {}
+}
+
+// TestRunTimed_SuccessAndTimeout covers the error-only variant used by
+// service probes.
+func TestRunTimed_SuccessAndTimeout(t *testing.T) {
+	if err := RunTimed(func() error { return nil }, 50*time.Millisecond); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if err := RunTimed(func() error { return errors.New("boom") }, time.Second); err == nil || err.Error() != "boom" {
+		t.Fatalf("expected boom to pass through, got %v", err)
+	}
+	started := time.Now()
+	err := RunTimed(func() error { time.Sleep(time.Hour); return nil }, 50*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("err = %v, want timeout", err)
+	}
+	if time.Since(started) > 2*time.Second {
+		t.Fatalf("timeout took %s, want well under 2s", time.Since(started))
+	}
+}
+
+// TestCallTimed_PreservesValue verifies the generic passthrough on success.
+func TestCallTimed_PreservesValue(t *testing.T) {
+	got, err := CallTimed(func() (int, error) { return 42, nil }, time.Second)
+	if err != nil || got != 42 {
+		t.Fatalf("got (%d, %v), want (42, nil)", got, err)
+	}
+}
+
+// TestFilterOutdated_TimeoutKeepsAll is the silent-upgrade regression test:
+// when a manager's outdated query wedges, FilterOutdated must keep ALL of that
+// manager's packages (conservative) — never interpret the timeout as "nothing
+// is outdated", which would silently skip real upgrades.
+func TestFilterOutdated_TimeoutKeepsAll(t *testing.T) {
+	swapLiveListTimeout(t, 80*time.Millisecond)
+	swapLookupAdapter(t, map[string]adapter.Adapter{
+		"brew": &hangingOutdatedMgr{outdatedTestMgr{name: "brew"}},
+	})
+	packages := []genvfile.LockedPackage{
+		{ID: "wget", Manager: "brew", PkgName: "wget"},
+		{ID: "jq", Manager: "brew", PkgName: "jq"},
+	}
+	kept, warnings := FilterOutdated(packages)
+	if got := keptIDs(kept); len(got) != 2 {
+		t.Fatalf("kept = %v, want all packages kept on timeout", got)
+	}
+	if len(warnings) == 0 || !strings.Contains(strings.Join(warnings, "\n"), "timed out") {
+		t.Fatalf("warnings = %v, want a timeout warning", warnings)
+	}
+}
+
+// hangingVersionListerMgr blocks in ListInstalledVersions, like a wedged
+// `apk info -v`, while its mutating command succeeds.
+type hangingVersionListerMgr struct {
+	plainTestMgr
+	listStarted chan struct{}
+}
+
+func (m *hangingVersionListerMgr) ListInstalledVersions() (map[string]string, error) {
+	if m.listStarted != nil {
+		close(m.listStarted)
+	}
+	select {}
+}
+
+// TestExecuteUpgrade_HangingVersionProbeStillRecordsUpgrade: a manager whose
+// version probe wedges after a successful upgrade must not hang the lock
+// update. The upgrade is still recorded; since the new version is unknown,
+// the previously recorded version is carried over unchanged.
+func TestExecuteUpgrade_HangingVersionProbeStillRecordsUpgrade(t *testing.T) {
+	swapLiveListTimeout(t, 80*time.Millisecond)
+	mgr := &hangingVersionListerMgr{plainTestMgr: plainTestMgr{name: "hanglister"}}
+	plan := []UpgradeAction{
+		{
+			LPs: []genvfile.LockedPackage{
+				{ID: "git", Manager: "hanglister", PkgName: "git", InstalledVersion: "2.44.0"},
+			},
+			Mgr: mgr,
+			Cmd: []string{"true"},
+		},
+	}
+
+	done := make(chan UpgradeExecution, 1)
+	go func() {
+		done <- ExecuteUpgrade(context.Background(), plan, nil, &bytes.Buffer{}, &bytes.Buffer{})
+	}()
+	select {
+	case out := <-done:
+		if len(out.Errors) != 0 {
+			t.Fatalf("expected no errors, got %v", out.Errors)
+		}
+		if len(out.Upgraded) != 1 {
+			t.Fatalf("expected the upgrade to be recorded, got %d", len(out.Upgraded))
+		}
+		if out.Upgraded[0].InstalledVersion != "2.44.0" {
+			t.Fatalf("version = %q, want previous %q carried over (probe timed out)", out.Upgraded[0].InstalledVersion, "2.44.0")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ExecuteUpgrade hung on a wedged version probe")
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/ks1686/genv/internal/adapter"
+	"github.com/ks1686/genv/internal/resolver"
 )
 
 const maxConcurrentSearches = 4
@@ -90,7 +91,9 @@ func runSearches(query string, jobs []searchJob) []searchResult {
 		go func() {
 			defer wg.Done()
 			for job := range jobCh {
-				names, err := job.searchable.Search(query)
+				// Bound each backend like every other manager probe: one
+				// stalled registry query must not hang the whole search.
+				names, err := resolver.CallTimed(func() ([]string, error) { return job.searchable.Search(query) }, resolver.DefaultLiveListTimeout)
 				results[job.index] = searchResult{manager: job.manager, names: names, err: err}
 			}
 		}()

--- a/internal/search/search_timeout_test.go
+++ b/internal/search/search_timeout_test.go
@@ -1,0 +1,59 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ks1686/genv/internal/adapter"
+	"github.com/ks1686/genv/internal/resolver"
+)
+
+// TestAll_HangingSearchDoesNotBlockOthers: one stalled registry query must not
+// hang the whole search — the stalled backend is dropped after the deadline
+// while healthy backends still contribute results.
+func TestAll_HangingSearchDoesNotBlockOthers(t *testing.T) {
+	origTimeout := resolver.DefaultLiveListTimeout
+	resolver.DefaultLiveListTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { resolver.DefaultLiveListTimeout = origTimeout })
+
+	hanging := mockSearchableAdapter{
+		mockAdapter: mockAdapter{name: "hangingmgr"},
+		searchFunc: func(string) ([]string, error) {
+			time.Sleep(time.Hour)
+			return nil, nil
+		},
+	}
+	healthy := mockSearchableAdapter{
+		mockAdapter: mockAdapter{name: "healthymgr"},
+		searchFunc: func(string) ([]string, error) {
+			return []string{"jq"}, nil
+		},
+	}
+
+	originalAll := adapter.All
+	t.Cleanup(func() { adapter.All = originalAll })
+	adapter.All = []adapter.Adapter{hanging, healthy}
+	available := map[string]bool{"hangingmgr": true, "healthymgr": true}
+
+	started := time.Now()
+	candidates := All("jq", available)
+	elapsed := time.Since(started)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("search took %s; a hanging backend must not stall All()", elapsed)
+	}
+	for _, c := range candidates {
+		if c.Manager == "hangingmgr" {
+			t.Fatalf("hanging backend contributed results: %v", candidates)
+		}
+	}
+	found := false
+	for _, c := range candidates {
+		if c.Manager == "healthymgr" && c.PkgName == "jq" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("healthy backend results missing from %v", candidates)
+	}
+}

--- a/internal/service/brew.go
+++ b/internal/service/brew.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"github.com/ks1686/genv/internal/resolver"
 )
 
 // IsBrewServicesAvailable reports whether `brew services` can be used.
@@ -47,8 +49,12 @@ func BrewServicesRestart(ctx context.Context, formula string) error {
 
 // BrewServicesRunning reports whether a brew-managed service is currently running.
 // It parses the output of `brew services list` and looks for a "started" status.
+// The probe is capped like every other manager inventory so a wedged brew
+// cannot stall `genv service list` forever.
 func BrewServicesRunning(formula string) bool {
-	out, err := exec.Command("brew", "services", "list").Output()
+	out, err := resolver.CallTimed(func() ([]byte, error) {
+		return exec.Command("brew", "services", "list").Output()
+	}, resolver.DefaultLiveListTimeout)
 	if err != nil {
 		return false
 	}
@@ -63,8 +69,11 @@ func BrewServicesRunning(formula string) bool {
 }
 
 // BrewServicesList returns the raw output of `brew services list`.
+// Capped like BrewServicesRunning so a wedged brew cannot stall callers.
 func BrewServicesList() (string, error) {
-	out, err := exec.Command("brew", "services", "list").Output()
+	out, err := resolver.CallTimed(func() ([]byte, error) {
+		return exec.Command("brew", "services", "list").Output()
+	}, resolver.DefaultLiveListTimeout)
 	if err != nil {
 		return "", fmt.Errorf("brew services list: %w", err)
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ks1686/genv/internal/genvfile"
+	"github.com/ks1686/genv/internal/resolver"
 	"github.com/ks1686/genv/internal/schema"
 )
 
@@ -109,13 +110,17 @@ func ServiceStatus(specServices map[string]schema.Service, lockServices []genvfi
 		if probe && inSpec && svc.BrewFormula != "" {
 			running = BrewServicesRunning(svc.BrewFormula)
 		} else if probe && inSpec && len(svc.Status) > 0 {
-			cmd := exec.Command(svc.Status[0], svc.Status[1:]...)
-			if err := cmd.Run(); err == nil {
+			// Status commands are user-configured; still bound them so a wedged
+			// probe script cannot stall `genv service list`.
+			if err := resolver.RunTimed(func() error {
+				return exec.Command(svc.Status[0], svc.Status[1:]...).Run()
+			}, resolver.DefaultLiveListTimeout); err == nil {
 				running = true
 			}
 		} else if probe && inSpec && IsSystemdAvailable() {
-			cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", systemdUnitName(name))
-			if err := cmd.Run(); err == nil {
+			if err := resolver.RunTimed(func() error {
+				return exec.Command("systemctl", "--user", "is-active", "--quiet", systemdUnitName(name)).Run()
+			}, resolver.DefaultLiveListTimeout); err == nil {
 				running = true
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -2745,8 +2745,11 @@ func scanCmd(args []string) int {
 	for _, a := range scanAdaptersOnGOOS(available, scanGOOS) {
 		versions := map[string]string(nil)
 		var pkgs []string
+		// Cap every manager inventory like apply/status do, so one hung
+		// manager (winget's first-run source sync can stall for minutes)
+		// cannot wedge the whole scan.
 		if versionLister, ok := a.(adapter.VersionLister); ok {
-			if listedVersions, err := versionLister.ListInstalledVersions(); err == nil {
+			if listedVersions, err := resolver.CallTimed(versionLister.ListInstalledVersions, resolver.DefaultLiveListTimeout); err == nil {
 				versions = listedVersions
 				for pkgName := range versions {
 					pkgs = append(pkgs, pkgName)
@@ -2755,7 +2758,7 @@ func scanCmd(args []string) int {
 			}
 		}
 		if pkgs == nil {
-			listed, err := a.ListInstalled()
+			listed, err := resolver.CallTimed(a.ListInstalled, resolver.DefaultLiveListTimeout)
 			if err != nil {
 				fprintf(os.Stderr, "genv scan: %s: listing packages: %v\n", a.Name(), err)
 				continue

--- a/main_scan_timeout_test.go
+++ b/main_scan_timeout_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ks1686/genv/internal/adapter"
+	"github.com/ks1686/genv/internal/genvfile"
+	"github.com/ks1686/genv/internal/resolver"
+)
+
+// TestScanCmd_HangingManagerDoesNotWedgeScan is the end-to-end regression test
+// for the Windows CI hang (TestScanCmd_JsonOutput timed out after a winget
+// first-run stall): a manager whose ListInstalled blocks forever must be
+// skipped after the per-manager deadline, and scan must still exit OK with a
+// valid JSON envelope.
+func TestScanCmd_HangingManagerDoesNotWedgeScan(t *testing.T) {
+	origTimeout := resolver.DefaultLiveListTimeout
+	resolver.DefaultLiveListTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { resolver.DefaultLiveListTimeout = origTimeout })
+
+	// A cross-platform manager name so the fake participates on every OS
+	// (AutomaticOnGOOS only restricts brew/linuxbrew).
+	hanging := &hangingScanAdapter{name: "hangmgr"}
+	healthy := &scanManagerNameAdapter{name: "healthymgr", installed: []string{"jq"}}
+
+	origAll := adapter.All
+	adapter.All = []adapter.Adapter{hanging, healthy}
+	t.Cleanup(func() { adapter.All = origAll })
+	origScanGOOS := scanGOOS
+	scanGOOS = runtime.GOOS
+	t.Cleanup(func() { scanGOOS = origScanGOOS })
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := dir + "/genv.json"
+
+	var code int
+	done := make(chan struct{})
+	var out string
+	go func() {
+		defer close(done)
+		out = captureStdout(t, func() {
+			code = run([]string{"scan", "--file", path, "--json"})
+		})
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("scan hung on a wedged manager inventory")
+	}
+	if code != exitOK {
+		t.Fatalf("scan: expected exitOK (%d), got %d", exitOK, code)
+	}
+	var env map[string]any
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("scan --json output is not valid JSON: %v\noutput: %q", err, out)
+	}
+	if env["command"] != "scan" {
+		t.Errorf("JSON command: got %v, want %q", env["command"], "scan")
+	}
+}
+
+// hangingScanAdapter blocks forever in ListInstalled, standing in for a
+// wedged winget first run. It also exercises the QueryVersion fallback path.
+type hangingScanAdapter struct {
+	name string
+}
+
+func (a *hangingScanAdapter) Name() string    { return a.name }
+func (a *hangingScanAdapter) Available() bool { return true }
+func (a *hangingScanAdapter) NormalizeID(id string, _ map[string]string) (string, bool) {
+	return id, false
+}
+func (a *hangingScanAdapter) PlanInstall(pkgName string) []string { return []string{"true"} }
+func (a *hangingScanAdapter) PlanUninstall(pkgName string) []string {
+	return []string{"true"}
+}
+func (a *hangingScanAdapter) PlanUpgrade(pkgName string) []string { return []string{"true"} }
+func (a *hangingScanAdapter) PlanClean() [][]string               { return nil }
+func (a *hangingScanAdapter) Query(pkgName string) (bool, error)  { return false, nil }
+func (a *hangingScanAdapter) ListInstalled() ([]string, error) {
+	time.Sleep(time.Hour)
+	return nil, nil
+}
+func (a *hangingScanAdapter) QueryVersion(pkgName string) (string, error) {
+	time.Sleep(time.Hour)
+	return "", nil
+}
+
+// TestScanCmd_TimeoutWarnsButContinues verifies the warn-and-skip contract:
+// the hung manager produces a stderr warning and scan continues with the
+// remaining managers instead of aborting.
+func TestScanCmd_TimeoutWarnsButContinues(t *testing.T) {
+	origTimeout := resolver.DefaultLiveListTimeout
+	resolver.DefaultLiveListTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { resolver.DefaultLiveListTimeout = origTimeout })
+
+	hanging := &hangingScanAdapter{name: "hangmgr"}
+	healthy := &scanManagerNameAdapter{name: "healthymgr", installed: []string{"jq"}}
+
+	origAll := adapter.All
+	adapter.All = []adapter.Adapter{hanging, healthy}
+	t.Cleanup(func() { adapter.All = origAll })
+	origScanGOOS := scanGOOS
+	scanGOOS = runtime.GOOS
+	t.Cleanup(func() { scanGOOS = origScanGOOS })
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := dir + "/genv.json"
+
+	var code int
+	var errOut string
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		out := captureStderr(t, func() {
+			code = run([]string{"scan", "--file", path, "--yes"})
+		})
+		errOut = out
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("scan hung on a wedged manager inventory")
+	}
+	if code != exitOK {
+		t.Fatalf("scan: expected exitOK (%d), got %d", exitOK, code)
+	}
+	if !strings.Contains(errOut, "hangmgr") || !strings.Contains(errOut, "timed out") {
+		t.Fatalf("expected a timeout warning for hangmgr on stderr, got %q", errOut)
+	}
+
+	// The healthy manager's package should still have been adopted. On a v8
+	// spec that lives under the active target, so check everywhere.
+	f, err := genvfile.Read(path)
+	if err != nil {
+		t.Fatalf("read spec: %v", err)
+	}
+	found := false
+	for _, p := range f.Packages {
+		if p.ID == "jq" {
+			found = true
+		}
+	}
+	for _, target := range f.Targets {
+		for _, p := range target.Packages {
+			if p.ID == "jq" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("healthy manager package jq not adopted; spec = %+v", f)
+	}
+}


### PR DESCRIPTION
## Problem

Main's CI is red: `TestScanCmd_JsonOutput` timed out after 8m on the Windows runner (`panic: test timed out after 8m0s`, goroutine blocked in a subprocess wait). The same commit passed when run as the v4.2.1 tag, so this is a flaky hang — but a deterministic one in the wrong conditions.

Root cause: apply and status got a per-manager inventory cap (30s) in #109, but **scan** calls each adapter's `ListInstalled` / `ListInstalledVersions` / `QueryVersion` directly with no deadline. On a fresh Windows profile, `winget list` can stall for minutes while winget initializes its sources; scan (and therefore CI's main-package test suite) wedges behind it. The repo already carried a scar acknowledging this class — `TestAllAdapters_MethodsNoPanic` skips live winget/choco on Windows "because those list/query calls can hang for minutes".

The same unbounded-spawn defect existed in search, upgrade version capture, the outdated filter, service status probes, and several adapters that spawn inventory commands with plain `exec.Command`.

## Fix

Three layers, mirroring the #109 approach:

1. **Adapter level** (`internal/adapter`): new `runProbe`/`runProbeCombined` helpers bound every read-only spawn by a shared `probeTimeout` (30s). Context kills are reclassified into timeout errors — verified empirically that `CommandContext` surfaces a kill as `*exec.ExitError`, which callers would otherwise misread as "manager said not installed". `WaitDelay` bounds the post-exit pipe wait so killed shim grandchildren can't hold `Output()` open (found via test: a killed fake still blocked for its natural sleep).
2. **Command level**: scan inventories each manager under the same 30s cap apply/status use (`resolver.CallTimed`, now exported); upgrade version capture, `FilterOutdated`, cross-manager search, and service probes are bounded too. A timed-out `ListOutdated` keeps all packages conservatively — never silently "no updates".
3. **Tests**: timeout-vs-exit-code contract at the helper level, keep-all-on-timeout, upgrade recording with a wedged probe, search surviving a stalled backend, and end-to-end scan tests with a manager whose list hangs forever (regression test named after the CI failure).

Mutating commands (install/upgrade/clean/hooks) are untouched — they keep the caller-supplied context and existing `--timeout` semantics.

## Verification

- `make ci` locally green: race tests, coverage 81.3% (floor 80), bench-gate 162ms worst-case vs 200ms budget.
- New regression tests pass in ~1s total (shortened deadline vars per house style).
- Docs: README documents the `external` pseudo-manager and apply's `--timeout`/`--hook-timeout`; CHANGELOG updated under Unreleased.