### PR TITLE
fix: do not treat unimplemented Query as absent

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -201,6 +201,13 @@ func Absent(a Adapter, pkgName string) bool {
 	return err == nil && !installed
 }
 
+// queryUnsupported is for adapters that cannot report installed state.
+// Returning an error (not false, nil) keeps Absent() from treating the
+// package as gone and dropping the lock without an uninstall attempt.
+func queryUnsupported(manager, pkgName string) (bool, error) {
+	return false, fmt.Errorf("%s: cannot determine whether %q is installed", manager, pkgName)
+}
+
 // lookPath is the exec.LookPath implementation used by adapters.
 // Replaced in tests to avoid PATH dependence.
 // On WSL2 hosts it uses wslSafeLookPath to prevent Windows-mounted binaries

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -63,6 +63,42 @@ func TestByName(t *testing.T) {
 	}
 }
 
+type absentQueryStub struct {
+	installed bool
+	err       error
+}
+
+func (absentQueryStub) Name() string    { return "absent-query-stub" }
+func (absentQueryStub) Available() bool { return true }
+func (absentQueryStub) NormalizeID(id string, _ map[string]string) (string, bool) {
+	return id, false
+}
+func (absentQueryStub) PlanInstall(pkgName string) []string   { return []string{"true"} }
+func (absentQueryStub) PlanUninstall(pkgName string) []string { return []string{"true"} }
+func (absentQueryStub) PlanUpgrade(pkgName string) []string   { return []string{"true"} }
+func (absentQueryStub) PlanClean() [][]string                 { return nil }
+func (s absentQueryStub) Query(string) (bool, error)          { return s.installed, s.err }
+func (absentQueryStub) ListInstalled() ([]string, error)      { return nil, nil }
+func (absentQueryStub) QueryVersion(string) (string, error)   { return "", nil }
+
+func TestAbsent_QueryErrorIsNotAbsent(t *testing.T) {
+	if Absent(absentQueryStub{err: errors.New("brew list timed out")}, "jq") {
+		t.Fatal("Query error must not be treated as absent")
+	}
+}
+
+func TestAbsent_ConfirmedAbsent(t *testing.T) {
+	if !Absent(absentQueryStub{}, "jq") {
+		t.Fatal("Query false, nil must be treated as absent")
+	}
+	if Absent(absentQueryStub{installed: true}, "jq") {
+		t.Fatal("Query true, nil must not be treated as absent")
+	}
+	if Absent(nil, "jq") {
+		t.Fatal("nil adapter must not be treated as absent")
+	}
+}
+
 // TestNormalizeID_ExplicitMapping verifies that a manager-specific name in the
 // managers map takes precedence over the canonical ID.
 func TestNormalizeID_ExplicitMapping(t *testing.T) {

--- a/internal/adapter/asdf.go
+++ b/internal/adapter/asdf.go
@@ -58,7 +58,7 @@ func (Asdf) PlanUpgrade(pkgName string) []string {
 
 func (Asdf) PlanClean() [][]string { return nil }
 
-func (Asdf) Query(string) (bool, error) { return false, nil }
+func (Asdf) Query(pkgName string) (bool, error) { return queryUnsupported("asdf", pkgName) }
 
 func (Asdf) ListInstalled() ([]string, error) { return nil, nil }
 

--- a/internal/adapter/lang_ecosystem_test.go
+++ b/internal/adapter/lang_ecosystem_test.go
@@ -112,3 +112,16 @@ func TestStack_PlanCommands_whenTrackedAndUninstallUnsupported(t *testing.T) {
 		t.Errorf("PlanUninstall = %v, want failing unsupported command", got)
 	}
 }
+
+func TestStack_QueryDoesNotClaimAbsent(t *testing.T) {
+	ok, err := Stack{}.Query("hlint")
+	if err == nil {
+		t.Fatal("Query must not claim a confirmed-absent result when inventory is unimplemented")
+	}
+	if ok {
+		t.Fatalf("Query = true, want false with error")
+	}
+	if Absent(Stack{}, "hlint") {
+		t.Fatal("Absent must be false when Query errors — otherwise apply drops the lock without running the failing uninstall")
+	}
+}

--- a/internal/adapter/sdkman.go
+++ b/internal/adapter/sdkman.go
@@ -46,7 +46,7 @@ func (Sdkman) PlanClean() [][]string {
 	return [][]string{{"sdk", "flush", "temp"}}
 }
 
-func (Sdkman) Query(string) (bool, error) { return false, nil }
+func (Sdkman) Query(pkgName string) (bool, error) { return queryUnsupported("sdkman", pkgName) }
 
 func (Sdkman) ListInstalled() ([]string, error) { return nil, nil }
 

--- a/internal/adapter/stack.go
+++ b/internal/adapter/stack.go
@@ -31,7 +31,7 @@ func (Stack) PlanUpgrade(pkgName string) []string {
 
 func (Stack) PlanClean() [][]string { return nil }
 
-func (Stack) Query(string) (bool, error) { return false, nil }
+func (Stack) Query(pkgName string) (bool, error) { return queryUnsupported("stack", pkgName) }
 
 func (Stack) ListInstalled() ([]string, error) { return nil, nil }
 

--- a/internal/adapter/universal_manager_test.go
+++ b/internal/adapter/universal_manager_test.go
@@ -53,6 +53,32 @@ func TestAsdf_PlanCommands_whenPluginOrToolID(t *testing.T) {
 	}
 }
 
+func TestAsdf_QueryDoesNotClaimAbsent(t *testing.T) {
+	ok, err := Asdf{}.Query("tool:nodejs@22.11.0")
+	if err == nil {
+		t.Fatal("Query must not claim a confirmed-absent result when inventory is unimplemented")
+	}
+	if ok {
+		t.Fatalf("Query = true, want false with error")
+	}
+	if Absent(Asdf{}, "tool:nodejs@22.11.0") {
+		t.Fatal("Absent must be false when Query errors")
+	}
+}
+
+func TestSdkman_QueryDoesNotClaimAbsent(t *testing.T) {
+	ok, err := Sdkman{}.Query("java:21.0.2-tem")
+	if err == nil {
+		t.Fatal("Query must not claim a confirmed-absent result when inventory is unimplemented")
+	}
+	if ok {
+		t.Fatalf("Query = true, want false with error")
+	}
+	if Absent(Sdkman{}, "java:21.0.2-tem") {
+		t.Fatal("Absent must be false when Query errors")
+	}
+}
+
 func TestAsdf_PlanInstall_whenIDInvalidFailsActionably(t *testing.T) {
 	a := Asdf{}
 	for _, id := range []string{"nodejs", "plugin:", "tool:nodejs", "tool:@22", "tool:nodejs@", ""} {

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os/exec"
 	"slices"
@@ -1352,6 +1353,11 @@ type presentQueryMgr struct{ absentQueryMgr }
 func (presentQueryMgr) Name() string               { return "present-query-mgr" }
 func (presentQueryMgr) Query(string) (bool, error) { return true, nil }
 
+type errorQueryMgr struct{ absentQueryMgr }
+
+func (errorQueryMgr) Name() string               { return "error-query-mgr" }
+func (errorQueryMgr) Query(string) (bool, error) { return false, errors.New("query timed out") }
+
 // TestExecuteApply_FailedRemoval verifies that a failed removal produces an
 // error and the package is NOT in Uninstalled.
 func TestExecuteApply_FailedRemoval(t *testing.T) {
@@ -1376,6 +1382,30 @@ func TestExecuteApply_FailedRemoval(t *testing.T) {
 	}
 	if len(exec.Uninstalled) != 0 {
 		t.Errorf("Uninstalled: got %v, want empty (failed removal must not appear)", exec.Uninstalled)
+	}
+}
+
+func TestExecuteApply_QueryErrorDoesNotTreatFailedUninstallAsSuccess(t *testing.T) {
+	orig := adapter.All
+	adapter.All = append([]adapter.Adapter{errorQueryMgr{}}, orig...)
+	t.Cleanup(func() { adapter.All = orig })
+
+	result := ReconcileResult{
+		ToRemove: []Action{
+			{
+				Pkg:          schema.Package{ID: "stuck-pkg"},
+				Manager:      "error-query-mgr",
+				PkgName:      "stuck-pkg",
+				UninstallCmd: []string{"false"},
+			},
+		},
+	}
+	exec := ExecuteApply(context.Background(), result, nil, io.Discard, io.Discard)
+	if len(exec.Errors) == 0 {
+		t.Fatal("Query error must not convert a failed uninstall into success")
+	}
+	if len(exec.Uninstalled) != 0 {
+		t.Errorf("Uninstalled: got %v, want empty (Query error is not confirmed absent)", exec.Uninstalled)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the apply/remove/lock recovery on main (`2892952`). That change treats a confirmed-absent `Query` as a successful uninstall and drops the lock. Most managers implement a real `Query`. Three did not: **asdf**, **sdkman**, and **stack** always returned `(false, nil)`.

Apply and `remove` then skipped uninstall and dropped the lock even when the package was still installed. For stack that also skipped the intentional failing uninstall (`stack has no safe global uninstall`).

`Query` on those adapters now returns an error. `adapter.Absent` already refuses to treat Query errors as absent, so uninstall still runs and a failed uninstall keeps the lock. Use `disown` when inventory cannot confirm the package is gone.

## Test plan

- [ ] `go test -count=1 ./internal/adapter ./internal/resolver -run 'TestAbsent_|TestAsdf_Query|TestSdkman_Query|TestStack_Query|TestExecuteApply_QueryError|TestExecuteApply_AlreadyAbsent|TestExecuteApply_FailedRemoval'`
- [ ] `go test -count=1 -run 'TestApply_BrewLockDesyncAlreadyAbsentRecovers|TestApply_PackageRemovalFailureRunsPostApplyWithoutMismatchSkip|TestRemove_UninstallFailureLeavesLock|TestDisownCmd_LockOnlyLeftoverClearsLock|TestRemoveCmd_NotFound|TestAddCmd_InstallFailureLeavesSpecUnchanged' .`
- [ ] `make ci`