### PR TITLE
fix: unlink lock mutex sidecar on unlock

### DIFF
--- a/internal/genvfile/lockmutex.go
+++ b/internal/genvfile/lockmutex.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // LockMutation acquires an exclusive cross-process lock for mutating lockPath.
-// The returned unlock function releases it. Safe to call with an empty path.
+// The returned unlock function releases it and removes the sidecar mutex file.
+// Safe to call with an empty path.
 func LockMutation(lockPath string) (unlock func(), err error) {
 	if lockPath == "" {
 		return func() {}, nil
@@ -16,16 +18,54 @@ func LockMutation(lockPath string) (unlock func(), err error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("creating parent directory for lock file (%s): %w", dir, err)
 	}
-	f, err := os.OpenFile(lockPath+".mutex", os.O_CREATE|os.O_RDWR, 0o600)
+	mutexPath := lockPath + ".mutex"
+	f, err := acquireMutex(mutexPath)
 	if err != nil {
 		return nil, fmt.Errorf("locking %s: %w", lockPath, err)
 	}
-	if err := flockExclusive(f); err != nil {
-		_ = f.Close()
-		return nil, fmt.Errorf("locking %s: %w", lockPath, err)
-	}
 	return func() {
+		releaseMutex(f, mutexPath)
+	}, nil
+}
+
+// acquireMutex opens mutexPath and takes an exclusive flock. After waiting it
+// re-checks that the path still names the locked inode so an unlocker that
+// unlinked the sidecar cannot race a new creator onto a different inode.
+func acquireMutex(mutexPath string) (*os.File, error) {
+	for {
+		f, err := os.OpenFile(mutexPath, os.O_CREATE|os.O_RDWR, 0o600)
+		if err != nil {
+			return nil, err
+		}
+		if err := flockExclusive(f); err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+		held, err := f.Stat()
+		if err != nil {
+			_ = flockUnlock(f)
+			_ = f.Close()
+			return nil, err
+		}
+		onDisk, err := os.Stat(mutexPath)
+		if err == nil && os.SameFile(held, onDisk) {
+			return f, nil
+		}
 		_ = flockUnlock(f)
 		_ = f.Close()
-	}, nil
+	}
+}
+
+func releaseMutex(f *os.File, mutexPath string) {
+	// Unlink while still holding the flock on Unix so a waiter that then
+	// acquires the stale inode fails the SameFile check and retries. Windows
+	// cannot remove an open file, so unlink after close instead.
+	if runtime.GOOS != "windows" {
+		_ = os.Remove(mutexPath)
+	}
+	_ = flockUnlock(f)
+	_ = f.Close()
+	if runtime.GOOS == "windows" {
+		_ = os.Remove(mutexPath)
+	}
 }

--- a/internal/genvfile/lockmutex_test.go
+++ b/internal/genvfile/lockmutex_test.go
@@ -3,7 +3,9 @@ package genvfile
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestLockMutation_CreatesMutexAndUnlocks(t *testing.T) {
@@ -18,6 +20,9 @@ func TestLockMutation_CreatesMutexAndUnlocks(t *testing.T) {
 		t.Fatalf("mutex file missing: %v", err)
 	}
 	unlock()
+	if _, err := os.Stat(path + ".mutex"); !os.IsNotExist(err) {
+		t.Fatalf("mutex leftover after unlock: stat err=%v", err)
+	}
 }
 
 func TestLockMutation_EmptyPathIsNoop(t *testing.T) {
@@ -26,4 +31,46 @@ func TestLockMutation_EmptyPathIsNoop(t *testing.T) {
 		t.Fatalf("empty path: %v", err)
 	}
 	unlock()
+}
+
+func TestLockMutation_SerializesConcurrentHolders(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "genv.lock.json")
+
+	var (
+		mu    sync.Mutex
+		inCS  int
+		maxCS int
+		wg    sync.WaitGroup
+	)
+	const n = 8
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			unlock, err := LockMutation(path)
+			if err != nil {
+				t.Errorf("LockMutation: %v", err)
+				return
+			}
+			defer unlock()
+			mu.Lock()
+			inCS++
+			if inCS > maxCS {
+				maxCS = inCS
+			}
+			mu.Unlock()
+			time.Sleep(5 * time.Millisecond)
+			mu.Lock()
+			inCS--
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	if maxCS != 1 {
+		t.Fatalf("max concurrent holders = %d, want 1", maxCS)
+	}
+	if _, err := os.Stat(path + ".mutex"); !os.IsNotExist(err) {
+		t.Fatalf("mutex leftover after concurrent unlocks: stat err=%v", err)
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #148.

`LockMutation` created `<lock>.mutex` with `O_CREATE` and never removed it. After apply/upgrade/remove that left a zero-byte `genv.lock.json.mutex` beside the lock — noisy when `~/.config/genv` is a git repo.

## Change

- Unlink the sidecar on unlock (Unix while still holding the flock; Windows after close, because an open file cannot be deleted there).
- After `flock`, re-check that the path still names the locked inode. An unlocker that unlinked the sidecar cannot race a new creator onto a different inode, so concurrent apply still serializes (#97).

No leftover `*.mutex` after a successful mutation. The file is not documented as a generated sibling because it no longer remains.

## Tests

- `TestLockMutation_CreatesMutexAndUnlocks` now asserts the sidecar is gone after unlock
- `TestLockMutation_SerializesConcurrentHolders` — eight goroutines, max in-critical-section is 1, no leftover file

## Verification

`make ci` passed locally: statement coverage 80.8% (floor 80%), `BenchmarkDetect` worst-case 181ms (budget 200ms).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f964f9b4-ea4f-4999-9885-9773e0fefc50?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f964f9b4-ea4f-4999-9885-9773e0fefc50&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

