### PR TITLE
docs: cut CHANGELOG for v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-### Fixed
-
-- `genv updates check` / `genv upgrade` no longer treat VS Code/Cursor
-  extensions as perpetually outdated. The vscode adapter now queries the
-  editor's marketplace (from `product.json`, so Cursor uses
-  marketplace.cursorapi.com) and compares against the newest **stable**
-  version. Pre-release gallery versions are skipped; the emitted command
-  remains `code --install-extension <id> --force`, which cannot install
-  pre-releases. Previously vscode had no `OutdatedLister`, so every
-  tracked extension was kept on every check.
+## v4.3.0 - 2026-09-03
 
 ### Added
 
@@ -37,6 +28,26 @@ All notable changes to this project will be documented in this file.
   abort later steps. `genv updates check`, the timer, and `updates.autoApply`
   remain tracked packages only. Further steps (rustup, editors, containers, and
   other extra tools) land in follow-ups.
+
+### Fixed
+
+- `genv updates check` / `genv upgrade` no longer treat VS Code/Cursor
+  extensions as perpetually outdated. The vscode adapter now queries the
+  editor's marketplace (from `product.json`, so Cursor uses
+  marketplace.cursorapi.com) and compares against the newest **stable**
+  version. Pre-release gallery versions are skipped; the emitted command
+  remains `code --install-extension <id> --force`, which cannot install
+  pre-releases. Previously vscode had no `OutdatedLister`, so every
+  tracked extension was kept on every check.
+- `genv apply` recovers when the lock and the manager disagree: uninstalling
+  a package that is already gone is treated as success and the lock entry is
+  dropped. `genv remove` writes the spec only after uninstall succeeds, and
+  `genv disown` can clear lock-only leftovers. Package removal failures no
+  longer skip post-apply hooks unless there is a real unresolved file mismatch.
+- asdf, sdkman, and stack `Query` no longer report absent for packages they
+  cannot inspect. After apply's Query-based uninstall recovery, that false
+  absent dropped the lock while the package was still installed. Those adapters
+  now return an error so uninstall still runs.
 
 ## v4.2.2 - 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ genv map --target arch                # assist-only manager suggestions
 **Linux x86-64 example** (replace the version to match [Releases](https://github.com/ks1686/genv/releases/latest)):
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.2.1_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.3.0_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 genv version
@@ -50,7 +50,7 @@ The bucket is self-hosted (not Scoop extras). `scoop install genv` needs a root
 **Windows (PowerShell zip):**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.2.1_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.3.0_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .
 # put genv.exe on PATH, then:
 genv version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,6 +40,7 @@ follow-up macOS workflow job publishes the AUR packages.
 | `v4.2.0` | Windows apply skip-if-present, 10m timeout, live status, `--skip-packages`, `external` manager |
 | `v4.2.1` | Apply/status list only needed managers; 30s listing timeout so hung Composer cannot stall Windows CI |
 | `v4.2.2` | Every manager probe bounded (scan/search/upgrade/outdated/services); crash-safe fsync'd spec & lock writes; atomic pull; docs/completions/CI fixes; updates worker shutdown grace |
+| `v4.3.0` | Windows updates scheduler, vscode stable-only outdated detection, lock/apply recovery, and `genv upgrade` OS/firmware steps |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew, Scoop,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move Unreleased notes into `v4.3.0` (2026-09-03) and leave a fresh empty Unreleased heading.

Covers:
- Windows Task Scheduler for `genv updates` (#118)
- apply/remove lock recovery when brew/manager and lock disagree (#119)
- asdf/sdkman/stack Query no longer reports absent (#120)
- vscode marketplace stable-only outdated detection (#121)
- OS/firmware steps on `genv upgrade` (#122)

Also pins README install archive examples to 4.3.0 and adds a Versioning row in RELEASING.md.

Do not tag until this PR is merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc4f93be-3ff1-4481-be65-5b6ecd4c0649?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc4f93be-3ff1-4481-be65-5b6ecd4c0649&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

