### PR TITLE
fix: accept --help on command groups and leaves

### DIFF
--- a/main.go
+++ b/main.go
@@ -475,7 +475,7 @@ func addCmd(args []string) int {
 
 	id, flagArgs := extractPositional(args)
 	if err := fs.Parse(flagArgs); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if *hookTimeout < 0 {
 		fPrintln(os.Stderr, "genv add: --hook-timeout must be non-negative")
@@ -627,7 +627,7 @@ func removeCmd(args []string) int {
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if *hookTimeout < 0 {
 		fPrintln(os.Stderr, "genv remove: --hook-timeout must be non-negative")
@@ -846,13 +846,13 @@ func adoptCmd(args []string) int {
 	id := ""
 	if hasBoolFlag(args, "files") {
 		if err := fs.Parse(args); err != nil {
-			return exitUsage
+			return flagParseExit(err)
 		}
 	} else {
 		var flagArgs []string
 		id, flagArgs = extractPositional(args)
 		if err := fs.Parse(flagArgs); err != nil {
-			return exitUsage
+			return flagParseExit(err)
 		}
 		if id == "" {
 			fPrintln(os.Stderr, "genv adopt: missing package id")
@@ -1040,7 +1040,7 @@ func disownCmd(args []string) int {
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if fs.NArg() < 1 {
 		fPrintln(os.Stderr, "genv disown: missing package id")
@@ -1131,7 +1131,7 @@ func listCmd(args []string) int {
 	lockFile := fs.String("lock-file", "", "path to genv lock file")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	lf, err := genvfile.ReadLock(lockPathForSpec(*file, *lockFile))
@@ -1223,7 +1223,7 @@ func applyCmd(args []string) int {
 	fs.BoolVar(&opts.ForceNewLock, "force-new-lock", false, "back up a foreign lock file and start with a new local lock")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if opts.HookTimeout < 0 {
 		fPrintln(os.Stderr, "genv apply: --hook-timeout must be non-negative")
@@ -2196,13 +2196,12 @@ func upgradeFailedIDs(plan []resolver.UpgradeAction, errs []error) []string {
 // Subcommands: set, unset, list.
 func envCmd(args []string) int {
 	if len(args) == 0 {
-		fPrintln(os.Stderr, "usage: genv env <set|unset|list> [flags]")
-		fPrintln(os.Stderr)
-		fPrintln(os.Stderr, "subcommands:")
-		fPrintln(os.Stderr, "  set <NAME> <value> [--sensitive]   Add or update a variable in the spec")
-		fPrintln(os.Stderr, "  unset <NAME>                        Remove a variable from the spec")
-		fPrintln(os.Stderr, "  list [--json]                       Show all declared variables")
+		printEnvUsage()
 		return exitUsage
+	}
+	if isHelpArg(args[0]) {
+		printEnvUsage()
+		return exitOK
 	}
 	switch args[0] {
 	case "set":
@@ -2215,6 +2214,15 @@ func envCmd(args []string) int {
 		fprintf(os.Stderr, "genv env: unknown subcommand %q\n\nRun 'genv env' for usage.\n", args[0])
 		return exitUsage
 	}
+}
+
+func printEnvUsage() {
+	fPrintln(os.Stderr, "usage: genv env <set|unset|list> [flags]")
+	fPrintln(os.Stderr)
+	fPrintln(os.Stderr, "subcommands:")
+	fPrintln(os.Stderr, "  set <NAME> <value> [--sensitive]   Add or update a variable in the spec")
+	fPrintln(os.Stderr, "  unset <NAME>                        Remove a variable from the spec")
+	fPrintln(os.Stderr, "  list [--json]                       Show all declared variables")
 }
 
 // envSetCmd implements `genv env set <NAME> <value> [--sensitive] [--file]`.
@@ -2231,7 +2239,7 @@ func envSetCmd(args []string) int {
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if fs.NArg() < 2 {
 		fPrintln(os.Stderr, "genv env set: NAME and value are required")
@@ -2284,7 +2292,7 @@ func envUnsetCmd(args []string) int {
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if fs.NArg() < 1 {
 		fPrintln(os.Stderr, "genv env unset: NAME is required")
@@ -2341,7 +2349,7 @@ func envListCmd(args []string) int {
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	f, code := readMaterializedSpec("env list", *file, "", *targetFlag)
@@ -2383,14 +2391,12 @@ func envListCmd(args []string) int {
 // shellCmd implements `genv shell <subcommand>`.
 func shellCmd(args []string) int {
 	if len(args) == 0 {
-		fPrintln(os.Stderr, "usage: genv shell <alias|status|edit> [flags]")
-		fPrintln(os.Stderr)
-		fPrintln(os.Stderr, "subcommands:")
-		fPrintln(os.Stderr, "  alias set <name> <value> [--shell bash|zsh|fish]   Add or update an alias")
-		fPrintln(os.Stderr, "  alias unset <name>                                 Remove an alias")
-		fPrintln(os.Stderr, "  status [--json]                                    Show shell config drift")
-		fPrintln(os.Stderr, "  edit                                               Open genv.json in $EDITOR")
+		printShellUsage()
 		return exitUsage
+	}
+	if isHelpArg(args[0]) {
+		printShellUsage()
+		return exitOK
 	}
 	switch args[0] {
 	case "alias":
@@ -2405,11 +2411,25 @@ func shellCmd(args []string) int {
 	}
 }
 
+func printShellUsage() {
+	fPrintln(os.Stderr, "usage: genv shell <alias|status|edit> [flags]")
+	fPrintln(os.Stderr)
+	fPrintln(os.Stderr, "subcommands:")
+	fPrintln(os.Stderr, "  alias set <name> <value> [--shell bash|zsh|fish]   Add or update an alias")
+	fPrintln(os.Stderr, "  alias unset <name>                                 Remove an alias")
+	fPrintln(os.Stderr, "  status [--json]                                    Show shell config drift")
+	fPrintln(os.Stderr, "  edit                                               Open genv.json in $EDITOR")
+}
+
 // shellAliasCmd dispatches `genv shell alias set|unset`.
 func shellAliasCmd(args []string) int {
 	if len(args) == 0 {
-		fPrintln(os.Stderr, "usage: genv shell alias <set|unset> [flags]")
+		printShellAliasUsage()
 		return exitUsage
+	}
+	if isHelpArg(args[0]) {
+		printShellAliasUsage()
+		return exitOK
 	}
 	switch args[0] {
 	case "set":
@@ -2420,6 +2440,10 @@ func shellAliasCmd(args []string) int {
 		fprintf(os.Stderr, "genv shell alias: unknown subcommand %q\n", args[0])
 		return exitUsage
 	}
+}
+
+func printShellAliasUsage() {
+	fPrintln(os.Stderr, "usage: genv shell alias <set|unset> [flags]")
 }
 
 // shellAliasSetCmd implements `genv shell alias set <name> <value> [--shell] [--file]`.
@@ -2436,7 +2460,7 @@ func shellAliasSetCmd(args []string) int {
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if fs.NArg() < 2 {
 		fPrintln(os.Stderr, "genv shell alias set: name and value are required")
@@ -2492,7 +2516,7 @@ func shellAliasUnsetCmd(args []string) int {
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if fs.NArg() < 1 {
 		fPrintln(os.Stderr, "genv shell alias unset: name is required")
@@ -2549,7 +2573,7 @@ func shellStatusCmd(args []string) int {
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	f, code := readMaterializedSpec("shell status", *file, "", *targetFlag)
@@ -2603,7 +2627,7 @@ func shellEditCmd(args []string) int {
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	editor := os.Getenv("EDITOR")
@@ -2761,7 +2785,7 @@ func scanCmd(args []string) int {
 	includeDeps := fs.Bool("deps", false, "include manager dependencies and language stdlib (same as --all)")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if *debug {
 		logging.Init(true)
@@ -3017,7 +3041,7 @@ func statusCmd(args []string) int {
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if *debug {
 		logging.Init(true)
@@ -3325,7 +3349,7 @@ func cleanCmd(args []string) int {
 	}
 	dryRun := fs.Bool("dry-run", false, "print the clean commands without executing")
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	availableNames := resolver.Detect()
@@ -3470,7 +3494,7 @@ func editCmd(args []string) int {
 	fs := flag.NewFlagSet("edit", flag.ContinueOnError)
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	editor := os.Getenv("VISUAL")
@@ -3525,7 +3549,7 @@ func completionCmd(args []string) int {
 		fPrintln(os.Stderr, "  genv completion install zsh    # install for a specific shell")
 	}
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if fs.NArg() < 1 {
 		fPrintln(os.Stderr, "genv completion: missing shell argument (bash, zsh, fish, or powershell)")
@@ -3585,7 +3609,7 @@ func completionInstallCmd(args []string) int {
 	}
 	shell, flagArgs := extractPositional(args)
 	if err := fs.Parse(flagArgs); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if shell == "" {
 		shell = detectShell()
@@ -3733,7 +3757,7 @@ func validateCmd(args []string) int {
 	}
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	_, err := genvfile.Read(*file)
@@ -3788,7 +3812,7 @@ func upgradeCmd(args []string) int {
 	hookTimeoutFlag := fs.String("hook-timeout", "", "per-hook deadline, e.g. 5m or 30s (default: no hook timeout)")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if *debug {
 		logging.Init(true)
@@ -4429,7 +4453,7 @@ func initCmd(args []string) int {
 	}
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	// Refuse to overwrite an existing valid spec.
@@ -4684,17 +4708,12 @@ func printVersion() {
 // serviceCmd implements `genv service <subcommand>`.
 func serviceCmd(args []string) int {
 	if len(args) == 0 {
-		fPrintln(os.Stderr, "usage: genv service <add|remove|list|start|stop|status> [flags]")
-		fPrintln(os.Stderr)
-		fPrintln(os.Stderr, "subcommands:")
-		fPrintln(os.Stderr, "  add <name> --start <cmd> [--stop <cmd>] [--restart <cmd>] [--status <cmd>]   Add or update a service (raw commands)")
-		fPrintln(os.Stderr, "  add <name> --brew-formula <formula>                                          Add a brew-managed service (macOS)")
-		fPrintln(os.Stderr, "  remove <name>                                                              Remove a service from the spec")
-		fPrintln(os.Stderr, "  list                                                                        Show all declared services")
-		fPrintln(os.Stderr, "  start <name>                                                               Start a service")
-		fPrintln(os.Stderr, "  stop <name>                                                                Stop a service")
-		fPrintln(os.Stderr, "  status <name>                                                              Show service running status")
+		printServiceUsage()
 		return exitUsage
+	}
+	if isHelpArg(args[0]) {
+		printServiceUsage()
+		return exitOK
 	}
 	switch args[0] {
 	case "add":
@@ -4713,6 +4732,19 @@ func serviceCmd(args []string) int {
 		fprintf(os.Stderr, "genv service: unknown subcommand %q\n\nRun 'genv service' for usage.\n", args[0])
 		return exitUsage
 	}
+}
+
+func printServiceUsage() {
+	fPrintln(os.Stderr, "usage: genv service <add|remove|list|start|stop|status> [flags]")
+	fPrintln(os.Stderr)
+	fPrintln(os.Stderr, "subcommands:")
+	fPrintln(os.Stderr, "  add <name> --start <cmd> [--stop <cmd>] [--restart <cmd>] [--status <cmd>]   Add or update a service (raw commands)")
+	fPrintln(os.Stderr, "  add <name> --brew-formula <formula>                                          Add a brew-managed service (macOS)")
+	fPrintln(os.Stderr, "  remove <name>                                                              Remove a service from the spec")
+	fPrintln(os.Stderr, "  list                                                                        Show all declared services")
+	fPrintln(os.Stderr, "  start <name>                                                               Start a service")
+	fPrintln(os.Stderr, "  stop <name>                                                                Stop a service")
+	fPrintln(os.Stderr, "  status <name>                                                              Show service running status")
 }
 
 // serviceAddCmd implements `genv service add <name> --start <cmd> [--stop <cmd>] [--restart <cmd>] [--status <cmd>]`.
@@ -4735,7 +4767,7 @@ func serviceAddCmd(args []string) int {
 
 	name, flagArgs := extractPositional(args)
 	if err := fs.Parse(flagArgs); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if name == "" {
 		fPrintln(os.Stderr, "genv service add: missing service name")
@@ -4823,7 +4855,7 @@ func serviceRemoveCmd(args []string) int {
 
 	name, flagArgs := extractPositional(args)
 	if err := fs.Parse(flagArgs); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if name == "" {
 		fPrintln(os.Stderr, "genv service remove: name is required")
@@ -4878,7 +4910,7 @@ func serviceListCmd(args []string) int {
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	f, code := readMaterializedSpec("service list", *file, "", *targetFlag)
@@ -4898,7 +4930,7 @@ func serviceStartCmd(args []string) int {
 
 	name, flagArgs := extractPositional(args)
 	if err := fs.Parse(flagArgs); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if name == "" {
 		fPrintln(os.Stderr, "genv service start: name is required")
@@ -4953,7 +4985,7 @@ func serviceStopCmd(args []string) int {
 
 	name, flagArgs := extractPositional(args)
 	if err := fs.Parse(flagArgs); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if name == "" {
 		fPrintln(os.Stderr, "genv service stop: name is required")
@@ -5004,7 +5036,7 @@ func serviceStatusCmd(args []string) int {
 
 	name, flagArgs := extractPositional(args)
 	if err := fs.Parse(flagArgs); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if name == "" {
 		fPrintln(os.Stderr, "genv service status: name is required")

--- a/main_export.go
+++ b/main_export.go
@@ -31,7 +31,7 @@ func exportCmd(args []string) int {
 	fromV7 := fs.Bool("from-v7", false, "migrate a v1-v7 spec to schemaVersion 8 in memory before exporting")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if fs.NArg() != 0 {
 		fs.Usage()

--- a/main_help.go
+++ b/main_help.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"errors"
+	"flag"
+)
+
+func isHelpArg(s string) bool {
+	switch s {
+	case "help", "--help", "-h":
+		return true
+	default:
+		return false
+	}
+}
+
+// flagParseExit maps flag.Parse errors to CLI exit codes. --help/-h are
+// success; any other parse failure is a usage error.
+func flagParseExit(err error) int {
+	if errors.Is(err, flag.ErrHelp) {
+		return exitOK
+	}
+	return exitUsage
+}

--- a/main_help_test.go
+++ b/main_help_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// registeredHelpCommands is the user-facing command tree. Hidden internals
+// (__complete, updates __run-once) and version (prints version, not usage)
+// are omitted. New user-facing commands must be added here.
+var registeredHelpCommands = [][]string{
+	{"add"},
+	{"remove"},
+	{"adopt"},
+	{"disown"},
+	{"list"},
+	{"apply"},
+	{"edit"},
+	{"clean"},
+	{"scan"},
+	{"status"},
+	{"validate"},
+	{"upgrade"},
+	{"pull"},
+	{"migrate"},
+	{"export"},
+	{"map"},
+	{"init"},
+	{"completion"},
+	{"completion", "install"},
+	{"env"},
+	{"env", "set"},
+	{"env", "unset"},
+	{"env", "list"},
+	{"shell"},
+	{"shell", "alias"},
+	{"shell", "alias", "set"},
+	{"shell", "alias", "unset"},
+	{"shell", "status"},
+	{"shell", "edit"},
+	{"service"},
+	{"service", "add"},
+	{"service", "remove"},
+	{"service", "list"},
+	{"service", "start"},
+	{"service", "stop"},
+	{"service", "status"},
+	{"profile"},
+	{"profile", "list"},
+	{"profile", "create"},
+	{"profile", "switch"},
+	{"updates"},
+	{"updates", "check"},
+	{"updates", "start"},
+	{"updates", "stop"},
+	{"updates", "status"},
+}
+
+var commandGroups = [][]string{
+	{"env"},
+	{"shell"},
+	{"shell", "alias"},
+	{"service"},
+	{"profile"},
+	{"updates"},
+}
+
+func TestRegisteredCommands_Help_printsUsageAndExitsOK(t *testing.T) {
+	for _, cmd := range registeredHelpCommands {
+		args := append(append([]string{}, cmd...), "--help")
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			assertHelpOK(t, args)
+		})
+	}
+}
+
+func TestCommandGroups_HelpFlags_printUsageAndExitOK(t *testing.T) {
+	for _, group := range commandGroups {
+		for _, flag := range []string{"help", "--help", "-h"} {
+			args := append(append([]string{}, group...), flag)
+			t.Run(strings.Join(args, " "), func(t *testing.T) {
+				assertHelpOK(t, args)
+			})
+		}
+	}
+}
+
+func assertHelpOK(t *testing.T, args []string) {
+	t.Helper()
+	var code int
+	errOut := captureStderr(t, func() { code = run(args) })
+	if code != exitOK {
+		t.Fatalf("run(%v): expected exitOK (%d), got %d\nstderr: %s", args, exitOK, code, errOut)
+	}
+	if !strings.Contains(strings.ToLower(errOut), "usage") {
+		t.Fatalf("run(%v): stderr = %q, want usage text", args, errOut)
+	}
+	if strings.Contains(errOut, "unknown subcommand") || strings.Contains(errOut, "unknown command") {
+		t.Fatalf("run(%v): stderr = %q, must not report unknown command for help", args, errOut)
+	}
+}

--- a/main_map.go
+++ b/main_map.go
@@ -26,7 +26,7 @@ func mapCmd(args []string) int {
 	targetID := fs.String("target", "", "destination target id")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if fs.NArg() != 0 {
 		fs.Usage()

--- a/main_migrate.go
+++ b/main_migrate.go
@@ -26,7 +26,7 @@ func migrateCmd(args []string) int {
 	write := fs.Bool("write", false, "overwrite genv.json with the migrated schemaVersion 8 spec")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if fs.NArg() != 0 {
 		fs.Usage()

--- a/main_profile.go
+++ b/main_profile.go
@@ -10,8 +10,12 @@ import (
 
 func profileCmd(args []string) int {
 	if len(args) == 0 {
-		fPrintln(os.Stderr, "usage: genv profile <list|create|switch> [flags]")
+		printProfileUsage()
 		return exitUsage
+	}
+	if isHelpArg(args[0]) {
+		printProfileUsage()
+		return exitOK
 	}
 	switch args[0] {
 	case "list", "ls":
@@ -26,12 +30,16 @@ func profileCmd(args []string) int {
 	}
 }
 
+func printProfileUsage() {
+	fPrintln(os.Stderr, "usage: genv profile <list|create|switch> [flags]")
+}
+
 func profileListCmd(args []string) int {
 	fs := flag.NewFlagSet("profile list", flag.ContinueOnError)
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
 	lockFile := fs.String("lock-file", "", "path to genv lock file")
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	lockPath := lockPathForSpec(*file, *lockFile)
@@ -72,7 +80,7 @@ func profileCreateCmd(args []string) int {
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
 	name, flagArgs := extractPositional(args)
 	if err := fs.Parse(flagArgs); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if name == "" {
 		fPrintln(os.Stderr, "genv profile create: missing profile name")
@@ -108,7 +116,7 @@ func profileSwitchCmd(args []string) int {
 
 	name, flagArgs := extractPositional(args)
 	if err := fs.Parse(flagArgs); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	if name == "" {
 		fPrintln(os.Stderr, "genv profile switch: missing profile name")

--- a/main_pull.go
+++ b/main_pull.go
@@ -36,7 +36,7 @@ func pullCmd(args []string) int {
 	dryRun := fs.Bool("dry-run", false, "print what would be pulled without writing")
 
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	if *file == "-" {

--- a/main_scan_userfacing_test.go
+++ b/main_scan_userfacing_test.go
@@ -235,8 +235,8 @@ func TestScanCmd_HelpDescribesUserFacingInventory(t *testing.T) {
 	out := captureStderr(t, func() {
 		code = run([]string{"scan", "--help"})
 	})
-	if code != exitUsage {
-		t.Fatalf("scan --help: expected exitUsage (%d), got %d\n%s", exitUsage, code, out)
+	if code != exitOK {
+		t.Fatalf("scan --help: expected exitOK (%d), got %d\n%s", exitOK, code, out)
 	}
 	for _, want := range []string{"leaves", "casks", "--all", "user-facing"} {
 		if !strings.Contains(strings.ToLower(out), strings.ToLower(want)) {

--- a/main_updates.go
+++ b/main_updates.go
@@ -66,7 +66,7 @@ func updatesCheckCmd(args []string) int {
 	onlyManagerFlag := fs.String("only-manager", "", "comma-separated list of managers to check")
 	skipManagerFlag := fs.String("skip-manager", "", "comma-separated list of managers to skip")
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 
 	lockPath := lockPathForSpec(*file, *lockFile)

--- a/main_updates_daemon.go
+++ b/main_updates_daemon.go
@@ -48,7 +48,7 @@ func updatesStartCmd(args []string) int {
 	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to $GENV_HOST or os.Hostname())")
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	cfg, interval, code := readUpdatesConfigForLifecycle(*file)
 	if code != exitOK {
@@ -97,7 +97,7 @@ func updatesStopCmd(args []string) int {
 	fs := flag.NewFlagSet("updates stop", flag.ContinueOnError)
 	fs.Usage = func() { fPrintln(os.Stderr, "usage: genv updates stop") }
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	backend := newUpdatesSupervisor()
 	if !backend.Supported() {
@@ -116,7 +116,7 @@ func updatesStatusCmd(args []string) int {
 	fs := flag.NewFlagSet("updates status", flag.ContinueOnError)
 	fs.Usage = func() { fPrintln(os.Stderr, "usage: genv updates status") }
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	backend := newUpdatesSupervisor()
 	status, err := backend.Status(context.Background(), updatesServiceName)

--- a/main_updates_worker.go
+++ b/main_updates_worker.go
@@ -44,7 +44,7 @@ func updatesRunOnceCmd(args []string) int {
 	hostFlag := fs.String("host", "", "host name for host-specific records")
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 	if err := fs.Parse(args); err != nil {
-		return exitUsage
+		return flagParseExit(err)
 	}
 	logger, closeLog, err := updatesLogger()
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #147.

`--help`, `-h`, and `help` were treated as unknown subcommands on `env`, `shell`, `service`, `profile`, and `shell alias`. Leaf FlagSets already printed usage for `--help`/`-h` but exited 1 (`flag.ErrHelp` → `exitUsage`).

## Changes

- Group dispatchers print usage and exit 0 for `help` / `--help` / `-h`, same pattern as `updates`.
- `flag.ErrHelp` from every FlagSet parse is exit 0 so leaf `--help` matches top-level `genv --help`.
- Test iterates every registered user-facing command with `--help`, plus group `help`/`-h`.

Hidden internals (`__complete`, `updates __run-once`) and `version` (prints version, not usage) are omitted from that list.

## Test plan

- `go test -run 'TestRegisteredCommands_Help|TestCommandGroups_HelpFlags|TestScanCmd_Help|TestUpdates_Help|TestRun_Help'`
- `make ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb12e454-4d75-4e0e-93af-5203772b6c12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb12e454-4d75-4e0e-93af-5203772b6c12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

