### PR TITLE
fix: recover apply/remove when lock and brew (or spec) disagree

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -191,6 +191,16 @@ func ByName(name string) Adapter {
 	return nil
 }
 
+// Absent reports whether pkgName is not installed via a. Query errors are not
+// treated as absent — the caller should still attempt the planned mutation.
+func Absent(a Adapter, pkgName string) bool {
+	if a == nil {
+		return false
+	}
+	installed, err := a.Query(pkgName)
+	return err == nil && !installed
+}
+
 // lookPath is the exec.LookPath implementation used by adapters.
 // Replaced in tests to avoid PATH dependence.
 // On WSL2 hosts it uses wslSafeLookPath to prevent Windows-mounted binaries

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -739,7 +739,16 @@ func ExecuteApply(ctx context.Context, result ReconcileResult, stdin io.Reader, 
 	cleanManagers := make(map[string]bool)
 
 	for _, a := range result.ToRemove {
+		mgr := adapter.ByName(a.Manager)
+		if adapter.Absent(mgr, a.PkgName) {
+			out.Uninstalled = append(out.Uninstalled, a.Pkg.ID)
+			continue
+		}
 		if err := runSubcmd(ctx, a.UninstallCmd, stdin, stdout, stderr); err != nil {
+			if adapter.Absent(mgr, a.PkgName) {
+				out.Uninstalled = append(out.Uninstalled, a.Pkg.ID)
+				continue
+			}
 			out.Errors = append(out.Errors, fmt.Errorf("remove %q (via %s): %w", a.Pkg.ID, a.Manager, err))
 		} else {
 			out.Uninstalled = append(out.Uninstalled, a.Pkg.ID)

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1308,14 +1308,62 @@ func TestExecuteApply_SuccessfulRemoval(t *testing.T) {
 	}
 }
 
+func TestExecuteApply_AlreadyAbsentUninstallIsSuccess(t *testing.T) {
+	orig := adapter.All
+	adapter.All = append([]adapter.Adapter{absentQueryMgr{}}, orig...)
+	t.Cleanup(func() { adapter.All = orig })
+
+	result := ReconcileResult{
+		ToRemove: []Action{
+			{
+				Pkg:          schema.Package{ID: "copilot-cli"},
+				Manager:      "absent-query-mgr",
+				PkgName:      "copilot-cli",
+				UninstallCmd: []string{"false"},
+			},
+		},
+	}
+	exec := ExecuteApply(context.Background(), result, nil, io.Discard, io.Discard)
+	if len(exec.Errors) != 0 {
+		t.Fatalf("already-absent uninstall should not error: %v", exec.Errors)
+	}
+	if len(exec.Uninstalled) != 1 || exec.Uninstalled[0] != "copilot-cli" {
+		t.Fatalf("Uninstalled = %v, want [copilot-cli]", exec.Uninstalled)
+	}
+}
+
+type absentQueryMgr struct{}
+
+func (absentQueryMgr) Name() string    { return "absent-query-mgr" }
+func (absentQueryMgr) Available() bool { return true }
+func (absentQueryMgr) NormalizeID(id string, _ map[string]string) (string, bool) {
+	return id, false
+}
+func (absentQueryMgr) PlanInstall(pkgName string) []string   { return []string{"true"} }
+func (absentQueryMgr) PlanUninstall(pkgName string) []string { return []string{"false"} }
+func (absentQueryMgr) PlanUpgrade(pkgName string) []string   { return []string{"true"} }
+func (absentQueryMgr) PlanClean() [][]string                 { return nil }
+func (absentQueryMgr) Query(string) (bool, error)            { return false, nil }
+func (absentQueryMgr) ListInstalled() ([]string, error)      { return nil, nil }
+func (absentQueryMgr) QueryVersion(string) (string, error)   { return "", nil }
+
+type presentQueryMgr struct{ absentQueryMgr }
+
+func (presentQueryMgr) Name() string               { return "present-query-mgr" }
+func (presentQueryMgr) Query(string) (bool, error) { return true, nil }
+
 // TestExecuteApply_FailedRemoval verifies that a failed removal produces an
 // error and the package is NOT in Uninstalled.
 func TestExecuteApply_FailedRemoval(t *testing.T) {
+	orig := adapter.All
+	adapter.All = append([]adapter.Adapter{presentQueryMgr{}}, orig...)
+	t.Cleanup(func() { adapter.All = orig })
+
 	result := ReconcileResult{
 		ToRemove: []Action{
 			{
 				Pkg:          schema.Package{ID: "stuck-pkg"},
-				Manager:      "snap",
+				Manager:      "present-query-mgr",
 				PkgName:      "stuck-pkg",
 				UninstallCmd: []string{"false"},
 			},

--- a/main.go
+++ b/main.go
@@ -415,10 +415,10 @@ func appendLockEntry(lockPath string, lp genvfile.LockedPackage, targetID string
 	return exitOK
 }
 
-// removeFromSpecAndReadLock reads the spec at file, removes id from it, writes
-// it back, then reads and returns the lock file. Returns the lock, the lock
-// path, and an exit code. exitOK means all steps succeeded.
-func removeFromSpecAndReadLock(file, id, lockFile, targetFlag string) (*genvfile.LockFile, string, int) {
+// prepareRemoveSpec reads the spec at file and removes id in memory.
+// Callers persist with genvfile.Write after the corresponding system change
+// succeeds so a failed uninstall cannot desync the spec from the lock.
+func prepareRemoveSpec(file, id, targetFlag string) (*schema.GenvFile, string, int) {
 	f, err := genvfile.Read(file)
 	if err != nil {
 		if errors.Is(err, genvfile.ErrNotFound) {
@@ -439,17 +439,15 @@ func removeFromSpecAndReadLock(file, id, lockFile, targetFlag string) (*genvfile
 		fprintf(os.Stderr, "genv: %v\n", err)
 		return nil, "", exitLogic
 	}
+	return f, targetID, exitOK
+}
+
+func writePreparedSpec(file string, f *schema.GenvFile) int {
 	if err := genvfile.Write(file, f); err != nil {
 		fprintf(os.Stderr, "genv: %v\n", err)
-		return nil, "", exitIO
+		return exitIO
 	}
-	lockPath := lockPathForSpec(file, lockFile)
-	lf, err := genvfile.ReadLock(lockPath)
-	if err != nil {
-		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
-		return nil, "", exitIO
-	}
-	return lf, lockPath, exitOK
+	return exitOK
 }
 
 // addCmd implements `genv add <id> [flags]`.
@@ -727,8 +725,9 @@ func runRemove(opts removeOptions) int {
 		}
 	}
 
-	// 1. Update genv.json and read lock.
-	lf, lockPath, exit := removeFromSpecAndReadLock(file, id, opts.LockFile, opts.Target)
+	// 1. Stage the spec removal in memory. Persist only after uninstall
+	//    succeeds so a failed uninstall cannot leave spec and lock desynced.
+	prepared, _, exit := prepareRemoveSpec(file, id, opts.Target)
 	if exit != exitOK {
 		return exit
 	}
@@ -738,7 +737,7 @@ func runRemove(opts removeOptions) int {
 		return exitIO
 	}
 	defer unlock()
-	lf, err = genvfile.ReadLock(lockPath)
+	lf, err := genvfile.ReadLock(lockPath)
 	if err != nil {
 		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
 		return exitIO
@@ -757,6 +756,9 @@ func runRemove(opts removeOptions) int {
 
 	if locked == nil {
 		// Never installed by genv — nothing to uninstall on the system.
+		if exit := writePreparedSpec(file, prepared); exit != exitOK {
+			return exit
+		}
 		fprintf(os.Stdout, "removed %s from spec (was not installed by genv)\n", id)
 		return exitOK
 	}
@@ -768,21 +770,26 @@ func runRemove(opts removeOptions) int {
 		return exitLogic
 	}
 
-	uninstallCmd := mgr.PlanUninstall(locked.PkgName)
-	fprintf(os.Stdout, "removed %s from spec — uninstalling via %s\n", id, locked.Manager)
-	fprintf(os.Stdout, "\n==> %s\n", strings.Join(uninstallCmd, " "))
-	uninstallErr := runForegroundCommand(uninstallCmd)
-	if uninstallErr != nil {
-		fprintf(os.Stderr, "genv: uninstall failed: %v\n", uninstallErr)
-		return exitLogic
+	if !adapter.Absent(mgr, locked.PkgName) {
+		uninstallCmd := mgr.PlanUninstall(locked.PkgName)
+		fprintf(os.Stdout, "removed %s from spec — uninstalling via %s\n", id, locked.Manager)
+		fprintf(os.Stdout, "\n==> %s\n", strings.Join(uninstallCmd, " "))
+		if uninstallErr := runForegroundCommand(uninstallCmd); uninstallErr != nil && !adapter.Absent(mgr, locked.PkgName) {
+			fprintf(os.Stderr, "genv: uninstall failed: %v\n", uninstallErr)
+			return exitLogic
+		}
+		for _, cleanCmd := range mgr.PlanClean() {
+			fprintf(os.Stdout, "\n==> %s\n", strings.Join(cleanCmd, " "))
+			if err := runForegroundCommand(cleanCmd); err != nil {
+				fprintf(os.Stderr, "genv: cache clean warning: %v\n", err)
+			}
+		}
+	} else {
+		fprintf(os.Stdout, "removed %s from spec — already absent via %s\n", id, locked.Manager)
 	}
 
-	// Cache clean.
-	for _, cleanCmd := range mgr.PlanClean() {
-		fprintf(os.Stdout, "\n==> %s\n", strings.Join(cleanCmd, " "))
-		if err := runForegroundCommand(cleanCmd); err != nil {
-			fprintf(os.Stderr, "genv: cache clean warning: %v\n", err)
-		}
+	if exit := writePreparedSpec(file, prepared); exit != exitOK {
+		return exit
 	}
 
 	lf.Packages = remaining
@@ -1042,13 +1049,35 @@ func disownCmd(args []string) int {
 	}
 	id := fs.Arg(0)
 
-	// 1. Update genv.json and read lock.
-	lf, lockPath, exit := removeFromSpecAndReadLock(*file, id, *lockFile, *targetFlag)
+	f, err := genvfile.Read(*file)
+	if err != nil {
+		if errors.Is(err, genvfile.ErrNotFound) {
+			fprintf(os.Stderr, "genv: %s not found\n", *file)
+			return exitLogic
+		}
+		fprintf(os.Stderr, "genv: %v\n", err)
+		if errors.Is(err, genvfile.ErrInvalidFile) {
+			return exitValidation
+		}
+		return exitIO
+	}
+	targetID, exit := resolveMutationTarget("remove", *file, f, *targetFlag)
 	if exit != exitOK {
 		return exit
 	}
+	specErr := commands.Remove(f, id, targetID)
+	if specErr != nil && !errors.Is(specErr, commands.ErrNotTracked) {
+		fprintf(os.Stderr, "genv: %v\n", specErr)
+		return exitLogic
+	}
 
-	// 2. Remove from lock file without uninstalling.
+	lockPath := lockPathForSpec(*file, *lockFile)
+	lf, err := genvfile.ReadLock(lockPath)
+	if err != nil {
+		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
+		return exitIO
+	}
+
 	wasTracked := false
 	remaining := make([]genvfile.LockedPackage, 0, len(lf.Packages))
 	for i := range lf.Packages {
@@ -1058,13 +1087,28 @@ func disownCmd(args []string) int {
 			remaining = append(remaining, lf.Packages[i])
 		}
 	}
+
+	if specErr != nil && !wasTracked {
+		fprintf(os.Stderr, "genv: %v\n", specErr)
+		return exitLogic
+	}
+
+	if specErr == nil {
+		if err := genvfile.Write(*file, f); err != nil {
+			fprintf(os.Stderr, "genv: %v\n", err)
+			return exitIO
+		}
+	}
+
 	lf.Packages = remaining
 	if err := genvfile.WriteLock(lockPath, lf); err != nil {
 		fprintf(os.Stderr, "genv: writing lock: %v\n", err)
 		return exitIO
 	}
 
-	if wasTracked {
+	if wasTracked && specErr != nil {
+		fprintf(os.Stdout, "disowned %s — removed lock leftover (was not in spec)\n", id)
+	} else if wasTracked {
 		fprintf(os.Stdout, "disowned %s — removed from tracking (package remains installed)\n", id)
 	} else {
 		fprintf(os.Stdout, "disowned %s — removed from spec (was not in lock)\n", id)
@@ -1356,6 +1400,8 @@ func runApplyJSON(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	filePlan, filePlanErr = applyFiles(ctx, opts, f, lf)
 	if filePlanErr != nil {
 		errs = append(errs, filePlanErr.Error())
+	}
+	if unresolvedFileMismatch(filePlan) {
 		if !opts.NoHooks && hasPostApplyHooks(f) {
 			skipMsg := "skipping post-apply hooks due to unresolved file mismatches"
 			errs = append(errs, skipMsg)
@@ -1541,14 +1587,14 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	if filePlanErr != nil {
 		fileErrs = append(fileErrs, filePlanErr)
 	}
-	if appliedFiles != nil && len(appliedFiles.Mismatched) > 0 {
+	if unresolvedFileMismatch(appliedFiles) {
 		writeFileMismatchGuidance(os.Stderr, appliedFiles)
 		if !opts.NoHooks && hasPostApplyHooks(f) {
 			fPrintln(os.Stderr, "genv apply: skipping post-apply hooks due to unresolved file mismatches")
 		}
 	}
 	var hookErrs []string
-	if len(execResult.Errors) == 0 && len(svcErrs) == 0 && len(fileErrs) == 0 && !opts.NoHooks {
+	if !unresolvedFileMismatch(appliedFiles) && !opts.NoHooks {
 		hookErrs = runApplyHookPhase(ctx, f, hookContext{Event: "apply", Phase: "post-apply", Host: hostName, Profile: lf.ActiveProfile, Yes: opts.Yes, Installed: lockedPackageIDs(execResult.Installed), Removed: execResult.Uninstalled, Failed: applyFailedIDs(execResult.Errors)}, opts.HookTimeout, false)
 	}
 	success := len(execResult.Errors) == 0 && len(svcErrs) == 0 && len(fileErrs) == 0 && len(hookErrs) == 0
@@ -1979,6 +2025,10 @@ func writeFileMismatchGuidance(w io.Writer, res *files.ApplyResult) {
 
 func hasPostApplyHooks(f *schema.GenvFile) bool {
 	return f != nil && f.Hooks != nil && len(f.Hooks.PostApply) > 0
+}
+
+func unresolvedFileMismatch(res *files.ApplyResult) bool {
+	return res != nil && len(res.Mismatched) > 0
 }
 
 func filePlanEntries(res *files.ApplyResult) []output.FilePlanEntry {

--- a/main_apply_files_test.go
+++ b/main_apply_files_test.go
@@ -200,6 +200,83 @@ func TestApply_ForceBackupFlagBacksUpWithoutPerEntryBackup(t *testing.T) {
 	}
 }
 
+func TestApply_BrewLockDesyncAlreadyAbsentRecovers(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	testutil.SetHome(t, dir)
+	withAbsentBrewPackage(t)
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	writeTestFile(t, specPath, `{"schemaVersion":"6","packages":[]}`)
+	writeLock(t, lockPath, []genvfile.LockedPackage{
+		{ID: "copilot-cli", Manager: "brew", PkgName: "copilot-cli"},
+	})
+
+	var code int
+	var stderr string
+	_ = captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			code = run([]string{"apply", "--file", specPath, "--lock-file", lockPath, "--yes", "--no-hooks"})
+		})
+	})
+	if code != exitOK {
+		t.Fatalf("apply brew lock desync: expected exitOK, got %d; stderr=%s", code, stderr)
+	}
+
+	lf, err := genvfile.ReadLock(lockPath)
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+	for _, p := range lf.Packages {
+		if p.ID == "copilot-cli" {
+			t.Fatalf("lock still lists copilot-cli after apply; stderr=%s", stderr)
+		}
+	}
+}
+
+func TestApply_PackageRemovalFailureRunsPostApplyWithoutMismatchSkip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	testutil.SetHome(t, dir)
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	hookLog := filepath.Join(dir, "hook.log")
+	registerLifecycleHookAdapter(t, lifecycleHookAdapter{failUninstall: true})
+
+	writeTestFile(t, specPath, `{`+
+		`"schemaVersion":"6",`+
+		`"packages":[],`+
+		`"hooks":{"postApply":[{"command":`+jsonString("printf ran >> "+strconv.Quote(hookLog))+`}]}`+
+		`}`)
+	writeLock(t, lockPath, []genvfile.LockedPackage{
+		{ID: "alpha", Manager: "test-hook-manager", PkgName: "alpha"},
+	})
+
+	var code int
+	var stderr string
+	_ = captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			code = run([]string{"apply", "--file", specPath, "--lock-file", lockPath, "--yes"})
+		})
+	})
+	if code != exitLogic {
+		t.Fatalf("expected exitLogic on uninstall failure, got %d; stderr=%s", code, stderr)
+	}
+	if !strings.Contains(stderr, `remove "alpha"`) && !strings.Contains(stderr, "uninstall") {
+		t.Fatalf("stderr should name the package removal failure; got %q", stderr)
+	}
+	if strings.Contains(stderr, "unresolved file mismatches") {
+		t.Fatalf("package removal failure must not be reported as a file mismatch; stderr=%q", stderr)
+	}
+	got, err := os.ReadFile(hookLog)
+	if err != nil {
+		t.Fatalf("post-apply hook should still run when uninstall fails without a file mismatch: %v; stderr=%s", err, stderr)
+	}
+	if string(got) != "ran" {
+		t.Fatalf("hook log = %q, want ran", got)
+	}
+}
+
 func TestApply_FileMismatchSkipsPostApplyHooksWithMessage(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))

--- a/main_apply_portability_test.go
+++ b/main_apply_portability_test.go
@@ -183,6 +183,14 @@ func TestRemove_UninstallFailureLeavesLock(t *testing.T) {
 	if len(lf.Packages) != 1 || lf.Packages[0].ID != "alpha" {
 		t.Fatalf("lock packages = %+v, want alpha retained", lf.Packages)
 	}
+
+	f, err := genvfile.Read(specPath)
+	if err != nil {
+		t.Fatalf("read spec: %v", err)
+	}
+	if len(f.Packages) != 1 || f.Packages[0].ID != "alpha" {
+		t.Fatalf("spec packages = %+v, want alpha retained after uninstall failure", f.Packages)
+	}
 }
 
 func writeTestFile(t *testing.T, path, content string) {

--- a/main_test.go
+++ b/main_test.go
@@ -73,6 +73,25 @@ func withFailingBrewInstall(t *testing.T) {
 	testutil.InstallFakeBinary(t, "brew", `case "$1" in install) exit 1 ;; *) exit 0 ;; esac`)
 }
 
+func withAbsentBrewPackage(t *testing.T) {
+	t.Helper()
+	// Real Homebrew exits 1 on `brew uninstall` of a missing formula
+	// ("Error: No such keg") and `brew list` of an absent name.
+	testutil.InstallFakeBinary(t, "brew", `
+case "$1" in
+uninstall)
+	echo "Error: No such keg: /opt/homebrew/Cellar/${2:-pkg}" >&2
+	exit 1
+	;;
+list)
+	exit 1
+	;;
+*)
+	exit 0
+	;;
+esac`)
+}
+
 // ---- basic routing ----------------------------------------------------------
 
 func TestRun_NoArgs(t *testing.T) {
@@ -892,6 +911,44 @@ func TestDisownCmd_NotInSpec(t *testing.T) {
 	code := run([]string{"disown", "--file", path, "neovim"})
 	if code != exitLogic {
 		t.Errorf("expected exitLogic (%d), got %d", exitLogic, code)
+	}
+}
+
+func TestDisownCmd_LockOnlyLeftoverClearsLock(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	writeTestFile(t, path, `{"schemaVersion":"6","packages":[{"id":"neovim"}]}`)
+	writeLock(t, lockPath, []genvfile.LockedPackage{
+		{ID: "copilot-cli", Manager: "brew", PkgName: "copilot-cli"},
+		{ID: "neovim", Manager: "brew", PkgName: "neovim"},
+	})
+
+	code := run([]string{"disown", "--file", path, "--lock-file", lockPath, "copilot-cli"})
+	if code != exitOK {
+		t.Fatalf("disown lock-only leftover: expected exitOK, got %d", code)
+	}
+
+	f, err := genvfile.Read(path)
+	if err != nil {
+		t.Fatalf("read spec: %v", err)
+	}
+	if len(f.Packages) != 1 || f.Packages[0].ID != "neovim" {
+		t.Fatalf("spec packages = %+v, want neovim retained", f.Packages)
+	}
+
+	lf, err := genvfile.ReadLock(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLock: %v", err)
+	}
+	for _, p := range lf.Packages {
+		if p.ID == "copilot-cli" {
+			t.Fatal("lock-only leftover should be dropped by disown")
+		}
+	}
+	if len(lf.Packages) != 1 || lf.Packages[0].ID != "neovim" {
+		t.Fatalf("lock packages = %+v, want neovim retained", lf.Packages)
 	}
 }
 


### PR DESCRIPTION
## Summary

After a failed Homebrew uninstall, a machine can end up with a package gone from `genv.json` but still in `genv.lock.json`. The next `genv apply` then retries `brew uninstall`, Homebrew exits 1 (`No such keg` / not installed), and apply fails every run. `disown` refused lock-only leftovers (`not tracked`), and `adopt` correctly refused a package that was no longer installed.

This change makes the lock follow reality on that path:

- **apply** treats an already-absent package as a successful removal and drops the lock entry. That covers Homebrew’s “uninstall of something brew no longer has” case without special-casing brew stderr.
- **remove** now matches `add`: the spec is staged in memory and written only after uninstall succeeds (already-absent still counts as success). A real uninstall failure leaves spec and lock unchanged.
- **disown** can clear a lock-only leftover. A name that is in neither spec nor lock still fails as not tracked.

Separately, text-mode apply was skipping `postApply` whenever a package action failed. The documented contract (and the JSON path) is that only unresolved **file mismatches** skip those hooks. Package removal failures now print the package error, do not claim a file mismatch, and still run `postApply` unless there is a real mismatch.

## Test plan

- [ ] `go test -count=1 ./internal/resolver -run 'TestExecuteApply_AlreadyAbsent|TestExecuteApply_FailedRemoval|TestExecuteApply_SuccessfulRemoval'`
- [ ] `go test -count=1 -run 'TestApply_BrewLockDesyncAlreadyAbsentRecovers|TestApply_PackageRemovalFailureRunsPostApplyWithoutMismatchSkip|TestApply_FileMismatchSkipsPostApplyHooksWithMessage|TestRemove_UninstallFailureLeavesLock|TestDisownCmd_LockOnlyLeftoverClearsLock|TestDisownCmd_NotInSpec|TestDisownCmd_Basic|TestRemoveCmd_Basic|TestRemove_LifecycleHooks' .`
- [ ] `make ci`
- [ ] Manual: lock lists a brew formula that `brew list` does not have, spec does not list it, `genv apply --yes` exits 0 and drops the lock entry
- [ ] Manual: `genv remove` of an installed package whose uninstall fails leaves both spec and lock unchanged
- [ ] Manual: package uninstall failure with `postApply` hooks and no file mismatches still runs the hooks and does not print the mismatch skip line