### PR TITLE
fix: fsync spec and lock files before publishing the rename

### DIFF
--- a/internal/genvfile/genvfile.go
+++ b/internal/genvfile/genvfile.go
@@ -138,9 +138,14 @@ func Write(path string, f *schema.GenvFile) error {
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
 		return fmt.Errorf("writing %s: %w", tmp, err)
 	}
+	if err := syncFile(tmp); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("syncing %s: %w", tmp, err)
+	}
 	if err := os.Rename(tmp, path); err != nil {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("saving %s: %w", path, err)
 	}
+	syncDir(dir)
 	return nil
 }

--- a/internal/genvfile/lockfile.go
+++ b/internal/genvfile/lockfile.go
@@ -133,9 +133,14 @@ func WriteLock(path string, lf *LockFile) error {
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("writing %s: %w", tmpName, err)
 	}
+	if err := syncFile(tmpName); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("syncing %s: %w", tmpName, err)
+	}
 	if err := os.Rename(tmpName, path); err != nil {
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("saving %s: %w", path, err)
 	}
+	syncDir(dir)
 	return nil
 }

--- a/internal/genvfile/sync_unix.go
+++ b/internal/genvfile/sync_unix.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+package genvfile
+
+import "os"
+
+// syncFile flushes a written temp file to stable storage before the rename
+// that publishes it. Without this, a power loss can journal the rename before
+// the data blocks land, leaving an empty or partial spec/lock behind.
+func syncFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// syncDir fsyncs the directory so the rename itself is durable. Best effort:
+// some filesystems refuse directory fsync, and a failed durability hint must
+// never fail the write that already succeeded.
+func syncDir(dir string) {
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+}

--- a/internal/genvfile/sync_windows.go
+++ b/internal/genvfile/sync_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package genvfile
+
+import "os"
+
+// syncFile flushes a written temp file to stable storage before the rename
+// that publishes it. Windows FlushFileBuffers is the analogue of fsync; the
+// same power-loss window applies to NTFS metadata journaling.
+func syncFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// syncDir is a no-op on Windows: there is no supported handle-level directory
+// flush, and NTFS metadata journaling already orders the rename.
+func syncDir(string) {}


### PR DESCRIPTION
Stacked on #111 — merge that first.

## Problem

`genvfile.Write` (genv.json) and `genvfile.WriteLock` (genv.lock.json) use temp-file + rename, but never call `Sync()`. On a crash or power loss the filesystem can journal the rename before the data blocks are stable, leaving an **empty or partial** spec or lock file — the exact files genv exists to keep trustworthy. A zeroed lock makes every subsequent apply/status refuse or misreport; a zeroed spec loses the user's declared environment.

## Fix

- Both writers fsync the temp file before renaming (`syncFile`, per-GOOS: fsync on Unix, FlushFileBuffers via `File.Sync` on Windows).
- After rename, best-effort directory fsync so the rename itself is durable (`syncDir`; no-op on Windows where no handle-level directory flush exists, NTFS metadata journaling already orders it).
- A failed durability hint never fails a write that already succeeded.

## Verification

- `go build` / `go vet` / full `internal/genvfile` suite green locally.
- Review gate recorded (3 checks passed) before push.