### PR TITLE
fix: record installed versions on adopt and backfill apply

### DIFF
--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -44,6 +44,20 @@ type StatusEntry struct {
 	InstalledVersion string // recorded version from lock, may be empty
 }
 
+// DisplayVersion is the human-readable version column for an OK status row.
+// A recorded install version wins. "*" means no spec constraint (and no
+// recorded install version). "?" means a constraint exists but the lock has
+// no installed version.
+func (e StatusEntry) DisplayVersion() string {
+	if e.InstalledVersion != "" {
+		return e.InstalledVersion
+	}
+	if e.SpecVersion == "" {
+		return "*"
+	}
+	return "?"
+}
+
 // Status computes the three-way diff between the spec (genv.json) and the lock
 // file (genv.lock.json). It does not query the live system — the lock file is
 // the record of what genv last installed.

--- a/internal/commands/status_test.go
+++ b/internal/commands/status_test.go
@@ -101,6 +101,28 @@ func TestStatus_NoDriftWhenNoInstalledVersion(t *testing.T) {
 	}
 }
 
+func TestStatusEntry_DisplayVersion(t *testing.T) {
+	cases := []struct {
+		name      string
+		spec      string
+		installed string
+		want      string
+	}{
+		{name: "installed version wins", spec: "", installed: "2.1.259", want: "2.1.259"},
+		{name: "installed version wins over constraint", spec: "2.*", installed: "2.1.259", want: "2.1.259"},
+		{name: "no constraint and unknown install", spec: "", installed: "", want: "*"},
+		{name: "constraint and unknown install", spec: "2.40.*", installed: "", want: "?"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StatusEntry{SpecVersion: tc.spec, InstalledVersion: tc.installed}.DisplayVersion()
+			if got != tc.want {
+				t.Fatalf("DisplayVersion() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestStatus_Empty(t *testing.T) {
 	entries := Status(&schema.GenvFile{}, &genvfile.LockFile{})
 	if len(entries) != 0 {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -835,3 +835,44 @@ func ExecuteApply(ctx context.Context, result ReconcileResult, stdin io.Reader, 
 
 	return out
 }
+
+// FillMissingInstalledVersions writes InstalledVersion on lock entries that
+// lack one, using each manager's VersionLister inventory when that listing
+// already reports versions. Existing versions are left unchanged. Managers
+// that are not VersionListers, failed listings, and names absent from the
+// inventory are skipped.
+func FillMissingInstalledVersions(pkgs []genvfile.LockedPackage) {
+	byMgr := make(map[string][]int)
+	for i, lp := range pkgs {
+		if lp.InstalledVersion != "" || lp.Manager == "" {
+			continue
+		}
+		byMgr[lp.Manager] = append(byMgr[lp.Manager], i)
+	}
+	for mgrName, idxs := range byMgr {
+		mgr := adapter.ByName(mgrName)
+		if mgr == nil {
+			continue
+		}
+		versionLister, ok := mgr.(adapter.VersionLister)
+		if !ok {
+			continue
+		}
+		listed, err := CallTimed(versionLister.ListInstalledVersions, DefaultLiveListTimeout)
+		if err != nil || len(listed) == 0 {
+			continue
+		}
+		for _, i := range idxs {
+			if v := listed[pkgs[i].PkgName]; v != "" {
+				pkgs[i].InstalledVersion = v
+				continue
+			}
+			for name, ver := range listed {
+				if ver != "" && strings.EqualFold(name, pkgs[i].PkgName) {
+					pkgs[i].InstalledVersion = ver
+					break
+				}
+			}
+		}
+	}
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -533,6 +533,39 @@ func (m *testBatchVersionListerMgr) ListInstalledVersions() (map[string]string, 
 	return m.versions, nil
 }
 
+func TestFillMissingInstalledVersions_UsesVersionListerInventory(t *testing.T) {
+	mgr := &testBatchVersionListerMgr{versions: map[string]string{
+		"git":     "2.45.0",
+		"ripgrep": "14.1.0",
+	}}
+	orig := adapter.All
+	adapter.All = append([]adapter.Adapter{mgr}, orig...)
+	t.Cleanup(func() { adapter.All = orig })
+
+	pkgs := []genvfile.LockedPackage{
+		{ID: "git", Manager: "batchmgr", PkgName: "git"},
+		{ID: "ripgrep", Manager: "batchmgr", PkgName: "ripgrep", InstalledVersion: "13.0.0"},
+		{ID: "neovim", Manager: "batchmgr", PkgName: "neovim"},
+		{ID: "curl", Manager: "not-a-manager", PkgName: "curl"},
+	}
+	FillMissingInstalledVersions(pkgs)
+	if mgr.listCalls != 1 {
+		t.Fatalf("ListInstalledVersions calls = %d, want 1", mgr.listCalls)
+	}
+	if pkgs[0].InstalledVersion != "2.45.0" {
+		t.Errorf("git = %q, want 2.45.0", pkgs[0].InstalledVersion)
+	}
+	if pkgs[1].InstalledVersion != "13.0.0" {
+		t.Errorf("ripgrep = %q, want existing 13.0.0", pkgs[1].InstalledVersion)
+	}
+	if pkgs[2].InstalledVersion != "" {
+		t.Errorf("neovim = %q, want empty (absent from inventory)", pkgs[2].InstalledVersion)
+	}
+	if pkgs[3].InstalledVersion != "" {
+		t.Errorf("curl = %q, want empty (unknown manager)", pkgs[3].InstalledVersion)
+	}
+}
+
 func TestReconcile_RemovalPathSkipsMissingManagers(t *testing.T) {
 	result := Reconcile(
 		nil,

--- a/main.go
+++ b/main.go
@@ -924,6 +924,10 @@ func adoptCmd(args []string) int {
 		fprintf(os.Stderr, "genv adopt: %q is not installed via %s — use 'genv add %s' to install it\n", id, action.Manager, id)
 		return exitLogic
 	}
+	installedVersion := ""
+	if v, err := mgr.QueryVersion(action.PkgName); err == nil {
+		installedVersion = v
+	}
 
 	lockPath := lockPathForSpec(*file, *lockFile)
 	lf, err := genvfile.ReadLock(lockPath)
@@ -953,9 +957,10 @@ func adoptCmd(args []string) int {
 		}
 	}
 	if exit := appendLockEntry(lockPath, genvfile.LockedPackage{
-		ID:      action.Pkg.ID,
-		Manager: action.Manager,
-		PkgName: action.PkgName,
+		ID:               action.Pkg.ID,
+		Manager:          action.Manager,
+		PkgName:          action.PkgName,
+		InstalledVersion: installedVersion,
 	}, targetID); exit != exitOK {
 		return exit
 	}
@@ -1696,6 +1701,7 @@ func writeLockAfterApply(lockPath string, lf *genvfile.LockFile, result resolver
 				}
 			}
 		}
+		resolver.FillMissingInstalledVersions(newPkgs)
 		lf.Packages = newPkgs
 	}
 	if err := genvfile.WriteLock(lockPath, lf); err != nil {
@@ -3188,11 +3194,7 @@ func statusCmd(args []string) int {
 		}
 		switch e.Kind {
 		case commands.StatusOK:
-			v := e.InstalledVersion
-			if v == "" {
-				v = "*"
-			}
-			fprintf(tw, "  ok	%s	%s	%s\n", e.ID, mgr, v)
+			fprintf(tw, "  ok	%s	%s	%s\n", e.ID, mgr, e.DisplayVersion())
 		case commands.StatusPresent:
 			note := "(installed, not in lock — apply will adopt)"
 			fprintf(tw, "  present	%s	%s	%s\n", e.ID, mgr, note)

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"slices"
 	"strconv"
@@ -824,6 +825,43 @@ func TestAdoptCmd_AlreadyInLock_StillFails(t *testing.T) {
 	}
 }
 
+func TestAdoptCmd_RecordsInstalledVersion(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.InstallFakeBinary(t, "brew", `
+case "$1" in
+list)
+	if [ "$2" = "--versions" ]; then
+		echo "${3:-git} 2.43.0"
+		exit 0
+	fi
+	exit 0
+	;;
+*)
+	exit 0
+	;;
+esac`)
+	path := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	writeTestFile(t, path, `{"schemaVersion":"1","packages":[]}`)
+	writeLock(t, lockPath, nil)
+
+	code := run([]string{"adopt", "--file", path, "--lock-file", lockPath, "--prefer", "brew", "git"})
+	if code != exitOK {
+		t.Fatalf("adopt: got %d, want %d", code, exitOK)
+	}
+	lf, err := genvfile.ReadLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lf.Packages) != 1 {
+		t.Fatalf("lock packages = %+v, want 1", lf.Packages)
+	}
+	if got := lf.Packages[0].InstalledVersion; got != "2.43.0" {
+		t.Fatalf("InstalledVersion = %q, want 2.43.0", got)
+	}
+}
+
 // ---- genv disown -------------------------------------------------------------
 // disown removes the package from genv.json and the lock file without uninstalling.
 
@@ -1207,6 +1245,51 @@ func TestApplyCmd_AlreadyUpToDate(t *testing.T) {
 	code := run([]string{"apply", "--file", path})
 	if code != exitOK {
 		t.Errorf("up to date: expected exitOK, got %d", code)
+	}
+}
+
+func TestApplyCmd_BackfillsMissingInstalledVersion(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.InstallFakeBinary(t, "brew", `
+case "$1" in
+list)
+	if [ "$2" = "--versions" ]; then
+		echo "git 2.43.0"
+		echo "ripgrep 14.1.0"
+		exit 0
+	fi
+	exit 0
+	;;
+*)
+	exit 0
+	;;
+esac`)
+	path := filepath.Join(dir, "genv.json")
+	lockPath := genvfile.LockPathFrom(path)
+	writeTestFile(t, path, `{"schemaVersion":"1","packages":[{"id":"git"},{"id":"ripgrep"}]}`)
+	writeLock(t, lockPath, []genvfile.LockedPackage{
+		{ID: "git", Manager: "brew", PkgName: "git"},
+		{ID: "ripgrep", Manager: "brew", PkgName: "ripgrep", InstalledVersion: "13.0.0"},
+	})
+
+	code := run([]string{"apply", "--file", path, "--yes", "--no-hooks"})
+	if code != exitOK {
+		t.Fatalf("apply: got %d, want %d", code, exitOK)
+	}
+	lf, err := genvfile.ReadLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, lp := range lf.Packages {
+		got[lp.ID] = lp.InstalledVersion
+	}
+	if got["git"] != "2.43.0" {
+		t.Errorf("git InstalledVersion = %q, want 2.43.0 (backfill)", got["git"])
+	}
+	if got["ripgrep"] != "13.0.0" {
+		t.Errorf("ripgrep InstalledVersion = %q, want 13.0.0 (keep existing)", got["ripgrep"])
 	}
 }
 
@@ -1789,6 +1872,37 @@ func TestStatusCmd_DriftEntry(t *testing.T) {
 	code := run([]string{"status", "--file", path})
 	if code != exitLogic {
 		t.Errorf("drift: expected exitLogic (%d), got %d", exitLogic, code)
+	}
+}
+
+func TestStatusCmd_DistinguishesUnknownVersionFromNoConstraint(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	lockPath := genvfile.LockPathFrom(path)
+
+	writeTestFile(t, path, `{"schemaVersion":"1","packages":[{"id":"git"},{"id":"vim","version":"9.*"},{"id":"ripgrep"}]}`)
+	writeLock(t, lockPath, []genvfile.LockedPackage{
+		{ID: "git", Manager: "brew", PkgName: "git"},
+		{ID: "vim", Manager: "brew", PkgName: "vim"},
+		{ID: "ripgrep", Manager: "brew", PkgName: "ripgrep", InstalledVersion: "14.1.0"},
+	})
+
+	var code int
+	out := captureStdout(t, func() {
+		code = run([]string{"status", "--file", path, "--offline"})
+	})
+	if code != exitOK {
+		t.Fatalf("status: got %d, want %d\n%s", code, exitOK, out)
+	}
+	if !regexp.MustCompile(`ok\s+git\s+\S+\s+\*`).MatchString(out) {
+		t.Errorf("unconstrained git without installed version should show *: %q", out)
+	}
+	if !regexp.MustCompile(`ok\s+vim\s+\S+\s+\?`).MatchString(out) {
+		t.Errorf("constrained vim without installed version should show ?: %q", out)
+	}
+	if !regexp.MustCompile(`ok\s+ripgrep\s+\S+\s+14\.1\.0`).MatchString(out) {
+		t.Errorf("ripgrep should show recorded installed version: %q", out)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #146.

`genv adopt` wrote id/manager into the lock without querying the installed version, so `genv status` printed `*` for adopted packages and never filled the gap later.

## Changes

- **`adopt`** queries the adapter (`QueryVersion`) after confirming the package is installed and records `InstalledVersion` in the lock.
- **`status`** keeps showing a recorded install version when present. Empty lock versions now distinguish **no constraint** (`*`) from **unknown installed version** (`?`).
- **`apply`** backfills empty lock versions from each manager's `VersionLister` inventory (`brew list --versions`, npm/bun/uv listings, and the other VersionLister adapters). Existing recorded versions are left alone.

## Tests

- `TestAdoptCmd_RecordsInstalledVersion` — adopt writes the queried version
- `TestStatusCmd_DistinguishesUnknownVersionFromNoConstraint` / `TestStatusEntry_DisplayVersion` — `*` vs `?` vs recorded version
- `TestApplyCmd_BackfillsMissingInstalledVersion` / `TestFillMissingInstalledVersions_UsesVersionListerInventory` — next apply fills empty lock versions from inventory

## Verification

`make ci` passed locally (race tests, 80.9% coverage, bench-gate 170ms / 200ms).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa46bc48-aa3f-460a-a77f-38cce65ab1b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa46bc48-aa3f-460a-a77f-38cce65ab1b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

