### PR TITLE
fix: write pulled spec via temp+rename so an interrupted pull cannot truncate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
   before the publishing rename (and the directory afterwards), so a power
   loss can no longer leave an empty or partial `genv.json` /
   `genv.lock.json`.
+- `genv pull` writes the pulled spec through a temp file and rename, so an
+  interrupted pull can no longer leave `genv.json` truncated.
 - Every package-manager probe is now bounded. `genv scan`, `genv search`,
   upgrade version capture, the outdated check, and service status probes cap
   each manager subprocess (30s default), so a hung manager — winget's

--- a/main_pull.go
+++ b/main_pull.go
@@ -247,7 +247,9 @@ func runGit(args ...string) error {
 	return nil
 }
 
-// copyFile copies src to dst, creating parent directories as needed.
+// copyFile copies src to dst, creating parent directories as needed. The
+// destination is written to a sibling temp file and renamed into place so an
+// interrupted pull cannot leave the live spec truncated or half-written.
 func copyFile(src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {
@@ -259,16 +261,23 @@ func copyFile(src, dst string) error {
 		return fmt.Errorf("creating parent directory: %w", err)
 	}
 
-	out, err := os.Create(dst)
+	tmp := dst + ".pull-tmp"
+	out, err := os.Create(tmp)
 	if err != nil {
-		return fmt.Errorf("creating %s: %w", dst, err)
+		return fmt.Errorf("creating %s: %w", tmp, err)
 	}
 	if _, err := io.Copy(out, in); err != nil {
 		_ = out.Close()
-		return fmt.Errorf("copying to %s: %w", dst, err)
+		_ = os.Remove(tmp)
+		return fmt.Errorf("copying to %s: %w", tmp, err)
 	}
 	if err := out.Close(); err != nil {
-		return fmt.Errorf("closing %s: %w", dst, err)
+		_ = os.Remove(tmp)
+		return fmt.Errorf("closing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("publishing %s: %w", dst, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Found in a read-only write-atomicity audit (third slice of the review started in #111).

## Problem

`genv pull` copied the remote `genv.json` straight over the live spec with `os.Create` + `io.Copy`. A crash, Ctrl-C, or disk-full mid-copy leaves the user's spec **truncated or empty** — with no backup and no recovery path. Ironic, given the repo already ships `RotateBackup` for the lock file and temp+rename everywhere else.

## Fix

The copy now lands in a sibling temp file (`genv.json.pull-tmp`) and is renamed into place on success — matching the atomic-write pattern every other spec writer uses. CHANGELOG updated.

## Verification

- `go build` / `go vet` / pull-related tests green locally.
- Review gate recorded before push (3 checks passed).