### PR TITLE
fix: keep lock and env/shell fragments next to --file

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Convenience commands (`add` / `remove` / `adopt` / `disown` / `scan`) update the
 | `scan` | Bulk-adopt user-facing installs (`--dry-run`, `--yes`; `--all` / `--deps` for full trees) |
 | `list` (`ls`) | Show lock-tracked packages |
 | `status` | Spec ↔ lock drift (`--files`, `--offline`, `--target`) |
-| `apply` | Reconcile (`--dry-run`, `--yes`, `--json`, `--force`, `--backup`, `--strict`, `--quiet`, `--skip-packages`, `--timeout <d>`, `--no-hooks`, `--hook-timeout <d>`, `--target`, `--force-new-lock`) |
+| `apply` | Reconcile (`--dry-run`, `--yes`, `--json`, `--force`, `--backup`, `--strict`, `--quiet`, `--skip-packages`, `--timeout <d>`, `--no-hooks`, `--hook-timeout <d>`, `--target`, `--force-new-lock`, `--state-dir`) |
 | `validate` | Validate spec + genv-managed agent executables |
 | `upgrade` | Upgrade tracked packages plus OS vendor updates (`--all`, `--only` / leftover IDs, `--skip`, `--only-manager`, `--skip-manager`, `--target`; `--json` wet-run requires `--yes`) |
 | `updates` | Background checker (`check` / `start` / `stop` / `status`; `--target`, `--only`, `--skip`, `--only-manager`, `--skip-manager` on check/start) |
@@ -253,7 +253,8 @@ Tab completion on `add` / `adopt` suggests package names from available managers
 ### Common flags
 
 - `--file <path>` — spec path (default under `~/.config/genv/`)
-- `--lock-file <path>` — lock path (default `genv.lock.json` in the genv config dir)
+- `--lock-file <path>` — lock path (default `genv.lock.json` next to `--file`)
+- `--state-dir <dir>` — directory for lock and env/shell fragments (default: directory of `--file`)
 - `--target <id>` — v8 target for apply / status / upgrade / updates / mutate / export / map / scan
 - `--host <name>` — legacy host filter override for v1–v7 records / hooks (defaults via host **classification**, not hostname)
 - `--json` — machine-readable envelope on stdout; subprocess noise on stderr

--- a/completions/genv.bash
+++ b/completions/genv.bash
@@ -76,7 +76,7 @@ _genv() {
 			mapfile -t COMPREPLY < <(compgen -W "$(genv __complete repo-packages "${cur}" 2>/dev/null)" -- "${cur}")
 			return 0
 		fi
-		opts="--file --lock-file --version --prefer --manager --host --target --files --json"
+		opts="--file --lock-file --state-dir --version --prefer --manager --host --target --files --json"
 		;;
 	upgrade)
 		# Complete positional arg (if any) with tracked package IDs.
@@ -113,7 +113,7 @@ _genv() {
 		fi
 		;;
 	apply)
-		opts="--file --lock-file --dry-run --force --backup --strict --yes --quiet --json --timeout --no-hooks --skip-packages --hook-timeout --debug --host --target --force-new-lock"
+		opts="--file --lock-file --state-dir --dry-run --force --backup --strict --yes --quiet --json --timeout --no-hooks --skip-packages --hook-timeout --debug --host --target --force-new-lock"
 		;;
 	migrate)
 		opts="--file --write"

--- a/completions/genv.fish
+++ b/completions/genv.fish
@@ -149,6 +149,7 @@ complete -c genv -n '__fish_genv_using_command list; or __fish_genv_using_comman
 complete -c genv -n '__fish_genv_using_command add' -f -a '(__fish_genv_repo_packages)' -d 'Package'
 complete -c genv -n '__fish_genv_using_command adopt' -f -a '(__fish_genv_repo_packages)' -d 'Package'
 complete -c genv -n '__fish_genv_using_command add; or __fish_genv_using_command adopt' -l lock-file -d 'Path to genv lock file' -r
+complete -c genv -n '__fish_genv_using_command adopt' -l state-dir -d 'Directory for lock and env/shell fragments' -r
 complete -c genv -n '__fish_genv_using_command add; or __fish_genv_using_command adopt' -l version -d 'Version constraint' -x
 complete -c genv -n '__fish_genv_using_command add; or __fish_genv_using_command adopt' \
     -l prefer -d 'Preferred manager' -x -a '(__fish_genv_managers)'
@@ -201,6 +202,7 @@ complete -c genv -n '__fish_genv_seen_sub updates start' -l target -d 'Portable 
 
 # apply
 complete -c genv -n '__fish_genv_using_command apply' -l lock-file -d 'Path to genv lock file' -r
+complete -c genv -n '__fish_genv_using_command apply' -l state-dir -d 'Directory for lock and env/shell fragments' -r
 complete -c genv -n '__fish_genv_using_command apply' -l dry-run -d 'Print the reconcile plan without executing'
 complete -c genv -n '__fish_genv_using_command apply' -l force -d 'Overwrite mismatched managed files'
 complete -c genv -n '__fish_genv_using_command apply' -l backup -d 'Back up mismatched files before overwrite'

--- a/completions/genv.ps1
+++ b/completions/genv.ps1
@@ -94,7 +94,7 @@ function script:Get-GenvCompletions {
 
 	switch ($cmd) {
 		{ $_ -in 'apply' } {
-			$flags = @('--file', '--lock-file', '--dry-run', '--force', '--backup', '--strict', '--yes',
+			$flags = @('--file', '--lock-file', '--state-dir', '--dry-run', '--force', '--backup', '--strict', '--yes',
 				'--quiet', '--json', '--timeout', '--no-hooks', '--skip-packages', '--hook-timeout', '--debug',
 				'--host', '--target', '--force-new-lock')
 			return (& $completeCandidates -Candidates $flags)
@@ -133,7 +133,7 @@ function script:Get-GenvCompletions {
 		}
 		{ $_ -in 'adopt' } {
 			if ($WordToComplete -like '-*') {
-				$flags = @('--file', '--lock-file', '--version', '--prefer', '--manager',
+				$flags = @('--file', '--lock-file', '--state-dir', '--version', '--prefer', '--manager',
 					'--host', '--target', '--files', '--json')
 				return (& $completeCandidates -Candidates $flags)
 			}

--- a/completions/genv.zsh
+++ b/completions/genv.zsh
@@ -107,6 +107,7 @@ _genv() {
 			_arguments \
 				'--file=[Path to genv.json]:path:_files' \
 				'--lock-file=[Path to genv lock file]:path:_files' \
+				'--state-dir=[Directory for lock and env/shell fragments]:path:_files -/' \
 				'--version=[Version constraint]:version:' \
 				"--prefer=[Preferred manager]:manager:($(genv __complete managers 2>/dev/null))" \
 				'--manager=[Manager-specific names]:manager:' \
@@ -190,6 +191,7 @@ _genv() {
 			_arguments \
 				'--file=[Path to genv.json]:path:_files' \
 				'--lock-file=[Path to genv lock file]:path:_files' \
+				'--state-dir=[Directory for lock and env/shell fragments]:path:_files -/' \
 				'--dry-run[Print the reconcile plan without executing]' \
 				'--force[Overwrite mismatched managed files]' \
 				'--backup[Back up mismatched files before overwrite]' \

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -86,7 +86,7 @@ drives the real binary. All eight currently pass.
 | S5 CodexTemplatedDrift | `status --files`, `apply --force --yes` | Stale rendered `copy-template` target is flagged `mismatch` (exit 4); force re-renders it with the real HOME (no literal `__HOME__`), writes one backup, and status then exits 0. |
 | S6 DryRun | `apply --dry-run --force --yes` | Reports the planned change but writes nothing to disk and creates no backup. |
 | S7 AdoptFilesRegistersRenderedConfig | `adopt --files` | Records an already-rendered `copy-template` target into the lock as mode `copy` without touching the file or writing a backup; `status --files` then exits 0. |
-| S8 AdoptFilesKeepsSpecRepoClean | `adopt --files` | Against a git-backed spec repo, leaves the working tree clean (`git status --porcelain` empty). Skips when `git` is unavailable. |
+| S8 AdoptFilesKeepsSpecRepoClean | `adopt --files` | Against a git-backed spec repo, writes the lock next to `--file` and leaves the working tree clean (`git status --porcelain` empty; lock is gitignored). Skips when `git` is unavailable. |
 
 ## Files-block behavior reference
 
@@ -132,10 +132,10 @@ Shared behavior across modes:
 - `genv adopt --files`: registers already-managed files into the lock without
   rewriting the targets; template targets are rendered before comparison.
 - `--file <path>`: spec location, injected by the test runners.
-- `--lock-file <path>`: lock location. The default is
-  `~/.config/genv/genv.lock.json` under HOME. The package-manager suite passes
-  `--lock-file` to keep the lock inside its temp dir; the files suite relies on
-  the HOME-based default inside its isolated temp HOME.
+- `--lock-file <path>`: lock location. The default is `genv.lock.json` next to
+  `--file` (or `--state-dir` when set). The package-manager suite passes
+  `--lock-file` explicitly. The files suite uses the sibling-of-`--file`
+  default and asserts adopt does not write the isolated HOME default lock.
 
 Exit codes used across the suite: `0` success, `1` usage error, `2` filesystem
 or serialization error, `3` schema validation failure, `4` semantic error or

--- a/e2e/files_test.go
+++ b/e2e/files_test.go
@@ -62,6 +62,16 @@ func (fr *fileRunner) env() []string {
 	return append(filtered, "HOME="+fr.home, "XDG_CONFIG_HOME="+filepath.Join(fr.home, ".config"), "GENV_NO_INTERACTIVE=1")
 }
 
+// lockPath is the lock that belongs with --file (sibling genv.lock.json).
+func (fr *fileRunner) lockPath() string {
+	return filepath.Join(filepath.Dir(fr.genvJSON), "genv.lock.json")
+}
+
+// defaultLockPath is the live-machine lock under the isolated HOME.
+func (fr *fileRunner) defaultLockPath() string {
+	return filepath.Join(fr.home, ".config", "genv", "genv.lock.json")
+}
+
 // genv runs a genv subcommand with --file and the isolated HOME injected.
 func (fr *fileRunner) genv(stdinData, subcmd string, extra ...string) (stdout, stderr string, code int) {
 	args := append([]string{subcmd, "--file", fr.genvJSON}, extra...)
@@ -395,13 +405,16 @@ func TestFiles_S7_AdoptFilesRegistersRenderedConfig(t *testing.T) {
 	if len(matches) != 0 {
 		t.Fatalf("adopt --files created backups: %v", matches)
 	}
-	lockPath := filepath.Join(r.home, ".config", "genv", "genv.lock.json")
+	lockPath := r.lockPath()
 	lf, err := genvfile.ReadLock(lockPath)
 	if err != nil {
-		t.Fatalf("read lock: %v", err)
+		t.Fatalf("read lock %s: %v", lockPath, err)
 	}
 	if len(lf.Files) != 1 || lf.Files[0].Mode != "copy" || lf.Files[0].Target != "~/.config/codex/config.toml" {
 		t.Fatalf("locked files = %+v, want one copied codex config", lf.Files)
+	}
+	if _, err := os.Stat(r.defaultLockPath()); err == nil {
+		t.Fatalf("adopt --file wrote the default config lock %s", r.defaultLockPath())
 	}
 
 	stdout, stderr, code = r.genv("", "status", "--files")
@@ -442,6 +455,12 @@ func TestFiles_S8_AdoptFilesKeepsSpecRepoClean(t *testing.T) {
 	if err := os.WriteFile(r.genvJSON, append(data, '\n'), 0o644); err != nil {
 		t.Fatalf("write spec: %v", err)
 	}
+	// Lock is machine-local and now lives next to --file. Ignore it so a
+	// git-tracked spec repo stays clean after adopt --files.
+	ignore := "genv.lock.json\ngenv.lock.json.mutex\n"
+	if err := os.WriteFile(filepath.Join(specRepo, ".gitignore"), []byte(ignore), 0o644); err != nil {
+		t.Fatalf("write gitignore: %v", err)
+	}
 	if out, err := exec.Command("git", "-C", specRepo, "add", ".").CombinedOutput(); err != nil {
 		t.Fatalf("git add: %v: %s", err, out)
 	}
@@ -469,5 +488,11 @@ func TestFiles_S8_AdoptFilesKeepsSpecRepoClean(t *testing.T) {
 	}
 	if strings.TrimSpace(string(out)) != "" {
 		t.Fatalf("spec repo dirty after adopt --files: %q", out)
+	}
+	if _, err := os.Stat(r.lockPath()); err != nil {
+		t.Fatalf("expected lock next to spec: %v", err)
+	}
+	if _, err := os.Stat(r.defaultLockPath()); err == nil {
+		t.Fatalf("adopt --file wrote the default config lock %s", r.defaultLockPath())
 	}
 }

--- a/internal/genvfile/genvfile.go
+++ b/internal/genvfile/genvfile.go
@@ -36,16 +36,60 @@ func DefaultSpecPath() (string, error) {
 	return filepath.Join(dir, "genv.json"), nil
 }
 
-// LockPathFrom returns the per-host lock file path inside the genv config
-// directory (~/.config/genv/genv.lock.json, or $XDG_CONFIG_HOME/genv/genv.lock.json
-// when set). The specPath argument is ignored so the lock lives outside the spec
-// repo by default.
+// ResolveStateDir returns the directory that owns the lock and env/shell
+// fragments. An explicit stateDir wins; otherwise the directory containing
+// specPath is used; if specPath is empty, DefaultDir is used.
+func ResolveStateDir(specPath, stateDir string) (string, error) {
+	if stateDir != "" {
+		abs, err := filepath.Abs(stateDir)
+		if err != nil {
+			return "", fmt.Errorf("resolving state directory %s: %w", stateDir, err)
+		}
+		return abs, nil
+	}
+	if specPath != "" {
+		abs, err := filepath.Abs(specPath)
+		if err != nil {
+			return "", fmt.Errorf("resolving spec path %s: %w", specPath, err)
+		}
+		return filepath.Dir(abs), nil
+	}
+	return DefaultDir()
+}
+
+// LockPathFrom returns the lock file path that belongs with specPath: a
+// genv.lock.json next to the spec. Empty specPath falls back to DefaultDir.
 func LockPathFrom(specPath string) string {
-	dir, err := DefaultDir()
+	dir, err := ResolveStateDir(specPath, "")
 	if err != nil {
 		return "genv.lock.json"
 	}
 	return filepath.Join(dir, "genv.lock.json")
+}
+
+// LockPathIn returns genv.lock.json inside stateDir.
+func LockPathIn(stateDir string) string {
+	if stateDir == "" {
+		return LockPathFrom("")
+	}
+	return filepath.Join(stateDir, "genv.lock.json")
+}
+
+// WithinDir reports whether path is the directory dir or a file inside it.
+func WithinDir(dir, path string) bool {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return false
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absDir, absPath)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
 }
 
 // ErrNotFound is returned by Read when the file does not exist.

--- a/internal/genvfile/genvfile_test.go
+++ b/internal/genvfile/genvfile_test.go
@@ -318,12 +318,19 @@ func TestWrite_OverwritesExistingFile(t *testing.T) {
 
 func TestLockPathFrom(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.FromSlash("/custom/config"))
+	got := LockPathFrom("/tmp/repo/genv.json")
+	want := filepath.Join(filepath.FromSlash("/tmp/repo"), "genv.lock.json")
+	if got != want {
+		t.Errorf("LockPathFrom(spec) = %q, want lock next to spec %q", got, want)
+	}
+}
+
+func TestLockPathFrom_EmptySpecUsesDefaultDir(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", filepath.FromSlash("/custom/config"))
+	got := LockPathFrom("")
 	want := filepath.Join(filepath.FromSlash("/custom/config"), "genv", "genv.lock.json")
-	for _, specPath := range []string{"genv.json", "/tmp/repo/genv.json", "/any/path.json"} {
-		got := LockPathFrom(specPath)
-		if got != want {
-			t.Errorf("LockPathFrom(%q) = %q, want %q", specPath, got, want)
-		}
+	if got != want {
+		t.Errorf("LockPathFrom(\"\") = %q, want %q", got, want)
 	}
 }
 
@@ -331,10 +338,46 @@ func TestLockPathFrom_FallsBackToHomeConfig(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	home := filepath.FromSlash("/home/testuser")
 	testutil.SetHome(t, home)
-	got := LockPathFrom("/ignored/path/genv.json")
+	got := LockPathFrom("")
 	want := filepath.Join(home, ".config", "genv", "genv.lock.json")
 	if got != want {
 		t.Errorf("LockPathFrom fallback = %q, want %q", got, want)
+	}
+}
+
+func TestResolveStateDir(t *testing.T) {
+	spec := filepath.Join(t.TempDir(), "nested", "genv.json")
+	got, err := ResolveStateDir(spec, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Dir(spec) {
+		t.Fatalf("ResolveStateDir(spec) = %q, want %q", got, filepath.Dir(spec))
+	}
+	override := t.TempDir()
+	got, err = ResolveStateDir(spec, override)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absOverride, err := filepath.Abs(override)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != absOverride {
+		t.Fatalf("ResolveStateDir(spec, override) = %q, want %q", got, absOverride)
+	}
+}
+
+func TestWithinDir(t *testing.T) {
+	dir := t.TempDir()
+	if !WithinDir(dir, filepath.Join(dir, "env.sh")) {
+		t.Fatal("expected env.sh inside dir")
+	}
+	if !WithinDir(dir, dir) {
+		t.Fatal("expected dir to contain itself")
+	}
+	if WithinDir(dir, filepath.Join(dir, "..", "outside")) {
+		t.Fatal("parent path must not be inside dir")
 	}
 }
 

--- a/internal/genvfile/genvfile_test.go
+++ b/internal/genvfile/genvfile_test.go
@@ -313,13 +313,18 @@ func TestWrite_OverwritesExistingFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// LockPathFrom — lock lives in the genv config directory, ignoring spec path.
+// LockPathFrom — lock lives next to the spec (absolute).
 // ---------------------------------------------------------------------------
 
 func TestLockPathFrom(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.FromSlash("/custom/config"))
-	got := LockPathFrom("/tmp/repo/genv.json")
-	want := filepath.Join(filepath.FromSlash("/tmp/repo"), "genv.lock.json")
+	spec := filepath.FromSlash("/tmp/repo/genv.json")
+	got := filepath.Clean(LockPathFrom(spec))
+	absSpec, err := filepath.Abs(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Clean(filepath.Join(filepath.Dir(absSpec), "genv.lock.json"))
 	if got != want {
 		t.Errorf("LockPathFrom(spec) = %q, want lock next to spec %q", got, want)
 	}

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -39,6 +39,14 @@ type FilePlanEntry struct {
 	Kind   string `json:"kind"`
 }
 
+// StatePaths names the lock and env/shell fragment files an apply will use.
+type StatePaths struct {
+	Dir   string `json:"dir"`
+	Lock  string `json:"lock"`
+	Env   string `json:"env,omitempty"`
+	Shell string `json:"shell,omitempty"`
+}
+
 // PlanResult is the Data payload for `genv apply [--dry-run] --json`.
 type PlanResult struct {
 	ToInstall       []PlanPackage   `json:"toInstall"`
@@ -50,6 +58,7 @@ type PlanResult struct {
 	ServicesToStop  []string        `json:"servicesToStop,omitempty"`
 	Files           []FilePlanEntry `json:"files,omitempty"`
 	FailedHooks     []string        `json:"failedHooks,omitempty"`
+	State           *StatePaths     `json:"state,omitempty"`
 }
 
 // StatusEntry is a single package entry in a StatusResult.

--- a/internal/profilebackend/backend.go
+++ b/internal/profilebackend/backend.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ks1686/genv/internal/genvfile"
 	"github.com/ks1686/genv/internal/schema"
 )
 
@@ -22,6 +23,40 @@ type Backend interface {
 // shell/rc is already relevant.
 // Windows without an engine: POSIX only when relevant; callers should warn
 // about the missing engine separately.
+// SelectBackendsIn is SelectBackends with fragments rooted at stateDir.
+// An empty stateDir keeps the default config directory.
+func SelectBackendsIn(goos, stateDir string) []Backend {
+	backends := SelectBackends(goos)
+	if stateDir == "" {
+		return backends
+	}
+	out := make([]Backend, len(backends))
+	for i, b := range backends {
+		switch t := b.(type) {
+		case POSIXBackend:
+			t.Dir = stateDir
+			out[i] = t
+		case PowerShellBackend:
+			t.Dir = stateDir
+			out[i] = t
+		default:
+			out[i] = b
+		}
+	}
+	return out
+}
+
+func shouldInjectRC(stateDir string) bool {
+	if stateDir == "" {
+		return true
+	}
+	def, err := genvfile.DefaultDir()
+	if err != nil {
+		return false
+	}
+	return genvfile.WithinDir(def, stateDir) && genvfile.WithinDir(stateDir, def)
+}
+
 func SelectBackends(goos string) []Backend {
 	if goos != "windows" {
 		return []Backend{POSIXBackend{}}

--- a/internal/profilebackend/engine_test.go
+++ b/internal/profilebackend/engine_test.go
@@ -89,6 +89,24 @@ func TestSelectBackends_NonWindows(t *testing.T) {
 	}
 }
 
+func TestSelectBackendsIn_SetsDir(t *testing.T) {
+	dir := t.TempDir()
+	backends := SelectBackendsIn("darwin", dir)
+	if len(backends) != 1 {
+		t.Fatalf("got %#v", backends)
+	}
+	posix, ok := backends[0].(POSIXBackend)
+	if !ok {
+		t.Fatalf("got %T", backends[0])
+	}
+	if posix.Dir != dir {
+		t.Fatalf("Dir = %q, want %q", posix.Dir, dir)
+	}
+	if SelectBackendsIn("darwin", "")[0].(POSIXBackend).Dir != "" {
+		t.Fatal("empty state dir should leave Dir unset")
+	}
+}
+
 func TestSelectBackends_WindowsWithEngine(t *testing.T) {
 	prev := lookPath
 	t.Cleanup(func() { lookPath = prev })

--- a/internal/profilebackend/posix.go
+++ b/internal/profilebackend/posix.go
@@ -1,28 +1,54 @@
 package profilebackend
 
 import (
+	"path/filepath"
+
 	genvenv "github.com/ks1686/genv/internal/env"
 	"github.com/ks1686/genv/internal/schema"
 	"github.com/ks1686/genv/internal/shellcfg"
 )
 
 // POSIXBackend writes env.sh / shell.sh and injects into bash/zsh rc files.
-type POSIXBackend struct{}
+type POSIXBackend struct {
+	// Dir is the state directory for fragments. Empty uses the default config dir.
+	Dir string
+}
 
 func (POSIXBackend) Name() string { return "posix" }
 
-func (POSIXBackend) ApplyEnv(vars map[string]schema.EnvVar) error {
-	fragPath, err := genvenv.FragmentPath()
+func (b POSIXBackend) ApplyEnv(vars map[string]schema.EnvVar) error {
+	fragPath, err := b.envFragmentPath()
 	if err != nil {
 		return err
 	}
-	return genvenv.ApplyEnv(fragPath, vars, genvenv.RcFiles())
+	return genvenv.ApplyEnv(fragPath, vars, b.rcFiles())
 }
 
-func (POSIXBackend) ApplyShell(cfg *schema.ShellConfig) error {
-	fragPath, err := shellcfg.FragmentPath()
+func (b POSIXBackend) ApplyShell(cfg *schema.ShellConfig) error {
+	fragPath, err := b.shellFragmentPath()
 	if err != nil {
 		return err
 	}
-	return shellcfg.ApplyShell(fragPath, cfg, genvenv.RcFiles())
+	return shellcfg.ApplyShell(fragPath, cfg, b.rcFiles())
+}
+
+func (b POSIXBackend) envFragmentPath() (string, error) {
+	if b.Dir != "" {
+		return filepath.Join(b.Dir, "env.sh"), nil
+	}
+	return genvenv.FragmentPath()
+}
+
+func (b POSIXBackend) shellFragmentPath() (string, error) {
+	if b.Dir != "" {
+		return filepath.Join(b.Dir, "shell.sh"), nil
+	}
+	return shellcfg.FragmentPath()
+}
+
+func (b POSIXBackend) rcFiles() []string {
+	if !shouldInjectRC(b.Dir) {
+		return nil
+	}
+	return genvenv.RcFiles()
 }

--- a/internal/profilebackend/posix_test.go
+++ b/internal/profilebackend/posix_test.go
@@ -10,6 +10,28 @@ import (
 	"github.com/ks1686/genv/internal/testutil"
 )
 
+func TestPOSIXBackend_StateDirSkipsRCInject(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("SHELL", "/bin/zsh")
+
+	state := t.TempDir()
+	b := POSIXBackend{Dir: state}
+	if err := b.ApplyEnv(map[string]schema.EnvVar{"FOO": {Value: "bar"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(state, "env.sh")); err != nil {
+		t.Fatalf("expected fragment in state dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "genv", "env.sh")); err == nil {
+		t.Fatal("wrote default env.sh despite StateDir")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".zshrc")); err == nil {
+		t.Fatal("injected rc despite non-default state dir")
+	}
+}
+
 func TestPOSIXBackend_ApplyEnvAndShell(t *testing.T) {
 	home := t.TempDir()
 	testutil.SetHome(t, home)

--- a/internal/profilebackend/powershell.go
+++ b/internal/profilebackend/powershell.go
@@ -18,6 +18,8 @@ type PowerShellBackend struct {
 	Home string
 	// Engine overrides DetectEngine in tests.
 	Engine *Engine
+	// Dir is the state directory for fragments. Empty uses the default config dir.
+	Dir string
 }
 
 func (PowerShellBackend) Name() string { return "powershell" }
@@ -30,7 +32,7 @@ func (b PowerShellBackend) ApplyEnv(vars map[string]schema.EnvVar) error {
 	if err := WriteEnvPS1(fragPath, vars); err != nil {
 		return err
 	}
-	if len(vars) == 0 {
+	if len(vars) == 0 || !shouldInjectRC(b.Dir) {
 		return nil
 	}
 	profile, err := b.profilePath()
@@ -52,7 +54,7 @@ func (b PowerShellBackend) ApplyShell(cfg *schema.ShellConfig) error {
 	if err := WriteShellPS1(fragPath, cfg); err != nil {
 		return err
 	}
-	if !hasPowerShellFragmentContent(cfg) {
+	if !hasPowerShellFragmentContent(cfg) || !shouldInjectRC(b.Dir) {
 		return nil
 	}
 	profile, err := b.profilePath()
@@ -67,6 +69,9 @@ func (b PowerShellBackend) ApplyShell(cfg *schema.ShellConfig) error {
 }
 
 func (b PowerShellBackend) envFragmentPath() (string, error) {
+	if b.Dir != "" {
+		return filepath.Join(b.Dir, "env.ps1"), nil
+	}
 	dir, err := genvfile.DefaultDir()
 	if err != nil {
 		return "", err
@@ -75,6 +80,9 @@ func (b PowerShellBackend) envFragmentPath() (string, error) {
 }
 
 func (b PowerShellBackend) shellFragmentPath() (string, error) {
+	if b.Dir != "" {
+		return filepath.Join(b.Dir, "shell.ps1"), nil
+	}
 	dir, err := genvfile.DefaultDir()
 	if err != nil {
 		return "", err

--- a/main.go
+++ b/main.go
@@ -386,10 +386,74 @@ func addToSpec(file, id, version, prefer string, managers map[string]string, tar
 // appendLockEntry reads the lock at lockPath, appends lp, and writes it back.
 // Returns an exit code; exitOK means success.
 func lockPathForSpec(file, override string) string {
+	return lockPathForState(file, "", override)
+}
+
+func lockPathForState(file, stateDir, override string) string {
 	if override != "" {
 		return override
 	}
-	return genvfile.LockPathFrom(file)
+	dir, err := genvfile.ResolveStateDir(file, stateDir)
+	if err != nil {
+		return "genv.lock.json"
+	}
+	return genvfile.LockPathIn(dir)
+}
+
+func resolveApplyState(opts applyOptions) (stateDir, lockPath string, err error) {
+	stateDir, err = genvfile.ResolveStateDir(opts.File, opts.StateDir)
+	if err != nil {
+		return "", "", err
+	}
+	return stateDir, lockPathForState(opts.File, opts.StateDir, opts.LockFile), nil
+}
+
+func applyStatePaths(stateDir, lockPath string) output.StatePaths {
+	if stateDir == "" {
+		if dir, err := genvfile.DefaultDir(); err == nil {
+			stateDir = dir
+		}
+	}
+	envName, shellName := "env.sh", "shell.sh"
+	if runtime.GOOS == "windows" {
+		envName, shellName = "env.ps1", "shell.ps1"
+	}
+	return output.StatePaths{
+		Dir:   stateDir,
+		Lock:  lockPath,
+		Env:   filepath.Join(stateDir, envName),
+		Shell: filepath.Join(stateDir, shellName),
+	}
+}
+
+func printApplyStatePlan(w io.Writer, state output.StatePaths) {
+	fPrintln(w, "state:")
+	fprintf(w, "  lock: %s\n", state.Lock)
+	if state.Env != "" {
+		fprintf(w, "  env: %s\n", state.Env)
+	}
+	if state.Shell != "" {
+		fprintf(w, "  shell: %s\n", state.Shell)
+	}
+	fPrintln(w)
+}
+
+func guardApplyStateWrites(opts applyOptions, stateDir, lockPath string) error {
+	allowed, err := genvfile.ResolveStateDir(opts.File, opts.StateDir)
+	if err != nil {
+		return err
+	}
+	state := applyStatePaths(stateDir, lockPath)
+	if opts.LockFile == "" && !genvfile.WithinDir(allowed, lockPath) {
+		return fmt.Errorf("refusing to write lock %s outside %s (pass --lock-file or --state-dir)", lockPath, allowed)
+	}
+	if !genvfile.WithinDir(allowed, state.Env) {
+		return fmt.Errorf("refusing to write env fragment %s outside %s (pass --state-dir)", state.Env, allowed)
+	}
+	if !genvfile.WithinDir(allowed, state.Shell) {
+		return fmt.Errorf("refusing to write shell fragment %s outside %s (pass --state-dir)", state.Shell, allowed)
+	}
+	return nil
 }
 
 func stampLockTarget(lf *genvfile.LockFile, targetID string) {
@@ -835,6 +899,7 @@ func adoptCmd(args []string) int {
 
 	file := fs.String("file", defaultSpecPath(), "path to genv.json")
 	lockFile := fs.String("lock-file", "", "path to genv lock file")
+	stateDir := fs.String("state-dir", "", "directory for lock and env/shell fragments (default: directory of --file)")
 	version := fs.String("version", "", `version constraint, e.g. "0.10.*" (default: omitted, meaning any)`)
 	prefer := fs.String("prefer", "", "preferred package manager (e.g. brew)")
 	managerFlag := fs.String("manager", "", `manager-specific names, comma-separated mgr:name pairs (e.g. snap:hello,brew:hello)`)
@@ -861,7 +926,7 @@ func adoptCmd(args []string) int {
 		}
 	}
 	if *filesOnly {
-		return adoptFilesCmd(*file, *lockFile, *hostFlag, *targetFlag, *jsonOut)
+		return adoptFilesCmd(*file, *lockFile, *stateDir, *hostFlag, *targetFlag, *jsonOut)
 	}
 
 	managers, err := parseManagerFlag(*managerFlag)
@@ -925,7 +990,7 @@ func adoptCmd(args []string) int {
 		return exitLogic
 	}
 
-	lockPath := lockPathForSpec(*file, *lockFile)
+	lockPath := lockPathForState(*file, *stateDir, *lockFile)
 	lf, err := genvfile.ReadLock(lockPath)
 	if err != nil {
 		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
@@ -964,7 +1029,7 @@ func adoptCmd(args []string) int {
 	return exitOK
 }
 
-func adoptFilesCmd(file, lockFile, hostFlag, targetFlag string, jsonOut bool) int {
+func adoptFilesCmd(file, lockFile, stateDir, hostFlag, targetFlag string, jsonOut bool) int {
 	f, err := genvfile.Read(file)
 	if err != nil {
 		if errors.Is(err, genvfile.ErrNotFound) {
@@ -1008,7 +1073,7 @@ func adoptFilesCmd(file, lockFile, hostFlag, targetFlag string, jsonOut bool) in
 		return exitLogic
 	}
 
-	lockPath := lockPathForSpec(file, lockFile)
+	lockPath := lockPathForState(file, stateDir, lockFile)
 	lf, err := genvfile.ReadLock(lockPath)
 	if err != nil {
 		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
@@ -1174,24 +1239,26 @@ func hostForCommand(hostFlag string) string {
 // Reconciles the system against genv.json by installing added packages and
 // removing packages that were deleted from the spec since the last apply.
 type applyOptions struct {
-	File          string
-	LockFile      string
-	Host          string
-	DryRun        bool
-	Strict        bool
-	Yes           bool
-	Quiet         bool
-	JSONOut       bool
-	Force         bool
-	Backup        bool
-	Timeout       time.Duration
-	Debug         bool
-	TargetProfile string
-	Target        string
-	ForceNewLock  bool
-	NoHooks       bool
-	HookTimeout   time.Duration
-	SkipPackages  bool
+	File             string
+	LockFile         string
+	StateDir         string
+	Host             string
+	DryRun           bool
+	Strict           bool
+	Yes              bool
+	Quiet            bool
+	JSONOut          bool
+	Force            bool
+	Backup           bool
+	Timeout          time.Duration
+	Debug            bool
+	TargetProfile    string
+	Target           string
+	ForceNewLock     bool
+	NoHooks          bool
+	HookTimeout      time.Duration
+	SkipPackages     bool
+	resolvedStateDir string
 }
 
 func applyCmd(args []string) int {
@@ -1206,6 +1273,7 @@ func applyCmd(args []string) int {
 	opts := applyOptions{}
 	fs.StringVar(&opts.File, "file", defaultSpecPath(), "path to genv.json")
 	fs.StringVar(&opts.LockFile, "lock-file", "", "path to genv lock file")
+	fs.StringVar(&opts.StateDir, "state-dir", "", "directory for lock and env/shell fragments (default: directory of --file)")
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "print the reconcile plan without executing")
 	fs.BoolVar(&opts.Force, "force", false, "overwrite mismatched managed files")
 	fs.BoolVar(&opts.Backup, "backup", false, "back up mismatched files before overwrite (implies keeping originals as *.backup.*)")
@@ -1243,7 +1311,18 @@ func runApply(opts applyOptions) int {
 		ctx = resolver.WithSubprocessTimeout(ctx, opts.Timeout)
 	}
 
-	lockPath := lockPathForSpec(opts.File, opts.LockFile)
+	stateDir, lockPath, err := resolveApplyState(opts)
+	if err != nil {
+		fprintf(os.Stderr, "genv: resolving state paths: %v\n", err)
+		return exitIO
+	}
+	if !opts.DryRun {
+		if err := guardApplyStateWrites(opts, stateDir, lockPath); err != nil {
+			fprintf(os.Stderr, "genv apply: %v\n", err)
+			return exitLogic
+		}
+	}
+	opts.resolvedStateDir = stateDir
 	unlock, err := genvfile.LockMutation(lockPath)
 	if err != nil {
 		fprintf(os.Stderr, "genv: locking %s: %v\n", lockPath, err)
@@ -1348,6 +1427,8 @@ func runApplyWithSpecAndLock(ctx context.Context, opts applyOptions, f *schema.G
 func runApplyJSON(ctx context.Context, opts applyOptions, lockPath string, f *schema.GenvFile, lf *genvfile.LockFile, result resolver.ReconcileResult) int {
 	printReconcileWarnings(result)
 	planData := buildPlanResult(f, lf, result)
+	state := applyStatePaths(opts.resolvedStateDir, lockPath)
+	planData.State = &state
 	if opts.DryRun {
 		filePlan, filePlanErr := applyFiles(ctx, opts, f, lf)
 		planData.Files = filePlanEntries(filePlan)
@@ -1383,11 +1464,11 @@ func runApplyJSON(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	filePlan := &files.ApplyResult{}
 	filePlanErr := error(nil)
 	var envErr, shellErr error
-	envApplied, envRemoved, envErr = applyEnvVars(f, lf, false)
+	envApplied, envRemoved, envErr = applyEnvVars(f, lf, false, opts.resolvedStateDir)
 	if envErr != nil {
 		errs = append(errs, envErr.Error())
 	}
-	shellApplied, shellRemoved, shellErr = applyShellCfg(f, lf, false)
+	shellApplied, shellRemoved, shellErr = applyShellCfg(f, lf, false, opts.resolvedStateDir)
 	if shellErr != nil {
 		errs = append(errs, shellErr.Error())
 	}
@@ -1463,6 +1544,7 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	if opts.Quiet {
 		planOut = io.Discard
 	}
+	printApplyStatePlan(planOut, applyStatePaths(opts.resolvedStateDir, lockPath))
 	toInstall, toRemove, unresolvedCount := printApplyReconcilePlan(planOut, opts.SkipPackages, result)
 
 	var envChanges int
@@ -1560,10 +1642,10 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	var svcErrs []error
 	var fileErrs []error
 	var appliedFiles *files.ApplyResult
-	if _, _, err := applyEnvVars(f, lf, !opts.Quiet); err != nil {
+	if _, _, err := applyEnvVars(f, lf, !opts.Quiet, opts.resolvedStateDir); err != nil {
 		fileErrs = append(fileErrs, err)
 	}
-	if _, _, err := applyShellCfg(f, lf, !opts.Quiet); err != nil {
+	if _, _, err := applyShellCfg(f, lf, !opts.Quiet, opts.resolvedStateDir); err != nil {
 		fileErrs = append(fileErrs, err)
 	}
 	_, _, svcErrs = applyServices(ctx, f, lf, !opts.Quiet)
@@ -1709,7 +1791,7 @@ func writeLockAfterApply(lockPath string, lf *genvfile.LockFile, result resolver
 // names. The caller is responsible for persisting the lock file (avoiding a
 // double-write when packages and env vars are both applied in the same run).
 // If verbose is true, it prints progress lines to stdout.
-func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (applied, removed []string, err error) {
+func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool, stateDir string) (applied, removed []string, err error) {
 	if len(f.Env) == 0 && len(lf.Env) == 0 {
 		return nil, nil, nil
 	}
@@ -1728,7 +1810,7 @@ func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (appl
 		fprintf(os.Stderr, "genv: warning: %s\n", warn)
 	}
 
-	backends := profilebackend.SelectBackends(runtime.GOOS)
+	backends := profilebackend.SelectBackendsIn(runtime.GOOS, stateDir)
 	var lastFrag string
 	for _, b := range backends {
 		if err := b.ApplyEnv(f.Env); err != nil {
@@ -1750,9 +1832,8 @@ func applyEnvVars(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (appl
 			fprintf(os.Stdout, "  env: removed %s\n", name)
 		}
 		if len(applied) > 0 || len(removed) > 0 {
-			if fragPath, err := genvenv.FragmentPath(); err == nil {
-				fprintf(os.Stdout, "env fragment written (%s backends) e.g. %s\n", lastFrag, fragPath)
-			}
+			state := applyStatePaths(stateDir, "")
+			fprintf(os.Stdout, "env fragment written (%s backends) e.g. %s\n", lastFrag, state.Env)
 		}
 	}
 
@@ -2630,7 +2711,7 @@ func shellEditCmd(args []string) int {
 // applyShellCfg writes managed shell fragments via selected profile backends,
 // updates lf.Shell in memory, and returns lists of applied and removed entry
 // names. The caller writes the lock. If verbose is true, it prints progress.
-func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (applied, removed []string, err error) {
+func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool, stateDir string) (applied, removed []string, err error) {
 	if f.Shell == nil && lf.Shell == nil {
 		return nil, nil, nil
 	}
@@ -2676,7 +2757,7 @@ func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (app
 	if f.Shell != nil {
 		cfg = f.Shell
 	}
-	backends := profilebackend.SelectBackends(runtime.GOOS)
+	backends := profilebackend.SelectBackendsIn(runtime.GOOS, stateDir)
 	for _, b := range backends {
 		if err := b.ApplyShell(cfg); err != nil {
 			fprintf(os.Stderr, "genv: writing shell fragment (%s): %v\n", b.Name(), err)
@@ -2692,15 +2773,14 @@ func applyShellCfg(f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (app
 			fprintf(os.Stdout, "  shell: removed %s\n", name)
 		}
 		if len(applied) > 0 || len(removed) > 0 {
-			if fragPath, err := shellcfg.FragmentPath(); err == nil {
-				fprintf(os.Stdout, "shell fragment written to %s\n", fragPath)
-			}
+			state := applyStatePaths(stateDir, "")
+			fprintf(os.Stdout, "shell fragment written to %s\n", state.Shell)
 		}
 	}
 	if hasFishEntries {
-		fragPath, _ := shellcfg.FragmentPath()
+		state := applyStatePaths(stateDir, "")
 		fprintf(os.Stdout, "note: fish-specific shell entries are not auto-applied.\n")
-		fprintf(os.Stdout, "      Add '. %s' to ~/.config/fish/config.fish to source them.\n", fragPath)
+		fprintf(os.Stdout, "      Add '. %s' to ~/.config/fish/config.fish to source them.\n", state.Shell)
 	}
 
 	// Update lf.Shell in memory; caller writes the lock once.

--- a/main_helpers_coverage_test.go
+++ b/main_helpers_coverage_test.go
@@ -264,7 +264,7 @@ func TestApplyEnvVarsAndShellCfg(t *testing.T) {
 		},
 	}
 
-	applied, removed, err := applyEnvVars(f, lf, true)
+	applied, removed, err := applyEnvVars(f, lf, true, "")
 	if err != nil {
 		t.Fatalf("applyEnvVars: %v", err)
 	}
@@ -277,7 +277,7 @@ func TestApplyEnvVarsAndShellCfg(t *testing.T) {
 
 	// Removal path: clear spec env while lock still has FOO.
 	f.Env = map[string]schema.EnvVar{}
-	applied, removed, err = applyEnvVars(f, lf, true)
+	applied, removed, err = applyEnvVars(f, lf, true, "")
 	if err != nil {
 		t.Fatalf("applyEnvVars remove: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestApplyEnvVarsAndShellCfg(t *testing.T) {
 		t.Fatalf("env remove = %v %v", applied, removed)
 	}
 
-	applied, removed, err = applyShellCfg(f, lf, true)
+	applied, removed, err = applyShellCfg(f, lf, true, "")
 	if err != nil {
 		t.Fatalf("applyShellCfg: %v", err)
 	}
@@ -296,7 +296,7 @@ func TestApplyEnvVarsAndShellCfg(t *testing.T) {
 		t.Fatal("expected lock shell updated")
 	}
 	if !strings.Contains(captureStdout(t, func() {
-		_, _, _ = applyShellCfg(f, lf, false)
+		_, _, _ = applyShellCfg(f, lf, false, "")
 	}), "") {
 		// fish note only prints when hasFishEntries; force by keeping fish alias
 	}
@@ -304,16 +304,16 @@ func TestApplyEnvVarsAndShellCfg(t *testing.T) {
 	out := captureStdout(t, func() {
 		f2 := &schema.GenvFile{Shell: f.Shell}
 		lf2 := &genvfile.LockFile{}
-		_, _, _ = applyShellCfg(f2, lf2, false)
+		_, _, _ = applyShellCfg(f2, lf2, false, "")
 	})
 	if !strings.Contains(out, "fish-specific") {
 		t.Errorf("expected fish note, got %q", out)
 	}
 
-	if a, r, err := applyEnvVars(&schema.GenvFile{}, &genvfile.LockFile{}, false); a != nil || r != nil || err != nil {
+	if a, r, err := applyEnvVars(&schema.GenvFile{}, &genvfile.LockFile{}, false, ""); a != nil || r != nil || err != nil {
 		t.Errorf("empty env apply = %v %v %v", a, r, err)
 	}
-	if a, r, err := applyShellCfg(&schema.GenvFile{}, &genvfile.LockFile{}, false); a != nil || r != nil || err != nil {
+	if a, r, err := applyShellCfg(&schema.GenvFile{}, &genvfile.LockFile{}, false, ""); a != nil || r != nil || err != nil {
 		t.Errorf("empty shell apply = %v %v %v", a, r, err)
 	}
 }
@@ -338,7 +338,7 @@ func TestAdoptFilesCmd_SuccessAndJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if code := adoptFilesCmd(specPath, "", "", "", false); code != exitOK {
+	if code := adoptFilesCmd(specPath, "", "", "", "", false); code != exitOK {
 		t.Fatalf("adopt files = %d", code)
 	}
 	lockPath := genvfile.LockPathFrom(specPath)
@@ -352,7 +352,7 @@ func TestAdoptFilesCmd_SuccessAndJSON(t *testing.T) {
 
 	var code int
 	out := captureStdout(t, func() {
-		code = adoptFilesCmd(specPath, "", "", "", true)
+		code = adoptFilesCmd(specPath, "", "", "", "", true)
 	})
 	if code != exitOK {
 		t.Fatalf("adopt files --json = %d (%s)", code, out)
@@ -361,7 +361,7 @@ func TestAdoptFilesCmd_SuccessAndJSON(t *testing.T) {
 		t.Errorf("json output = %s", out)
 	}
 
-	if code := adoptFilesCmd(filepath.Join(dir, "missing.json"), "", "", "", false); code != exitIO {
+	if code := adoptFilesCmd(filepath.Join(dir, "missing.json"), "", "", "", "", false); code != exitIO {
 		t.Errorf("missing spec = %d", code)
 	}
 }

--- a/main_profile.go
+++ b/main_profile.go
@@ -96,6 +96,7 @@ func profileSwitchCmd(args []string) int {
 	opts := applyOptions{}
 	fs.StringVar(&opts.File, "file", defaultSpecPath(), "path to genv.json")
 	fs.StringVar(&opts.LockFile, "lock-file", "", "path to genv lock file")
+	fs.StringVar(&opts.StateDir, "state-dir", "", "directory for lock and env/shell fragments (default: directory of --file)")
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "print the reconcile plan without executing")
 	fs.BoolVar(&opts.Force, "force", false, "overwrite mismatched managed files")
 	fs.BoolVar(&opts.Strict, "strict", false, "exit with an error if any package cannot be resolved")

--- a/main_state_dir_test.go
+++ b/main_state_dir_test.go
@@ -1,0 +1,306 @@
+package main
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ks1686/genv/internal/genvfile"
+	"github.com/ks1686/genv/internal/schema"
+	"github.com/ks1686/genv/internal/testutil"
+)
+
+func TestApplyCmd_File_LeavesDefaultConfigDirUnchanged(t *testing.T) {
+	live := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", live)
+	testutil.SetHome(t, live)
+
+	liveGenv := filepath.Join(live, "genv")
+	if err := os.MkdirAll(liveGenv, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	liveSpec := filepath.Join(liveGenv, "genv.json")
+	writeTestFile(t, liveSpec, `{
+		"schemaVersion": "8",
+		"defaults": {
+			"env": {
+				"EDITOR": {"value": "nvim"},
+				"VISUAL": {"value": "nvim"},
+				"HOMEBREW_NO_ENV_HINTS": {"value": "1"}
+			}
+		},
+		"targets": {"linux": {}}
+	}`)
+	writeTestFile(t, filepath.Join(liveGenv, "env.sh"), "# live env\nexport EDITOR=nvim\n")
+	writeTestFile(t, filepath.Join(liveGenv, "shell.sh"), "# live shell\nalias ll='ls -la'\n")
+	liveLock := &genvfile.LockFile{
+		SchemaVersion: schema.Version8,
+		Target:        "linux",
+		GOOS:          runtime.GOOS,
+		Env: []genvfile.LockedEnvVar{
+			{Name: "EDITOR", Value: "nvim"},
+			{Name: "VISUAL", Value: "nvim"},
+			{Name: "HOMEBREW_NO_ENV_HINTS", Value: "1"},
+		},
+	}
+	if err := genvfile.WriteLock(filepath.Join(liveGenv, "genv.lock.json"), liveLock); err != nil {
+		t.Fatal(err)
+	}
+
+	before := snapshotDir(t, liveGenv)
+
+	sandbox := t.TempDir()
+	sandboxSpec := filepath.Join(sandbox, "genv.json")
+	writeTestFile(t, sandboxSpec, `{
+		"schemaVersion": "8",
+		"defaults": {
+			"env": {
+				"SANDBOX_ONLY": {"value": "1"}
+			}
+		},
+		"targets": {"linux": {}}
+	}`)
+
+	code := run([]string{"apply", "--file", sandboxSpec, "--skip-packages", "--no-hooks", "--yes", "--target", "linux"})
+	if code != exitOK {
+		t.Fatalf("sandbox apply: got exit %d, want %d", code, exitOK)
+	}
+
+	after := snapshotDir(t, liveGenv)
+	if diff := dirDiff(before, after); diff != "" {
+		t.Fatalf("default config dir changed after --file apply:\n%s", diff)
+	}
+
+	if _, err := os.Stat(filepath.Join(sandbox, "genv.lock.json")); err != nil {
+		t.Fatalf("expected lock next to sandbox spec: %v", err)
+	}
+	envName := "env.sh"
+	if runtime.GOOS == "windows" {
+		envName = "env.ps1"
+	}
+	if _, err := os.Stat(filepath.Join(sandbox, envName)); err != nil {
+		t.Fatalf("expected env fragment next to sandbox spec: %v", err)
+	}
+}
+
+func TestApplyCmd_DryRun_NamesStatePaths(t *testing.T) {
+	live := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", live)
+	testutil.SetHome(t, live)
+
+	sandbox := t.TempDir()
+	spec := filepath.Join(sandbox, "genv.json")
+	writeTestFile(t, spec, `{
+		"schemaVersion": "8",
+		"defaults": {
+			"env": {"SANDBOX_ONLY": {"value": "1"}},
+			"shell": {"aliases": {"ll": {"value": "ls -la"}}}
+		},
+		"targets": {"linux": {}}
+	}`)
+
+	var code int
+	out := captureStdout(t, func() {
+		code = run([]string{"apply", "--file", spec, "--dry-run", "--skip-packages", "--target", "linux"})
+	})
+	if code != exitOK {
+		t.Fatalf("dry-run apply: got exit %d, want %d\n%s", code, exitOK, out)
+	}
+
+	lockWant := filepath.Join(sandbox, "genv.lock.json")
+	if !strings.Contains(out, lockWant) {
+		t.Fatalf("plan missing lock path %q\n%s", lockWant, out)
+	}
+	if !strings.Contains(out, filepath.Join(sandbox, "env.sh")) && !strings.Contains(out, filepath.Join(sandbox, "env.ps1")) {
+		t.Fatalf("plan missing env fragment path under %s\n%s", sandbox, out)
+	}
+	if !strings.Contains(out, filepath.Join(sandbox, "shell.sh")) && !strings.Contains(out, filepath.Join(sandbox, "shell.ps1")) {
+		t.Fatalf("plan missing shell fragment path under %s\n%s", sandbox, out)
+	}
+
+	jsonOut := captureStdout(t, func() {
+		code = run([]string{"apply", "--file", spec, "--dry-run", "--json", "--skip-packages", "--target", "linux"})
+	})
+	if code != exitOK {
+		t.Fatalf("json dry-run: got exit %d\n%s", code, jsonOut)
+	}
+	var env map[string]any
+	if err := json.Unmarshal([]byte(jsonOut), &env); err != nil {
+		t.Fatalf("json: %v\n%s", err, jsonOut)
+	}
+	data, _ := env["data"].(map[string]any)
+	state, _ := data["state"].(map[string]any)
+	if state == nil {
+		t.Fatalf("json plan missing data.state: %s", jsonOut)
+	}
+	if lock, _ := state["lock"].(string); lock != lockWant {
+		t.Fatalf("json state.lock = %q, want %q", lock, lockWant)
+	}
+}
+
+func TestAdoptCmd_File_ReadsLockNextToSpec(t *testing.T) {
+	live := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", live)
+	testutil.SetHome(t, live)
+	withInstalledBrew(t)
+
+	liveGenv := filepath.Join(live, "genv")
+	if err := os.MkdirAll(liveGenv, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeLock(t, filepath.Join(liveGenv, "genv.lock.json"), []genvfile.LockedPackage{
+		{ID: "git", Manager: "brew", PkgName: "git"},
+	})
+
+	sandbox := t.TempDir()
+	spec := filepath.Join(sandbox, "genv.json")
+	writeTestFile(t, spec, `{
+		"schemaVersion": "8",
+		"defaults": {},
+		"targets": {"linux": {}}
+	}`)
+
+	code := run([]string{"adopt", "--file", spec, "--prefer", "brew", "--target", "linux", "git"})
+	if code != exitOK {
+		t.Fatalf("adopt --file: got exit %d, want %d (must not consult the default lock)", code, exitOK)
+	}
+
+	sandboxLock := filepath.Join(sandbox, "genv.lock.json")
+	lf, err := genvfile.ReadLock(sandboxLock)
+	if err != nil {
+		t.Fatalf("read sandbox lock: %v", err)
+	}
+	if len(lf.Packages) != 1 || lf.Packages[0].ID != "git" {
+		t.Fatalf("sandbox lock packages = %+v, want git", lf.Packages)
+	}
+
+	liveLF, err := genvfile.ReadLock(filepath.Join(liveGenv, "genv.lock.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(liveLF.Packages) != 1 || liveLF.Packages[0].ID != "git" {
+		t.Fatalf("live lock mutated: %+v", liveLF.Packages)
+	}
+}
+
+func TestApplyCmd_StateDir_OverridesLockAndFragments(t *testing.T) {
+	live := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", live)
+	testutil.SetHome(t, live)
+	liveGenv := filepath.Join(live, "genv")
+	if err := os.MkdirAll(liveGenv, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(liveGenv, "env.sh"), "# live\n")
+	before := snapshotDir(t, liveGenv)
+
+	specDir := t.TempDir()
+	stateDir := t.TempDir()
+	spec := filepath.Join(specDir, "genv.json")
+	writeTestFile(t, spec, `{
+		"schemaVersion": "8",
+		"defaults": {"env": {"FROM_STATE_DIR": {"value": "yes"}}},
+		"targets": {"linux": {}}
+	}`)
+
+	code := run([]string{
+		"apply", "--file", spec, "--state-dir", stateDir,
+		"--skip-packages", "--no-hooks", "--yes", "--target", "linux",
+	})
+	if code != exitOK {
+		t.Fatalf("apply --state-dir: got exit %d", code)
+	}
+
+	if _, err := os.Stat(filepath.Join(stateDir, "genv.lock.json")); err != nil {
+		t.Fatalf("lock not in --state-dir: %v", err)
+	}
+	envName := "env.sh"
+	if runtime.GOOS == "windows" {
+		envName = "env.ps1"
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, envName)); err != nil {
+		t.Fatalf("env fragment not in --state-dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(specDir, "genv.lock.json")); err == nil {
+		t.Fatal("lock written next to spec despite --state-dir")
+	}
+	if diff := dirDiff(before, snapshotDir(t, liveGenv)); diff != "" {
+		t.Fatalf("live config dir changed:\n%s", diff)
+	}
+}
+
+func TestApplyCmd_File_WetApplyDoesNotWriteDefaultLock(t *testing.T) {
+	live := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", live)
+	testutil.SetHome(t, live)
+
+	sandbox := t.TempDir()
+	spec := filepath.Join(sandbox, "genv.json")
+	writeTestFile(t, spec, `{
+		"schemaVersion": "8",
+		"defaults": {"env": {"SANDBOX_ONLY": {"value": "1"}}},
+		"targets": {"linux": {}}
+	}`)
+
+	code := run([]string{"apply", "--file", spec, "--skip-packages", "--no-hooks", "--yes", "--target", "linux"})
+	if code != exitOK {
+		t.Fatalf("apply: got exit %d", code)
+	}
+
+	defaultLock := filepath.Join(live, "genv", "genv.lock.json")
+	if _, err := os.Stat(defaultLock); err == nil {
+		t.Fatalf("wet apply wrote default lock %s", defaultLock)
+	}
+}
+
+func snapshotDir(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			out[rel+"/"] = ""
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		out[rel] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot %s: %v", root, err)
+	}
+	return out
+}
+
+func dirDiff(before, after map[string]string) string {
+	var b strings.Builder
+	for k, v := range before {
+		got, ok := after[k]
+		if !ok {
+			b.WriteString("removed " + k + "\n")
+			continue
+		}
+		if got != v {
+			b.WriteString("changed " + k + "\n")
+		}
+	}
+	for k := range after {
+		if _, ok := before[k]; !ok {
+			b.WriteString("added " + k + "\n")
+		}
+	}
+	return b.String()
+}

--- a/main_state_dir_test.go
+++ b/main_state_dir_test.go
@@ -187,6 +187,42 @@ func TestAdoptCmd_File_ReadsLockNextToSpec(t *testing.T) {
 	}
 }
 
+func TestAdoptCmd_Files_WritesLockNextToSpec(t *testing.T) {
+	live := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", live)
+	testutil.SetHome(t, live)
+
+	sandbox := t.TempDir()
+	src := filepath.Join(sandbox, "src.txt")
+	dst := filepath.Join(sandbox, "dst.txt")
+	if err := os.WriteFile(src, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	spec := filepath.Join(sandbox, "genv.json")
+	writeTestFile(t, spec, `{
+		"schemaVersion": "6",
+		"files": {"links": [{"source": `+jsonString(src)+`, "target": `+jsonString(dst)+`}]}
+	}`)
+
+	code := run([]string{"adopt", "--file", spec, "--files"})
+	if code != exitOK {
+		t.Fatalf("adopt --files --file: got exit %d, want %d", code, exitOK)
+	}
+	lf, err := genvfile.ReadLock(filepath.Join(sandbox, "genv.lock.json"))
+	if err != nil {
+		t.Fatalf("read sandbox lock: %v", err)
+	}
+	if len(lf.Files) != 1 {
+		t.Fatalf("sandbox lock files = %+v, want one entry", lf.Files)
+	}
+	if _, err := os.Stat(filepath.Join(live, "genv", "genv.lock.json")); err == nil {
+		t.Fatal("adopt --files wrote the default config lock")
+	}
+}
+
 func TestApplyCmd_StateDir_OverridesLockAndFragments(t *testing.T) {
 	live := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", live)

--- a/main_test.go
+++ b/main_test.go
@@ -29,7 +29,7 @@ import (
 // TestMain disables interactive prompts (package search picker, remove fuzzy
 // match) for all unit tests so they run non-interactively. It also isolates
 // the genv config directory so tests do not read or write the developer's
-// real lock file now that LockPathFrom uses the genv config directory.
+// real lock file now that commands default the lock next to --file.
 func TestMain(m *testing.M) {
 	_ = os.Setenv("GENV_NO_INTERACTIVE", "1")
 	if os.Getenv("XDG_CONFIG_HOME") == "" {
@@ -3518,7 +3518,7 @@ func TestApplyCmd_PackageFailure_StillAppliesEnv(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		fragName = "env.ps1"
 	}
-	frag := filepath.Join(dir, "genv", fragName)
+	frag := filepath.Join(dir, fragName)
 	if _, err := os.Stat(frag); err != nil {
 		t.Fatalf("env fragment %s missing after package failure: %v", frag, err)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #138.

`--file` used to move only the spec. The lock, `env.sh`, and `shell.sh` still lived under the default config dir, so a sandbox or worktree apply rewrote live machine state.

**Behavior**
- Lock and env/shell fragments default to the directory that contains `--file`.
- `--state-dir` relocates all three.
- `--lock-file` still overrides just the lock.
- Apply plan (text and JSON, including dry-run) names the lock and fragment paths.
- `adopt --file` / `adopt --files` read and write the lock next to the spec (or `--state-dir`).
- Wet apply refuses to write lock/fragments outside the spec (or `--state-dir`) directory without an explicit flag.
- Non-default state dirs skip rc/profile injection so a sandbox apply does not edit live shell rc files.

**Tests**
- Sandbox `apply --file` leaves the default config dir byte-identical.
- Files e2e S7 asserts the lock beside `--file`, not the isolated HOME default.
- Files e2e S8 gitignores the sibling lock so a git-tracked spec repo stays clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5d1b459-5423-459c-9808-e0ac5c2c9da9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5d1b459-5423-459c-9808-e0ac5c2c9da9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

