### PR TITLE
docs: cut CHANGELOG for v4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file.
   `WshShell.Run`s the existing `.cmd` with window style 0. `<Hidden>true</Hidden>`
   alone does not hide `cmd.exe`. `updates.log` and one completion notification
   are unchanged. Do not flip `genv.exe` to the Windows GUI subsystem.
+  `updates stop` now ends the running task before delete and retries removing
+  the `.vbs` host if `wscript` still has it open (sharing violation).
 - The `vscode` adapter now prefers `cursor` on PATH, then `code`. Cursor-only
   hosts can scan, adopt, and upgrade extensions without a `code` shim.
   VS Code-only hosts (`code`, no `cursor`) are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v4.3.1 - 2026-09-05
+
 ### Fixed
 
 - `genv upgrade --json` wet-run now requires `--yes` to execute (or `--dry-run`
@@ -13,7 +15,6 @@ All notable changes to this project will be documented in this file.
   shell completions. `--only` and positionals merge.
 - Upgrade and index-refresh planning skip a manager when `Available()` is false
   and record an explicit reason, instead of emitting commands that cannot run.
-
 - `genv apply --skip-packages` no longer inventories live package managers or
   prints the per-package `(up to date)` table. The header names files/env/services
   instead of a package count, and JSON omits the package plan the same way.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ genv map --target arch                # assist-only manager suggestions
 **Linux x86-64 example** (replace the version to match [Releases](https://github.com/ks1686/genv/releases/latest)):
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.3.0_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.3.1_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 genv version
@@ -50,7 +50,7 @@ The bucket is self-hosted (not Scoop extras). `scoop install genv` needs a root
 **Windows (PowerShell zip):**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.3.0_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.3.1_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .
 # put genv.exe on PATH, then:
 genv version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,6 +41,7 @@ follow-up macOS workflow job publishes the AUR packages.
 | `v4.2.1` | Apply/status list only needed managers; 30s listing timeout so hung Composer cannot stall Windows CI |
 | `v4.2.2` | Every manager probe bounded (scan/search/upgrade/outdated/services); crash-safe fsync'd spec & lock writes; atomic pull; docs/completions/CI fixes; updates worker shutdown grace |
 | `v4.3.0` | Windows updates scheduler, vscode stable-only outdated detection, lock/apply recovery, and `genv upgrade` OS/firmware steps |
+| `v4.3.1` | Index refresh before outdated; user-facing `scan` default; apply `--skip-packages` quiet; vscode prefers `cursor`; hidden Windows updates host; upgrade `--json`/`--only` polish |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew, Scoop,

--- a/internal/service/scheduled_schtasks.go
+++ b/internal/service/scheduled_schtasks.go
@@ -20,6 +20,13 @@ const (
 	schtasksRepetitionDuration = "P3650D"
 )
 
+// wscript can keep the .vbs mapped for a short time after schtasks /Delete.
+// Retry just long enough for the host to exit; do not block stop on a wedged job.
+var (
+	scheduledRemoveRetryDelay  = 50 * time.Millisecond
+	scheduledRemoveRetryBudget = 2 * time.Second
+)
+
 // schtasksRun invokes schtasks.exe. Tests replace it so Linux CI can cover
 // register/status/stop without a Windows host.
 var schtasksRun = func(ctx context.Context, args ...string) ([]byte, error) {
@@ -105,6 +112,7 @@ func startSchtasksScheduledJob(ctx context.Context, job ScheduledJob) error {
 
 func stopSchtasksScheduledJob(ctx context.Context, name string) error {
 	taskName := schtasksTaskName(name)
+	_, _ = schtasksRun(ctx, "/End", "/TN", taskName)
 	if out, err := schtasksRun(ctx, "/Delete", "/TN", taskName, "/F"); err != nil {
 		decoded := decodeSchtasksOutput(out)
 		if !schtasksTaskMissing(decoded) {
@@ -120,11 +128,40 @@ func stopSchtasksScheduledJob(ctx context.Context, name string) error {
 		filepath.Join(dir, schtasksVbsFileName(name)),
 		filepath.Join(dir, schtasksXMLFileName(name)),
 	} {
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("removing scheduled task file %q: %w", path, err)
+		if err := removeScheduledArtifact(path); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func removeScheduledArtifact(path string) error {
+	return removeScheduledArtifactWith(os.Remove, path, scheduledRemoveRetryBudget)
+}
+
+func removeScheduledArtifactWith(remove func(string) error, path string, budget time.Duration) error {
+	deadline := time.Now().Add(budget)
+	for {
+		err := remove(path)
+		if err == nil || os.IsNotExist(err) {
+			return nil
+		}
+		if !isBusyFile(err) || !time.Now().Before(deadline) {
+			return fmt.Errorf("removing scheduled task file %q: %w", path, err)
+		}
+		if scheduledRemoveRetryDelay > 0 {
+			time.Sleep(scheduledRemoveRetryDelay)
+		}
+	}
+}
+
+func isBusyFile(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "used by another process") ||
+		strings.Contains(msg, "sharing violation")
 }
 
 // SchtasksScheduledVbsContent renders a windowless WSH host that runs

--- a/internal/service/scheduled_schtasks_test.go
+++ b/internal/service/scheduled_schtasks_test.go
@@ -31,7 +31,7 @@ func TestSchtasksScheduledJob_registerStatusStop(t *testing.T) {
 			return nil, errors.New("missing schtasks args")
 		}
 		switch args[0] {
-		case "/Create", "/Run", "/Delete":
+		case "/Create", "/Run", "/End", "/Delete":
 			return []byte("SUCCESS\n"), nil
 		case "/Query":
 			return []byte(queryOutput), nil
@@ -100,6 +100,9 @@ func TestSchtasksScheduledJob_registerStatusStop(t *testing.T) {
 
 	if err := stopSchtasksScheduledJob(ctx, job.Name); err != nil {
 		t.Fatalf("stopSchtasksScheduledJob: %v", err)
+	}
+	if !schtasksCallHas(calls, "/End", "/TN", "genv-updates") {
+		t.Fatalf("schtasks calls = %#v, want /End of genv-updates before delete", calls)
 	}
 	if !schtasksCallHas(calls, "/Delete", "/TN", "genv-updates", "/F") {
 		t.Fatalf("schtasks calls = %#v, want /Delete of genv-updates", calls)
@@ -382,6 +385,45 @@ func TestSchtasksBackend_realWindowsRegisterStatusStop(t *testing.T) {
 	}
 	if status.Registered {
 		t.Fatalf("status after stop = %#v, want unregistered", status)
+	}
+}
+
+func TestRemoveScheduledArtifact_retriesBusyThenSucceeds(t *testing.T) {
+	origDelay := scheduledRemoveRetryDelay
+	scheduledRemoveRetryDelay = 0
+	t.Cleanup(func() { scheduledRemoveRetryDelay = origDelay })
+
+	n := 0
+	err := removeScheduledArtifactWith(func(string) error {
+		n++
+		if n < 3 {
+			return &os.PathError{
+				Op:   "remove",
+				Path: "genv-updates.vbs",
+				Err:  errors.New("The process cannot access the file because it is being used by another process."),
+			}
+		}
+		return nil
+	}, "genv-updates.vbs", time.Second)
+	if err != nil {
+		t.Fatalf("remove after retries: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("attempts = %d, want 3", n)
+	}
+}
+
+func TestRemoveScheduledArtifact_nonBusyFailsImmediately(t *testing.T) {
+	n := 0
+	err := removeScheduledArtifactWith(func(string) error {
+		n++
+		return &os.PathError{Op: "remove", Path: "genv-updates.vbs", Err: errors.New("access is denied")}
+	}, "genv-updates.vbs", time.Second)
+	if err == nil || !strings.Contains(err.Error(), "access is denied") {
+		t.Fatalf("error = %v, want access is denied", err)
+	}
+	if n != 1 {
+		t.Fatalf("attempts = %d, want 1 (no retry)", n)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move Unreleased notes into `v4.3.1` (2026-09-05) and leave a fresh empty Unreleased heading.

Covers:
- Refresh package-manager indexes before outdated on upgrade, check, and hourly (#124/#125)
- Windows scheduled updates no longer flash a console (`wscript` hidden host) (#132/#133)
- vscode adapter prefers `cursor` CLI when `code` is missing (#129/#134)
- `apply --skip-packages` skips inventory and package plan noise (#131/#135)
- Default `scan` to user-facing installs; `--all`/`--deps` for full inventory (#130/#136)
- `upgrade --json` needs `--yes`; leftover IDs are `--only`; skip unavailable managers (#126/#127/#128/#137)
- Windows `updates stop` ends the running task and retries `.vbs` removal if `wscript` still holds it (CI flake / start-then-stop race)

Also pins README install archive examples to 4.3.1 and adds a Versioning row in RELEASING.md.

Patch release: bugfixes and polish after v4.3.0. Do not tag until this PR is merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98c878d7-f020-404e-8027-158690c44134?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98c878d7-f020-404e-8027-158690c44134&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

