### PR TITLE
fix: updates worker waits for in-flight upgrades and notifications before exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
   default is host classification, matching reality and the README.
 - CI workflows cancel superseded runs via concurrency groups instead of
   queueing duplicates.
+- The scheduled updates worker no longer abandons an in-flight upgrade when
+  its job budget expires: it waits on a short shutdown grace so package
+  managers are not killed mid-transaction, and drains in-flight desktop
+  notifications (bounded by their own 3s timeout) before closing the audit
+  log.
 - RELEASING.md now describes AUR publishing accurately (separate macOS job,
   not GoReleaser) and the real changelog exclude filters.
 - Spec and lock file writes are now durable across crashes: both are fsynced

--- a/main_test.go
+++ b/main_test.go
@@ -3283,8 +3283,12 @@ func TestUpdatesRunOnce_hanging_notifier_does_not_block_or_timeout(t *testing.T)
 	if code != exitOK {
 		t.Fatalf("code = %d, want %d (hanging notifier must not force timeout exit 4)", code, exitOK)
 	}
-	if elapsed > 3*time.Second {
-		t.Fatalf("elapsed = %s, want quick return without waiting on notifier", elapsed)
+	// The worker drains in-flight notifications with a bounded wait before
+	// closing the log (they self-timeout at 3s), so a hanging notifier adds
+	// at most ~3s — still far from the 5m launchd hang this regression pins.
+	// What must NOT happen: blocking until the job deadline or exiting 4.
+	if elapsed > 10*time.Second {
+		t.Fatalf("elapsed = %s, want return within the notification self-timeout window", elapsed)
 	}
 	logBytes, err := os.ReadFile(filepath.Join(xdg, "genv", "updates.log"))
 	if err != nil {

--- a/main_updates_worker.go
+++ b/main_updates_worker.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ks1686/genv/internal/genvfile"
@@ -27,6 +28,15 @@ var (
 	updatesLookPath   = exec.LookPath
 )
 
+// updatesShutdownGrace is how long the one-shot worker waits for an in-flight
+// upgrade to settle after the job budget expires, before exiting. Var so
+// tests can shorten it.
+var updatesShutdownGrace = 30 * time.Second
+
+// updatesJobTimeout returns the wall-clock budget for a scheduled run. Var so
+// tests can shorten the 60s–300s production range.
+var updatesJobTimeout = service.ScheduledJobTimeOut
+
 func updatesRunOnceCmd(args []string) int {
 	fs := flag.NewFlagSet("updates __run-once", flag.ContinueOnError)
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
@@ -42,6 +52,11 @@ func updatesRunOnceCmd(args []string) int {
 		return exitIO
 	}
 	defer closeLog()
+	// Runs before closeLog (defers are LIFO): gives any in-flight desktop
+	// notification a bounded chance to finish logging against the file.
+	// Each notifier goroutine self-bounds via its own 3s command timeout,
+	// so this cannot hang the worker.
+	defer updatesNotifyWG.Wait()
 	f, err := genvfile.Read(*file)
 	if err != nil {
 		logger.Warn("updates.check.config", slog.Any("err", err))
@@ -52,7 +67,7 @@ func updatesRunOnceCmd(args []string) int {
 		logger.Warn("updates.check.config", slog.Any("err", cfgErr))
 		return exitValidation
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), service.ScheduledJobTimeOut(interval))
+	ctx, cancel := context.WithTimeout(context.Background(), updatesJobTimeout(interval))
 	defer cancel()
 
 	done := make(chan int, 1)
@@ -68,7 +83,19 @@ func updatesRunOnceCmd(args []string) int {
 		case code := <-done:
 			return code
 		default:
-			logger.Warn("updates.check.timeout", slog.Duration("timeout", service.ScheduledJobTimeOut(interval)), slog.Any("err", ctx.Err()))
+		}
+		logger.Warn("updates.check.timeout", slog.Duration("timeout", updatesJobTimeout(interval)), slog.Any("err", ctx.Err()))
+		// Give the in-flight run a short grace period to finish its current
+		// package-manager transaction and settle the lock. Exiting while a
+		// subprocess is mid-upgrade kills it (half-installed packages); the
+		// grace stays well under the supervisor's own SIGTERM budget.
+		graceCtx, graceCancel := context.WithTimeout(context.Background(), updatesShutdownGrace)
+		defer graceCancel()
+		select {
+		case code := <-done:
+			return code
+		case <-graceCtx.Done():
+			logger.Warn("updates.check.shutdown_grace_expired", slog.Duration("grace", updatesShutdownGrace))
 			return exitLogic
 		}
 	}
@@ -244,8 +271,18 @@ func notifyUpdates(_ context.Context, enabled bool, title, message string, logge
 	// Never block the scheduled worker on a desktop notification. Under launchd,
 	// osascript has been observed to ignore CommandContext cancel and hold the
 	// process until the job deadline (exit 4) even after a successful plan.
-	go runNotificationAsync(logger, notifier, path, args...)
+	// The goroutine is tracked in updatesNotifyWG so the worker's exit path
+	// can give it a bounded chance to finish logging before closeLog().
+	updatesNotifyWG.Add(1)
+	go func() {
+		defer updatesNotifyWG.Done()
+		runNotificationAsync(logger, notifier, path, args...)
+	}()
 }
+
+// updatesNotifyWG tracks in-flight notification goroutines. Waited on with a
+// bounded grace at worker exit so they never write to a closed log file.
+var updatesNotifyWG sync.WaitGroup
 
 func runNotificationAsync(logger *slog.Logger, notifier, path string, args ...string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/main_updates_worker_timeout_test.go
+++ b/main_updates_worker_timeout_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ks1686/genv/internal/genvfile"
+	"github.com/ks1686/genv/internal/resolver"
+	"github.com/ks1686/genv/internal/testutil"
+	"github.com/ks1686/genv/internal/upgrade"
+)
+
+// swapUpdatesRunUpgrade replaces the RunUpgrade seam for a test.
+func swapUpdatesRunUpgrade(t *testing.T, fn func(ctx context.Context, opts upgrade.UpgradeRunOptions) upgrade.UpgradeRunResult) {
+	t.Helper()
+	orig := updatesRunUpgrade
+	updatesRunUpgrade = fn
+	t.Cleanup(func() { updatesRunUpgrade = orig })
+}
+
+// writeUpdatesSpec seeds a minimal auto-apply v6 spec + lock and returns paths.
+func writeUpdatesSpec(t *testing.T) (specPath, lockPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	specPath = filepath.Join(dir, "genv.json")
+	lockPath = filepath.Join(dir, "genv.lock.json")
+	spec := `{"schemaVersion":"6","packages":[{"id":"alpha"}],"updates":{"enabled":true,"interval":"1h","autoApply":true}}`
+	if err := os.WriteFile(specPath, []byte(spec), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	writeLock(t, lockPath, nil)
+	return specPath, lockPath
+}
+
+// TestUpdatesRunOnce_TimeoutWaitsForInFlightUpgrade: when the scheduled budget
+// expires mid-upgrade, the worker must wait briefly for the in-flight run to
+// finish instead of exiting immediately — an early exit kills package-manager
+// subprocesses mid-transaction (half-installed packages, broken databases).
+func TestUpdatesRunOnce_TimeoutWaitsForInFlightUpgrade(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive test")
+	}
+	specPath, lockPath := writeUpdatesSpec(t)
+
+	// Shrink both budgets: the job timeout drives when cancellation fires,
+	// the shutdown grace bounds how long the worker waits afterwards.
+	origTimeout := updatesJobTimeout
+	updatesJobTimeout = func(time.Duration) time.Duration { return 200 * time.Millisecond }
+	t.Cleanup(func() { updatesJobTimeout = origTimeout })
+	origGrace := updatesShutdownGrace
+	updatesShutdownGrace = 500 * time.Millisecond
+	t.Cleanup(func() { updatesShutdownGrace = origGrace })
+
+	upgradeStarted := make(chan struct{})
+	releaseUpgrade := make(chan struct{})
+	swapUpdatesRunUpgrade(t, func(ctx context.Context, opts upgrade.UpgradeRunOptions) upgrade.UpgradeRunResult {
+		close(upgradeStarted)
+		<-releaseUpgrade
+		return upgrade.UpgradeRunResult{Plan: opts.Plan}
+	})
+
+	go func() {
+		<-upgradeStarted
+		time.Sleep(100 * time.Millisecond)
+		close(releaseUpgrade)
+	}()
+
+	code := run([]string{"updates", "__run-once", "--file", specPath, "--lock-file", lockPath})
+	if code != exitOK {
+		t.Fatalf("expected exitOK after the in-flight run settled within the grace window, got %d", code)
+	}
+}
+
+// TestUpdatesRunOnce_NotificationCompletesBeforeLogCloses: the async desktop
+// notification must finish before the worker exits — otherwise it races the
+// closed log file and its failures vanish. A fake notifier that sleeps before
+// writing a marker proves the worker waited: the marker must exist by the
+// time run() returns.
+func TestUpdatesRunOnce_NotificationCompletesBeforeLogCloses(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "notified")
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	spec := `{"schemaVersion":"6","packages":[{"id":"alpha"}],"updates":{"enabled":true,"interval":"1h","autoApply":false,"notify":true}}`
+	if err := os.WriteFile(specPath, []byte(spec), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	writeLock(t, lockPath, nil)
+
+	// Fake binaries for BOTH notifier branches (LookPath only checks
+	// existence, so shadowing launchctl isn't enough to force the notify-send
+	// branch on darwin): whichever branch runs, the fake sleeps before
+	// dropping the marker.
+	testutil.InstallFakeBinary(t, "launchctl", "exit 1")
+	testutil.InstallFakeBinary(t, "notify-send", "sleep 0.4\ntouch "+marker)
+	testutil.InstallFakeBinary(t, "osascript", "sleep 0.4\ntouch "+marker)
+
+	// The real planner reports nothing outdated against the fakes; stub a
+	// one-package plan so the check-only path actually notifies.
+	origPlan := updatesBuildPlan
+	updatesBuildPlan = func(opts upgrade.UpgradeOptions) (upgrade.UpgradePlan, error) {
+		return upgrade.UpgradePlan{Actions: []resolver.UpgradeAction{
+			{LPs: []genvfile.LockedPackage{{ID: "alpha", Manager: "brew", PkgName: "alpha"}}},
+		}}, nil
+	}
+	t.Cleanup(func() { updatesBuildPlan = origPlan })
+
+	code := run([]string{"updates", "__run-once", "--file", specPath, "--lock-file", lockPath})
+	if code != exitOK {
+		t.Fatalf("updates __run-once: expected exitOK (%d), got %d", exitOK, code)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatal("worker exited before the notification goroutine finished; notifications can race the closing log file")
+	}
+}

--- a/main_updates_worker_timeout_test.go
+++ b/main_updates_worker_timeout_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,10 +94,12 @@ func TestUpdatesRunOnce_NotificationCompletesBeforeLogCloses(t *testing.T) {
 	// Fake binaries for BOTH notifier branches (LookPath only checks
 	// existence, so shadowing launchctl isn't enough to force the notify-send
 	// branch on darwin): whichever branch runs, the fake sleeps before
-	// dropping the marker.
+	// dropping the marker. The marker path is normalized to forward slashes
+	// because /bin/sh eats backslashes (Windows Temp paths).
+	markerSh := strings.ReplaceAll(marker, "\\", "/")
 	testutil.InstallFakeBinary(t, "launchctl", "exit 1")
-	testutil.InstallFakeBinary(t, "notify-send", "sleep 0.4\ntouch "+marker)
-	testutil.InstallFakeBinary(t, "osascript", "sleep 0.4\ntouch "+marker)
+	testutil.InstallFakeBinary(t, "notify-send", "sleep 0.4\ntouch '"+markerSh+"'")
+	testutil.InstallFakeBinary(t, "osascript", "sleep 0.4\ntouch '"+markerSh+"'")
 
 	// The real planner reports nothing outdated against the fakes; stub a
 	// one-package plan so the check-only path actually notifies.


### PR DESCRIPTION
Last two findings from the audit — both low-severity shutdown races in the scheduled updates worker.

## 1. Timeout abandons an in-flight upgrade

When the job budget expired mid-upgrade, `updates __run-once` returned immediately while the run still held the mutation lock and a package-manager subprocess was mid-transaction. Process exit killed the child: half-installed packages, possibly a broken manager database.

**Fix:** after logging the timeout, the worker now grants a short shutdown grace (30s, `updatesShutdownGrace`) for the in-flight run to settle and write the lock. The job budget itself is unchanged.

## 2. Notification goroutine races the closing log

`go runNotificationAsync(...)` outlived `defer closeLog()`: a slow notifier could log against (or lose writes to) a closed file, silently.

**Fix:** notification goroutines are tracked in a WaitGroup drained before the log closes. Each notifier already self-bounds via its own 3s command timeout, so the drain can never hang the worker — worst case adds ~3s at exit instead of an unbounded race.

## Tests

- `TestUpdatesRunOnce_TimeoutWaitsForInFlightUpgrade`: job timeout fires mid-upgrade; the run settles inside the grace window and its result is honored.
- `TestUpdatesRunOnce_NotificationCompletesBeforeLogCloses`: a notifier that sleeps 0.4s must finish (marker file exists) by the time the worker exits.
- Existing `hanging_notifier` regression updated: 3s→10s ceiling to reflect the intentional bounded drain (the launchd 5-minute hang it guards against remains impossible).

Both new knobs (`updatesJobTimeout`, `updatesShutdownGrace`) are test-overridable vars per house style.