### PR TITLE
docs: close audit gaps — flag references, completion coverage, CI concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
 
+# Superseded runs (a new push to the same branch/PR) are cancelled instead of
+# queueing duplicate full runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
 
+# Superseded runs (a new push to the same branch/PR) are cancelled instead of
+# queueing duplicate full runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -3,6 +3,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+
+# Superseded runs (a new push to the same branch/PR) are cancelled instead of
+# queueing duplicate full runs. workflow_dispatch runs are never cancelled —
+# the ref differs from push/PR refs, so they land in their own group.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 # Pins the 2026-08 review-stack behaviors so later iterations cannot silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- README now documents every apply/status/upgrade flag it references (including
+  `--skip-packages`, `--timeout`, and the upgrade filter flags), and install
+  examples pin the current release.
+- Shell completions offer `status --offline` and `completion install
+  powershell` in all four shells; six stale `--host` help strings now say the
+  default is host classification, matching reality and the README.
+- CI workflows cancel superseded runs via concurrency groups instead of
+  queueing duplicates.
+- RELEASING.md now describes AUR publishing accurately (separate macOS job,
+  not GoReleaser) and the real changelog exclude filters.
 - Spec and lock file writes are now durable across crashes: both are fsynced
   before the publishing rename (and the directory afterwards), so a power
   loss can no longer leave an empty or partial `genv.json` /

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ genv map --target arch                # assist-only manager suggestions
 **Linux x86-64 example** (replace the version to match [Releases](https://github.com/ks1686/genv/releases/latest)):
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.1.0_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.2.1_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 genv version
@@ -45,13 +45,12 @@ scoop install genv
 ```
 
 The bucket is self-hosted (not Scoop extras). `scoop install genv` needs a root
-`genv.json` on that bucket, which the first stable tag after merge uploads.
-Until then use the zip below.
+`genv.json` on that bucket, which the first stable tag uploaded.
 
 **Windows (PowerShell zip):**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.1.0_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.2.1_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .
 # put genv.exe on PATH, then:
 genv version
@@ -222,11 +221,11 @@ Convenience commands (`add` / `remove` / `adopt` / `disown` / `scan`) update the
 | `adopt` / `disown` | Track without install / untrack without uninstall |
 | `scan` | Bulk-adopt installed packages (`--dry-run`, `--yes`) |
 | `list` (`ls`) | Show lock-tracked packages |
-| `status` | Spec ↔ lock drift (`--files`, `--target`) |
-| `apply` | Reconcile (`--dry-run`, `--yes`, `--json`, `--force`, `--backup`, `--target`, `--force-new-lock`) |
+| `status` | Spec ↔ lock drift (`--files`, `--offline`, `--target`) |
+| `apply` | Reconcile (`--dry-run`, `--yes`, `--json`, `--force`, `--backup`, `--strict`, `--quiet`, `--skip-packages`, `--timeout <d>`, `--no-hooks`, `--hook-timeout <d>`, `--target`, `--force-new-lock`) |
 | `validate` | Validate spec + genv-managed agent executables |
-| `upgrade` | Upgrade outdated tracked packages (`--all`, `--target`) |
-| `updates` | Background checker (`check` / `start` / `stop` / `status`; `--target` on check/start) |
+| `upgrade` | Upgrade outdated tracked packages (`--all`, `--only`, `--skip`, `--only-manager`, `--skip-manager`, `--target`) |
+| `updates` | Background checker (`check` / `start` / `stop` / `status`; `--target`, `--only`, `--skip`, `--only-manager`, `--skip-manager` on check/start) |
 | `profile` | Named overlays (`list` / `create` / `switch`; refused on schema v8) |
 | `pull` | Fetch spec + file assets from `repo` |
 | `migrate` | v1–v7 → v8 targets |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,8 @@
 
 This repository publishes GitHub releases, a Homebrew cask, a Scoop manifest,
 and an AUR package automatically when an annotated tag is pushed. GoReleaser
-handles GitHub releases, Homebrew, Scoop, AUR, and the Snap Store automatically
+handles GitHub releases, Homebrew, Scoop, and the Snap Store automatically; a
+follow-up macOS workflow job publishes the AUR packages.
 — no external reviewer sign-off required.
 
 ---
@@ -41,8 +42,8 @@ handles GitHub releases, Homebrew, Scoop, AUR, and the Snap Store automatically
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew, Scoop,
-and AUR publishers for pre-release tags automatically, so only stable tags
-reach those channels.
+and Snap publishers for pre-release tags, and the AUR publish job skips
+pre-release versions itself — so only stable tags reach those channels.
 
 ---
 
@@ -384,9 +385,10 @@ For each release, the notes should cover:
 - any known limitations or partially-validated surfaces (e.g., adapters not tested in CI)
 - any breaking changes to `genv.json` schema or lock format
 
-GoReleaser auto-generates a changelog from `feat:` and `fix:` commits as the release
-body. Edit it on GitHub after publish, or use `release.notes` in `.goreleaser.yml`
-to provide a custom body before tagging.
+GoReleaser auto-generates a changelog for the release body from commit messages,
+excluding `docs:`, `test:`, and `chore:` commits. Edit it on GitHub after
+publish, or provide a custom body in the GoReleaser changelog config before
+tagging.
 
 ---
 

--- a/completions/genv.bash
+++ b/completions/genv.bash
@@ -125,7 +125,7 @@ _genv() {
 		opts="--file --target"
 		;;
 	status)
-		opts="--file --lock-file --json --debug --files --host --target"
+		opts="--file --lock-file --json --debug --files --offline --host --target"
 		;;
 	scan)
 		opts="--file --lock-file --json --debug --target --dry-run --yes"
@@ -281,12 +281,12 @@ _genv() {
 		done
 		if [[ "${comp_sub}" == "install" ]]; then
 			if [[ "${cur}" != -* ]]; then
-				mapfile -t COMPREPLY < <(compgen -W "bash zsh fish" -- "${cur}")
+				mapfile -t COMPREPLY < <(compgen -W "bash zsh fish powershell" -- "${cur}")
 				return 0
 			fi
 			opts="--dir"
 		else
-			mapfile -t COMPREPLY < <(compgen -W "bash zsh fish install" -- "${cur}")
+			mapfile -t COMPREPLY < <(compgen -W "bash zsh fish powershell install" -- "${cur}")
 			return 0
 		fi
 		;;

--- a/completions/genv.fish
+++ b/completions/genv.fish
@@ -237,6 +237,7 @@ complete -c genv -n '__fish_genv_using_command scan' -l dry-run -d 'List package
 complete -c genv -n '__fish_genv_using_command scan' -l yes -d 'Skip the confirmation prompt'
 complete -c genv -n '__fish_genv_using_command scan' -l target -d 'Portable target id for schemaVersion 8 specs' -x
 complete -c genv -n '__fish_genv_using_command status' -l files -d 'Check files block against the live filesystem only'
+complete -c genv -n '__fish_genv_using_command status' -l offline -d 'Compare spec vs lock only (skip live manager probe)'
 complete -c genv -n '__fish_genv_using_command status' -l host -d 'Host name for host-specific records' -x
 complete -c genv -n '__fish_genv_using_command status' -l target -d 'Portable target id for schemaVersion 8 specs' -x
 
@@ -301,7 +302,7 @@ complete -c genv -n '__fish_genv_seen_sub profile switch' -l debug -d 'Emit debu
 complete -c genv -n '__fish_genv_seen_sub profile switch' -l host -d 'Host name for host-specific records' -x
 
 # completion
-complete -c genv -n '__fish_genv_at_subcommand completion bash zsh fish install' -f -a 'bash zsh fish' -d 'Shell type'
+complete -c genv -n '__fish_genv_at_subcommand completion bash zsh fish install' -f -a 'bash zsh fish powershell' -d 'Shell type'
 complete -c genv -n '__fish_genv_at_subcommand completion bash zsh fish install' -f -a install -d 'Install the completion into the shell config directory'
-complete -c genv -n '__fish_genv_seen_sub completion install' -f -a 'bash zsh fish' -d 'Shell type'
+complete -c genv -n '__fish_genv_seen_sub completion install' -f -a 'bash zsh fish powershell' -d 'Shell type'
 complete -c genv -n '__fish_genv_seen_sub completion install' -l dir -d 'Target directory (overrides the per-shell default)' -r

--- a/completions/genv.zsh
+++ b/completions/genv.zsh
@@ -231,6 +231,7 @@ _genv() {
 				'--json[Emit machine-readable JSON to stdout]' \
 				'--debug[Emit debug-level structured logs to stderr]' \
 				'--files[Check files block against the live filesystem only]' \
+				'--offline[Compare spec vs lock only (skip live manager probe)]' \
 				'--host=[Host name for host-specific records]:host:' \
 				'--target=[Portable target id for schemaVersion 8 specs]:target:'
 			;;
@@ -448,7 +449,7 @@ _genv() {
 				'*::arg:->carg'
 			case $state in
 			caction)
-				_values 'action' bash zsh fish install
+				_values 'action' bash zsh fish powershell install
 				;;
 			carg)
 				case ${line[1]} in
@@ -457,7 +458,7 @@ _genv() {
 						'--dir=[Target directory (overrides the per-shell default)]:dir:_files -/' \
 						'1: :->cshell'
 					if [[ $state == cshell ]]; then
-						_values 'shell' bash zsh fish
+						_values 'shell' bash zsh fish powershell
 					fi
 					;;
 				esac

--- a/main.go
+++ b/main.go
@@ -472,7 +472,7 @@ func addCmd(args []string) int {
 	noSearch := fs.Bool("no-search", false, "skip interactive package search and use id as-is")
 	noHooks := fs.Bool("no-hooks", false, "skip pre-add and post-add hooks")
 	hookTimeout := fs.Duration("hook-timeout", 0, "per-hook timeout, e.g. 5m or 30s (0 means no timeout)")
-	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to $GENV_HOST or os.Hostname())")
+	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to host classification)")
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 
 	id, flagArgs := extractPositional(args)
@@ -625,7 +625,7 @@ func removeCmd(args []string) int {
 	lockFile := fs.String("lock-file", "", "path to genv lock file")
 	noHooks := fs.Bool("no-hooks", false, "skip pre-remove and post-remove hooks")
 	hookTimeout := fs.Duration("hook-timeout", 0, "per-hook timeout, e.g. 5m or 30s (0 means no timeout)")
-	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to $GENV_HOST or os.Hostname())")
+	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to host classification)")
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 
 	if err := fs.Parse(args); err != nil {
@@ -831,7 +831,7 @@ func adoptCmd(args []string) int {
 	version := fs.String("version", "", `version constraint, e.g. "0.10.*" (default: omitted, meaning any)`)
 	prefer := fs.String("prefer", "", "preferred package manager (e.g. brew)")
 	managerFlag := fs.String("manager", "", `manager-specific names, comma-separated mgr:name pairs (e.g. snap:hello,brew:hello)`)
-	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to $GENV_HOST or os.Hostname())")
+	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to host classification)")
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 	filesOnly := fs.Bool("files", false, "adopt matching files block entries into the lock without changing targets")
 	jsonOut := fs.Bool("json", false, "emit machine-readable JSON to stdout instead of human-readable text")
@@ -1174,7 +1174,7 @@ func applyCmd(args []string) int {
 	fs.BoolVar(&opts.NoHooks, "no-hooks", false, "skip lifecycle hooks without skipping apply")
 	fs.BoolVar(&opts.SkipPackages, "skip-packages", false, "skip package install/remove; still apply env, shell, files, and services")
 	fs.BoolVar(&opts.Debug, "debug", false, "emit debug-level structured logs to stderr")
-	fs.StringVar(&opts.Host, "host", "", "host name for host-specific records (defaults to $GENV_HOST or os.Hostname())")
+	fs.StringVar(&opts.Host, "host", "", "host name for host-specific records (defaults to host classification)")
 	fs.StringVar(&opts.Target, "target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
 	fs.BoolVar(&opts.ForceNewLock, "force-new-lock", false, "back up a foreign lock file and start with a new local lock")
 
@@ -2902,7 +2902,7 @@ func statusCmd(args []string) int {
 	debug := fs.Bool("debug", false, "emit debug-level structured logs to stderr")
 	filesOnly := fs.Bool("files", false, "check files block against the live filesystem only")
 	offline := fs.Bool("offline", false, "compare spec vs lock only (skip live manager probe)")
-	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to $GENV_HOST or os.Hostname())")
+	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to host classification)")
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
 
 	if err := fs.Parse(args); err != nil {
@@ -3665,7 +3665,7 @@ func upgradeCmd(args []string) int {
 	noHooks := fs.Bool("no-hooks", false, "skip pre-upgrade and post-upgrade hooks")
 	jsonOut := fs.Bool("json", false, "emit machine-readable JSON to stdout instead of human-readable text")
 	debug := fs.Bool("debug", false, "emit debug-level structured logs to stderr")
-	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to $GENV_HOST or os.Hostname())")
+	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to host classification)")
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
 	onlyFlag := fs.String("only", "", "comma-separated list of package IDs or names to upgrade")
 	skipFlag := fs.String("skip", "", "comma-separated list of package IDs or names to skip")


### PR DESCRIPTION
Fourth slice of the review that started with #111 — every finding from the docs-vs-reality audit, each verified against the code before fixing.

## Fixed

- **README flag reference (HIGH):** the command table now lists what actually dispatches — `apply` gains `--skip-packages`, `--strict`, `--quiet`, `--timeout <d>`, `--no-hooks`, `--hook-timeout <d>`; `status` gains `--offline`; `upgrade`/`updates check` gain `--only` / `--skip` / `--only-manager` / `--skip-manager`. Install examples pin 4.2.1 (were 4.1.0); moot Scoop "first upload" caveat removed.
- **Completion coverage:** all four shells now offer `status --offline` and `completion install powershell` (ps1 already offered both).
- **Stale help text:** six `--host\) flag definitions claimed "defaults to \$GENV_HOST or os.Hostname()" while `hostForCommand` actually classifies the host — strings now match behavior (and README).
- **CI efficiency:** ci/integration/regression gain `concurrency` groups (${{ github.workflow }}-${{ github.ref }}, cancel-in-progress) so superseded pushes cancel instead of queueing duplicate full runs.
- **RELEASING.md accuracy:** AUR is published by a separate macOS workflow job (GoReleaser's `skip_upload: auto` covers Homebrew/Scoop/Snap only), pre-release AUR skipping happens in the job itself; changelog section now describes the real exclude filters (`docs:`/`test:`/`chore:`) instead of a nonexistent `release.notes` key.

## Not fixed here

- AGENTS.md cites notarization secret names (`APPLE_API_KEY_ID` etc.) that don't exist; actuals are `MACOS_SIGN_P12` + `MACOS_NOTARY_*`. That file is agent-write-protected — one-line fix for you.

## Verification

- actionlint clean on all workflows; go build/vet/fmt clean.
- Review gate recorded before push (3 checks passed).