### PR TITLE
feat: record lock content hashes for managed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ All notable changes to this project will be documented in this file.
   existing links stay `ok` and only real file changes show. A missing or
   non-directory `--source-root` is refused. Lock, env, and shell paths still
   follow `--file` / `--lock-file` / `--state-dir`.
+- Lock files record a `contentHash` (`sha256:<hex>`) per managed link and
+  template after a successful apply. `genv status --files` reports `drifted`
+  (with the path) when the live source or rendered body no longer matches that
+  hash. Topology-only `ok` / `missing` / `wrong-type` / `mismatch` are
+  unchanged. Apply never reverts a drifted body; a later successful apply
+  refreshes the hash. Pre-hash locks omit the field and stay topology-only.
+  Hashing is always on for `link` / `managed-link` / templates; `merge-dir`
+  trees are not hashed.
 
 ## v4.3.1 - 2026-09-05
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Convenience commands (`add` / `remove` / `adopt` / `disown` / `scan`) update the
 | `adopt` / `disown` | Track without install / untrack without uninstall |
 | `scan` | Bulk-adopt user-facing installs (`--dry-run`, `--yes`; `--all` / `--deps` for full trees) |
 | `list` (`ls`) | Show lock-tracked packages |
-| `status` | Spec ↔ lock drift (`--files`, `--offline`, `--target`) |
+| `status` | Spec ↔ lock drift (`--files` includes content `drifted`, `--offline`, `--target`) |
 | `apply` | Reconcile (`--dry-run`, `--yes`, `--json`, `--force`, `--backup`, `--strict`, `--quiet`, `--skip-packages`, `--timeout <d>`, `--no-hooks`, `--hook-timeout <d>`, `--target`, `--force-new-lock`, `--state-dir`, `--source-root <dir>`) |
 | `validate` | Validate spec + genv-managed agent executables |
 | `upgrade` | Upgrade tracked packages plus OS vendor updates (`--all`, `--only` / leftover IDs, `--skip`, `--only-manager`, `--skip-manager`, `--target`; `--json` wet-run requires `--yes`) |

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -83,6 +83,8 @@ Merge order: copy `defaults`, overlay `targets.<id>`. Arrays defined on the targ
 
 `~/.config/genv/genv.lock.json` is machine-local. v8 locks may record `target` and `goos`. A foreign lock is refused; use `genv apply --force-new-lock` to back it up and start fresh. Never commit locks.
 
+Each applied `files.links[]` (`link` / `managed-link`) and `files.templates[]` entry may record `contentHash` (`sha256:<hex>` of the link source or rendered template). `genv status --files` reports `drifted` when the live hash differs. Older locks omit the field and stay topology-only. Apply refreshes the hash after a successful link/template op and never reverts the body.
+
 Guide: [docs/multi-machine.md](docs/multi-machine.md).
 
 ## v7 — PowerShell

--- a/internal/files/hash.go
+++ b/internal/files/hash.go
@@ -1,0 +1,90 @@
+package files
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+)
+
+// contentHashPrefix versions the lock digest so a future algorithm can coexist
+// with sha256 without a lock schema bump.
+const contentHashPrefix = "sha256:"
+
+// HashBytes returns a versioned SHA-256 digest of data.
+func HashBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return contentHashPrefix + hex.EncodeToString(sum[:])
+}
+
+// HashFile returns a versioned SHA-256 digest of a regular file. Directories
+// and other non-regular nodes return "" so callers can skip content tracking.
+func HashFile(path string) (string, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if !fi.Mode().IsRegular() {
+		return "", nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return HashBytes(data), nil
+}
+
+// HashLinkSource hashes the resolved source of a files.links entry.
+func HashLinkSource(sourceRoot, source string) (string, error) {
+	path, err := resolveSource(sourceRoot, source)
+	if err != nil {
+		return "", err
+	}
+	return HashFile(path)
+}
+
+// HashTemplate hashes the rendered template body (what apply writes).
+func HashTemplate(sourceRoot, source, hostName string) (string, error) {
+	path, err := resolveSource(sourceRoot, source)
+	if err != nil {
+		return "", err
+	}
+	rendered, err := renderedTemplate(path, hostName)
+	if err != nil {
+		return "", err
+	}
+	return HashBytes(rendered), nil
+}
+
+// ExpandTarget resolves ~ and $VARS then cleans, matching status/apply targets.
+func ExpandTarget(target string) (string, error) {
+	expanded, err := expandPath(target)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(expanded), nil
+}
+
+func applyContentDrift(entry StatusEntry, hashes map[string]string, current func() (string, error)) StatusEntry {
+	if entry.Kind != "ok" || len(hashes) == 0 {
+		return entry
+	}
+	want := hashes[entry.Target]
+	if want == "" {
+		return entry
+	}
+	got, err := current()
+	if err != nil || got == "" {
+		return entry
+	}
+	if got != want {
+		entry.Kind = "drifted"
+	}
+	return entry
+}
+
+// HashableLinkMode reports whether a files.links mode stores a content hash.
+// merge-dir trees are excluded (per-file lock records are out of scope).
+func HashableLinkMode(mode string) bool {
+	return mode == "" || mode == "link" || mode == "managed-link"
+}

--- a/internal/files/hash_test.go
+++ b/internal/files/hash_test.go
@@ -1,0 +1,90 @@
+package files
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHashBytes_isVersionedSHA256(t *testing.T) {
+	got := HashBytes([]byte("hello\n"))
+	if !strings.HasPrefix(got, "sha256:") {
+		t.Fatalf("HashBytes = %q, want sha256: prefix", got)
+	}
+	if len(got) != len("sha256:")+64 {
+		t.Fatalf("HashBytes = %q, want 64 hex digits", got)
+	}
+	if HashBytes([]byte("hello\n")) != got {
+		t.Fatal("HashBytes must be deterministic")
+	}
+	if HashBytes([]byte("hello\n")) == HashBytes([]byte("hello")) {
+		t.Fatal("HashBytes must change when content changes")
+	}
+}
+
+func TestHashFile_skipsDirectories(t *testing.T) {
+	dir := t.TempDir()
+	hash, err := HashFile(dir)
+	if err != nil {
+		t.Fatalf("HashFile(dir): %v", err)
+	}
+	if hash != "" {
+		t.Fatalf("HashFile(dir) = %q, want empty", hash)
+	}
+
+	path := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := HashFile(path)
+	if err != nil || got == "" {
+		t.Fatalf("HashFile(file) = %q err=%v", got, err)
+	}
+}
+
+func TestExpandTarget_cleansHomePath(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	got, err := ExpandTarget("~/.npmrc")
+	if err != nil {
+		t.Fatalf("ExpandTarget: %v", err)
+	}
+	want := filepath.Join(home, ".npmrc")
+	if got != want {
+		t.Fatalf("ExpandTarget = %q, want %q", got, want)
+	}
+}
+
+func TestHashableLinkMode(t *testing.T) {
+	if !HashableLinkMode("") || !HashableLinkMode("link") || !HashableLinkMode("managed-link") {
+		t.Fatal("link modes should be hashable")
+	}
+	if HashableLinkMode("merge-dir") || HashableLinkMode("dir") {
+		t.Fatal("merge-dir and dir must not be hashed")
+	}
+}
+
+func TestHashLinkSourceAndTemplate(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	src := filepath.Join(home, "repo", "a.txt")
+	if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("body\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := HashLinkSource("", src)
+	if err != nil || got == "" {
+		t.Fatalf("HashLinkSource = %q err=%v", got, err)
+	}
+	tmpl := filepath.Join(home, "repo", "t.txt")
+	if err := os.WriteFile(tmpl, []byte("home=__HOME__\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	th, err := HashTemplate("", tmpl, "any")
+	if err != nil || th == "" || th == got {
+		t.Fatalf("HashTemplate = %q err=%v", th, err)
+	}
+}

--- a/internal/files/status.go
+++ b/internal/files/status.go
@@ -27,6 +27,14 @@ type StatusResult struct {
 
 // Status compares cfg against the live filesystem for hostName.
 func Status(cfg *schema.FilesConfig, hostName string) (*StatusResult, error) {
+	return StatusWithHashes(cfg, hostName, nil)
+}
+
+// StatusWithHashes is Status plus optional lock content hashes keyed by the
+// cleaned expanded target path. A matching topology with a different hash is
+// reported as "drifted". Missing hashes keep the topology-only result so older
+// locks stay compatible. Status never rewrites files.
+func StatusWithHashes(cfg *schema.FilesConfig, hostName string, hashes map[string]string) (*StatusResult, error) {
 	res := &StatusResult{OK: true}
 	if cfg == nil {
 		return res, nil
@@ -51,14 +59,14 @@ func Status(cfg *schema.FilesConfig, hostName string) (*StatusResult, error) {
 			}
 			continue
 		}
-		entry, err := statusLink(l)
+		entry, err := statusLink(l, hashes)
 		if err != nil {
 			return res, err
 		}
 		res.add(entry)
 	}
 	for _, tmpl := range filtered.Templates {
-		entry, err := statusTemplate(tmpl, hostName)
+		entry, err := statusTemplate(tmpl, hostName, hashes)
 		if err != nil {
 			return res, err
 		}
@@ -96,7 +104,7 @@ func statusDir(d schema.FileDir) (StatusEntry, error) {
 	return entry, nil
 }
 
-func statusLink(l schema.FileLink) (StatusEntry, error) {
+func statusLink(l schema.FileLink, hashes map[string]string) (StatusEntry, error) {
 	target, err := statusTarget(l.Target)
 	if err != nil {
 		return StatusEntry{}, fmt.Errorf("link target %q: %w", l.Target, err)
@@ -113,6 +121,11 @@ func statusLink(l schema.FileLink) (StatusEntry, error) {
 	if err != nil {
 		return entry, err
 	}
+	// Topology first, then content drift, then perm. One kind per entry;
+	// statusPerm no-ops unless the kind is still ok.
+	entry = applyContentDrift(entry, hashes, func() (string, error) {
+		return HashFile(source)
+	})
 	return statusPerm(entry, source, l.Perm)
 }
 
@@ -200,7 +213,7 @@ func statusLinkAt(target, source, mode string) (StatusEntry, error) {
 	return entry, nil
 }
 
-func statusTemplate(tmpl schema.FileTemplate, hostName string) (StatusEntry, error) {
+func statusTemplate(tmpl schema.FileTemplate, hostName string, hashes map[string]string) (StatusEntry, error) {
 	target, err := statusTarget(tmpl.Target)
 	if err != nil {
 		return StatusEntry{}, fmt.Errorf("template target %q: %w", tmpl.Target, err)
@@ -232,6 +245,9 @@ func statusTemplate(tmpl schema.FileTemplate, hostName string) (StatusEntry, err
 	}
 	if bytes.Equal(existing, rendered) {
 		entry.Kind = "ok"
+		entry = applyContentDrift(entry, hashes, func() (string, error) {
+			return HashBytes(rendered), nil
+		})
 		return statusPerm(entry, target, tmpl.Perm)
 	}
 	entry.Kind = "mismatch"

--- a/internal/files/status_test.go
+++ b/internal/files/status_test.go
@@ -100,3 +100,159 @@ func TestStatus_reportsProblemKinds_whenTargetsDiffer(t *testing.T) {
 		}
 	}
 }
+
+func TestStatus_reportsDrifted_whenLinkedSourceHashDiffers(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	source := setupSource(t, home, "npmrc")
+	target := filepath.Join(home, ".npmrc")
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	cfg := &schema.FilesConfig{Links: []schema.FileLink{{
+		Source: source,
+		Target: "~/.npmrc",
+		Mode:   "managed-link",
+	}}}
+
+	applied, err := HashFile(source)
+	if err != nil || applied == "" {
+		t.Fatalf("HashFile: hash=%q err=%v", applied, err)
+	}
+	if err := os.WriteFile(source, []byte("registry=https://example.invalid\n"), 0o644); err != nil {
+		t.Fatalf("rewrite source: %v", err)
+	}
+
+	res, err := StatusWithHashes(cfg, "any", map[string]string{target: applied})
+	if err != nil {
+		t.Fatalf("StatusWithHashes: %v", err)
+	}
+	if res.OK {
+		t.Fatal("Status.OK = true, want false when source content drifted")
+	}
+	if len(res.Entries) != 1 || res.Entries[0].Kind != "drifted" {
+		t.Fatalf("entries = %+v, want one drifted entry", res.Entries)
+	}
+	if res.Entries[0].Target != target {
+		t.Fatalf("drifted target = %q, want %q", res.Entries[0].Target, target)
+	}
+}
+
+func TestStatus_keepsMismatch_whenHashAlsoDiffers(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	source := setupSource(t, home, "wanted.txt")
+	other := setupSource(t, home, "other.txt")
+	target := filepath.Join(home, ".genv-test", "link")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(other, target); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	hash, err := HashFile(source)
+	if err != nil {
+		t.Fatalf("HashFile: %v", err)
+	}
+	cfg := &schema.FilesConfig{Links: []schema.FileLink{{Source: source, Target: "~/.genv-test/link"}}}
+	res, err := StatusWithHashes(cfg, "any", map[string]string{target: hash})
+	if err != nil {
+		t.Fatalf("StatusWithHashes: %v", err)
+	}
+	if len(res.Entries) != 1 || res.Entries[0].Kind != "mismatch" {
+		t.Fatalf("topology mismatch must win over content drift: %+v", res.Entries)
+	}
+}
+
+func TestStatus_staysOK_whenContentHashMatches(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	source := setupSource(t, home, "simple.txt")
+	target := filepath.Join(home, ".genv-test", "simple.txt")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	hash, err := HashFile(source)
+	if err != nil {
+		t.Fatalf("HashFile: %v", err)
+	}
+	cfg := &schema.FilesConfig{Links: []schema.FileLink{{Source: source, Target: "~/.genv-test/simple.txt"}}}
+	res, err := StatusWithHashes(cfg, "any", map[string]string{target: hash})
+	if err != nil {
+		t.Fatalf("StatusWithHashes: %v", err)
+	}
+	if !res.OK || len(res.Entries) != 1 || res.Entries[0].Kind != "ok" {
+		t.Fatalf("matching hash should stay ok: %+v", res.Entries)
+	}
+}
+
+func TestStatus_staysOK_whenLockHasNoContentHash(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	source := setupSource(t, home, "simple.txt")
+	target := filepath.Join(home, ".genv-test", "simple.txt")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	cfg := &schema.FilesConfig{Links: []schema.FileLink{{Source: source, Target: "~/.genv-test/simple.txt"}}}
+
+	res, err := StatusWithHashes(cfg, "any", nil)
+	if err != nil {
+		t.Fatalf("StatusWithHashes: %v", err)
+	}
+	if !res.OK || len(res.Entries) != 1 || res.Entries[0].Kind != "ok" {
+		t.Fatalf("old locks without hashes must stay topology-only: %+v", res.Entries)
+	}
+}
+
+func TestStatus_reportsDrifted_whenTemplateSourceHashDiffersButTargetMatchesRender(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	source := filepath.Join(home, "repo", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("home = __HOME__\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	rendered, err := renderedTemplate(source, "any")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	applied := HashBytes(rendered)
+	target := filepath.Join(home, ".genv-test", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.WriteFile(target, rendered, 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	// Source changes, then the target is rewritten to the new render outside
+	// apply. Topology still matches; the lock hash is the previous render.
+	if err := os.WriteFile(source, []byte("home = __HOME__\neditor = helix\n"), 0o644); err != nil {
+		t.Fatalf("rewrite source: %v", err)
+	}
+	newRendered, err := renderedTemplate(source, "any")
+	if err != nil {
+		t.Fatalf("re-render: %v", err)
+	}
+	if err := os.WriteFile(target, newRendered, 0o644); err != nil {
+		t.Fatalf("rewrite target: %v", err)
+	}
+
+	cfg := &schema.FilesConfig{Templates: []schema.FileTemplate{{Source: source, Target: "~/.genv-test/config.toml"}}}
+	res, err := StatusWithHashes(cfg, "any", map[string]string{target: applied})
+	if err != nil {
+		t.Fatalf("StatusWithHashes: %v", err)
+	}
+	if res.OK || len(res.Entries) != 1 || res.Entries[0].Kind != "drifted" {
+		t.Fatalf("entries = %+v, want one drifted template", res.Entries)
+	}
+}

--- a/internal/genvfile/genvfile_test.go
+++ b/internal/genvfile/genvfile_test.go
@@ -562,6 +562,41 @@ func TestWriteLock_ProducesValidJSON(t *testing.T) {
 	}
 }
 
+func TestWriteLock_ContentHash_OmitEmptyAndRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "genv.lock.json")
+	lf := &LockFile{
+		SchemaVersion: schema.Version,
+		Files: []LockedFile{
+			{Source: "a", Target: "b", Mode: "managed-link", ContentHash: "sha256:abc"},
+			{Source: "c", Target: "d", Mode: "link"},
+		},
+	}
+	if err := WriteLock(path, lf); err != nil {
+		t.Fatalf("WriteLock: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), `"contentHash": "sha256:abc"`) {
+		t.Fatalf("expected contentHash in lock JSON:\n%s", data)
+	}
+	got, err := ReadLock(path)
+	if err != nil {
+		t.Fatalf("ReadLock: %v", err)
+	}
+	if got.Files[0].ContentHash != "sha256:abc" {
+		t.Fatalf("Files[0].ContentHash = %q", got.Files[0].ContentHash)
+	}
+	if got.Files[1].ContentHash != "" {
+		t.Fatalf("empty ContentHash should omit; got %q", got.Files[1].ContentHash)
+	}
+	if strings.Count(string(data), "contentHash") != 1 {
+		t.Fatalf("contentHash should be omitted when empty:\n%s", data)
+	}
+}
+
 func TestWriteLock_InstalledVersion_OmitEmpty(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "genv.lock.json")

--- a/internal/genvfile/lockfile.go
+++ b/internal/genvfile/lockfile.go
@@ -60,10 +60,14 @@ type LockedService struct {
 }
 
 // LockedFile records a single applied file entry from the spec files block.
+// ContentHash is a versioned digest ("sha256:<hex>") of the link source or
+// rendered template at last successful apply. Empty on pre-hash locks and for
+// dirs / merge-dir records.
 type LockedFile struct {
-	Source string `json:"source"`
-	Target string `json:"target"`
-	Mode   string `json:"mode,omitempty"`
+	Source      string `json:"source"`
+	Target      string `json:"target"`
+	Mode        string `json:"mode,omitempty"`
+	ContentHash string `json:"contentHash,omitempty"`
 }
 
 // LockFile is the on-disk representation of the applied state tracked by genv.
@@ -71,6 +75,7 @@ type LockedFile struct {
 // The Shell field is added in M9 (schemaVersion "3") and is absent in v1/v2 lock files.
 // The Services field is added in M10 (schemaVersion "4") and is absent in v1/v2/v3 lock files.
 // The Files field is added in M11 (schemaVersion "5") and is absent in v1-v4 lock files.
+// ContentHash on Files entries is additive (omitempty); older locks omit it.
 type LockFile struct {
 	SchemaVersion string             `json:"schemaVersion"`
 	Target        string             `json:"target,omitempty"`

--- a/main.go
+++ b/main.go
@@ -1053,7 +1053,7 @@ func adoptFilesCmd(file, lockFile, stateDir, hostFlag, targetFlag string, jsonOu
 		return code
 	}
 	statusCfg := filesConfigWithResolvedSources(filtered.Files, sourceRootForSpec(file, f))
-	res, err := files.Status(statusCfg, hostName)
+	res, err := files.StatusWithHashes(statusCfg, hostName, nil)
 	if jsonOut {
 		errs := []string(nil)
 		if err != nil {
@@ -1084,12 +1084,13 @@ func adoptFilesCmd(file, lockFile, stateDir, hostFlag, targetFlag string, jsonOu
 		fprintf(os.Stderr, "genv: reading lock: %v\n", err)
 		return exitIO
 	}
-	lf.Files = mergeLockedFiles(lf.Files, lockedFilesFromSpec(filtered.Files))
+	adopted := lockedFilesFromSpec(filtered.Files, hostName, sourceRootForSpec(file, f))
+	lf.Files = mergeLockedFiles(lf.Files, adopted)
 	if err := genvfile.WriteLock(lockPath, lf); err != nil {
 		fprintf(os.Stderr, "genv: writing lock: %v\n", err)
 		return exitIO
 	}
-	fprintf(os.Stdout, "adopted %d file entry/entries into %s\n", len(lockedFilesFromSpec(filtered.Files)), lockPath)
+	fprintf(os.Stdout, "adopted %d file entry/entries into %s\n", len(adopted), lockPath)
 	return exitOK
 }
 
@@ -1600,6 +1601,7 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 					return exitLogic
 				}
 			}
+			refreshLockedFileHashes(f, lf, hostForCommand(opts.Host), applySourceRoot(opts, f))
 			if err := writeLockAfterApply(lockPath, lf, result, resolver.ApplyExecution{}, opts.TargetProfile, opts.Target, opts.SkipPackages, true); err != nil {
 				fprintf(os.Stderr, "genv: writing lock: %v\n", err)
 				return exitIO
@@ -2043,7 +2045,7 @@ func expandCLIPath(path string) string {
 	return os.Expand(path, os.Getenv)
 }
 
-func lockedFilesFromSpec(cfg *schema.FilesConfig) []genvfile.LockedFile {
+func lockedFilesFromSpec(cfg *schema.FilesConfig, hostName, sourceRoot string) []genvfile.LockedFile {
 	if cfg == nil {
 		return nil
 	}
@@ -2053,10 +2055,20 @@ func lockedFilesFromSpec(cfg *schema.FilesConfig) []genvfile.LockedFile {
 		if mode == "" {
 			mode = "link"
 		}
-		locked = append(locked, genvfile.LockedFile{Source: l.Source, Target: l.Target, Mode: mode})
+		entry := genvfile.LockedFile{Source: l.Source, Target: l.Target, Mode: mode}
+		if files.HashableLinkMode(mode) {
+			if hash, err := files.HashLinkSource(sourceRoot, l.Source); err == nil {
+				entry.ContentHash = hash
+			}
+		}
+		locked = append(locked, entry)
 	}
 	for _, tmpl := range cfg.Templates {
-		locked = append(locked, genvfile.LockedFile{Source: tmpl.Source, Target: tmpl.Target, Mode: "copy"})
+		entry := genvfile.LockedFile{Source: tmpl.Source, Target: tmpl.Target, Mode: "copy"}
+		if hash, err := files.HashTemplate(sourceRoot, tmpl.Source, hostName); err == nil {
+			entry.ContentHash = hash
+		}
+		locked = append(locked, entry)
 	}
 	for _, d := range cfg.Dirs {
 		locked = append(locked, genvfile.LockedFile{Target: d.Target, Mode: "dir"})
@@ -2064,20 +2076,46 @@ func lockedFilesFromSpec(cfg *schema.FilesConfig) []genvfile.LockedFile {
 	return locked
 }
 
+func fileLockKey(f genvfile.LockedFile) string {
+	return f.Source + "\x00" + f.Target + "\x00" + f.Mode
+}
+
 func mergeLockedFiles(existing, adopted []genvfile.LockedFile) []genvfile.LockedFile {
 	merged := append([]genvfile.LockedFile(nil), existing...)
-	seen := make(map[genvfile.LockedFile]bool, len(existing)+len(adopted))
-	for _, f := range existing {
-		seen[f] = true
+	index := make(map[string]int, len(existing)+len(adopted))
+	for i, f := range existing {
+		index[fileLockKey(f)] = i
 	}
 	for _, f := range adopted {
-		if seen[f] {
+		key := fileLockKey(f)
+		if i, ok := index[key]; ok {
+			if f.ContentHash != "" {
+				merged[i].ContentHash = f.ContentHash
+			}
 			continue
 		}
+		index[key] = len(merged)
 		merged = append(merged, f)
-		seen[f] = true
 	}
 	return merged
+}
+
+func fileContentHashes(locked []genvfile.LockedFile) map[string]string {
+	if len(locked) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(locked))
+	for _, f := range locked {
+		if f.ContentHash == "" {
+			continue
+		}
+		target, err := files.ExpandTarget(f.Target)
+		if err != nil {
+			continue
+		}
+		out[target] = f.ContentHash
+	}
+	return out
 }
 
 func filesConfigWithResolvedSources(cfg *schema.FilesConfig, sourceRoot string) *schema.FilesConfig {
@@ -2198,16 +2236,25 @@ func fileStatusEntries(res *files.StatusResult) []output.FilePlanEntry {
 }
 
 func applyFiles(ctx context.Context, opts applyOptions, f *schema.GenvFile, lf *genvfile.LockFile) (*files.ApplyResult, error) {
-	res, err := files.Apply(ctx, f.Files, hostForCommand(opts.Host), files.ApplyOptions{
-		SourceRoot: applySourceRoot(opts, f),
+	hostName := hostForCommand(opts.Host)
+	sourceRoot := applySourceRoot(opts, f)
+	res, err := files.Apply(ctx, f.Files, hostName, files.ApplyOptions{
+		SourceRoot: sourceRoot,
 		Force:      opts.Force,
 		DryRun:     opts.DryRun,
 		Backup:     opts.Backup,
 	})
 	if err == nil && !opts.DryRun {
-		lf.Files = lockedFilesFromSpec(f.Files)
+		refreshLockedFileHashes(f, lf, hostName, sourceRoot)
 	}
 	return res, err
+}
+
+func refreshLockedFileHashes(f *schema.GenvFile, lf *genvfile.LockFile, hostName, sourceRoot string) {
+	if f == nil || lf == nil {
+		return
+	}
+	lf.Files = lockedFilesFromSpec(f.Files, hostName, sourceRoot)
 }
 
 type upgradeHookOptions struct {
@@ -3161,7 +3208,8 @@ func statusCmd(args []string) int {
 		fPrintln(os.Stderr, "Show the diff between genv.json, the lock file, and the live system.")
 		fPrintln(os.Stderr, "Unlocked packages that are already installed are reported as present.")
 		fPrintln(os.Stderr, "Use --offline to compare spec vs lock only.")
-		fPrintln(os.Stderr, "Run 'genv apply' to reconcile any differences shown.")
+		fPrintln(os.Stderr, "Use --files to check live file topology and content hashes (drifted).")
+		fPrintln(os.Stderr, "Run 'genv apply' to reconcile any differences shown. File content drift is reported only; apply does not revert bodies.")
 		fPrintln(os.Stderr)
 		fPrintln(os.Stderr, "flags:")
 		fs.PrintDefaults()
@@ -3171,7 +3219,7 @@ func statusCmd(args []string) int {
 	lockFile := fs.String("lock-file", "", "path to genv lock file")
 	jsonOut := fs.Bool("json", false, "emit machine-readable JSON to stdout instead of human-readable text")
 	debug := fs.Bool("debug", false, "emit debug-level structured logs to stderr")
-	filesOnly := fs.Bool("files", false, "check files block against the live filesystem only")
+	filesOnly := fs.Bool("files", false, "check files block against the live filesystem (topology plus content hashes)")
 	offline := fs.Bool("offline", false, "compare spec vs lock only (skip live manager probe)")
 	hostFlag := fs.String("host", "", "host name for host-specific records (defaults to host classification)")
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
@@ -3210,7 +3258,11 @@ func statusCmd(args []string) int {
 
 	if *filesOnly {
 		statusCfg := filesConfigWithResolvedSources(f.Files, sourceRootForSpec(*file, f))
-		res, err := files.Status(statusCfg, hostName)
+		var hashes map[string]string
+		if lf != nil {
+			hashes = fileContentHashes(lf.Files)
+		}
+		res, err := files.StatusWithHashes(statusCfg, hostName, hashes)
 		if *jsonOut {
 			errs := []string(nil)
 			if err != nil {

--- a/main_apply_files_test.go
+++ b/main_apply_files_test.go
@@ -127,6 +127,88 @@ func registerSkipPackagesListAdapter(t *testing.T, a *skipPackagesListAdapter) {
 	})
 }
 
+func TestApplyAndStatus_recordsAndReportsManagedLinkContentHash(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	testutil.SetHome(t, dir)
+	spec := filepath.Join(dir, "genv.json")
+	lock := filepath.Join(dir, "genv.lock.json")
+	src := filepath.Join(dir, "npmrc")
+	dst := filepath.Join(dir, ".npmrc")
+	writeTestFile(t, src, "registry=https://registry.npmjs.org/\n")
+	writeTestFile(t, spec, `{`+
+		`"schemaVersion":"6",`+
+		`"files":{"links":[{"source":`+jsonString(src)+`,"target":`+jsonString(dst)+`,"mode":"managed-link"}]}`+
+		`}`)
+
+	if code := run([]string{"apply", "--file", spec, "--lock-file", lock, "--yes", "--skip-packages"}); code != exitOK {
+		t.Fatalf("apply: expected exitOK (%d), got %d", exitOK, code)
+	}
+	lf, err := genvfile.ReadLock(lock)
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+	if len(lf.Files) != 1 || lf.Files[0].ContentHash == "" {
+		t.Fatalf("lock files = %#v, want one entry with contentHash", lf.Files)
+	}
+	appliedHash := lf.Files[0].ContentHash
+
+	var statusCode int
+	statusOut := captureStdout(t, func() {
+		statusCode = run([]string{"status", "--files", "--file", spec, "--lock-file", lock})
+	})
+	if statusCode != exitOK {
+		t.Fatalf("status after apply: exit %d, want 0\n%s", statusCode, statusOut)
+	}
+
+	writeTestFile(t, src, "registry=https://registry.npmjs.org/\n# jamf\n")
+	statusOut = captureStdout(t, func() {
+		statusCode = run([]string{"status", "--files", "--file", spec, "--lock-file", lock})
+	})
+	if statusCode != exitLogic {
+		t.Fatalf("status after source edit: exit %d, want %d\n%s", statusCode, exitLogic, statusOut)
+	}
+	if !strings.Contains(statusOut, "drifted") {
+		t.Fatalf("status after source edit: expected drifted, got %q", statusOut)
+	}
+	if !strings.Contains(statusOut, dst) && !strings.Contains(statusOut, filepath.Base(dst)) {
+		t.Fatalf("status after source edit: expected path %q in output %q", dst, statusOut)
+	}
+
+	got, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if !strings.Contains(string(got), "jamf") {
+		t.Fatalf("apply must not revert source; got %q", got)
+	}
+
+	if code := run([]string{"apply", "--file", spec, "--lock-file", lock, "--yes", "--skip-packages"}); code != exitOK {
+		t.Fatalf("re-apply: expected exitOK, got %d", code)
+	}
+	got, err = os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read source after re-apply: %v", err)
+	}
+	if !strings.Contains(string(got), "jamf") {
+		t.Fatalf("re-apply reverted source to %q", got)
+	}
+	lf, err = genvfile.ReadLock(lock)
+	if err != nil {
+		t.Fatalf("read lock after re-apply: %v", err)
+	}
+	if len(lf.Files) != 1 || lf.Files[0].ContentHash == "" || lf.Files[0].ContentHash == appliedHash {
+		t.Fatalf("re-apply should refresh contentHash; before=%q after=%#v", appliedHash, lf.Files)
+	}
+
+	statusOut = captureStdout(t, func() {
+		statusCode = run([]string{"status", "--files", "--file", spec, "--lock-file", lock})
+	})
+	if statusCode != exitOK {
+		t.Fatalf("status after re-apply: exit %d, want 0\n%s", statusCode, statusOut)
+	}
+}
+
 func TestApply_SkipPackagesStillAppliesFiles(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)

--- a/main_helpers_coverage_test.go
+++ b/main_helpers_coverage_test.go
@@ -70,12 +70,15 @@ func TestFileAndPathHelpers(t *testing.T) {
 	}
 	existing := []genvfile.LockedFile{{Source: "a", Target: "b", Mode: "link"}}
 	adopted := []genvfile.LockedFile{
-		{Source: "a", Target: "b", Mode: "link"},
+		{Source: "a", Target: "b", Mode: "link", ContentHash: "sha256:new"},
 		{Source: "c", Target: "d", Mode: "copy"},
 	}
 	merged := mergeLockedFiles(existing, adopted)
 	if len(merged) != 2 {
 		t.Fatalf("merged = %#v", merged)
+	}
+	if merged[0].ContentHash != "sha256:new" {
+		t.Fatalf("merge should refresh contentHash, got %#v", merged[0])
 	}
 
 	home := t.TempDir()
@@ -133,6 +136,27 @@ func TestFileAndPathHelpers(t *testing.T) {
 
 	if !hasBoolFlag([]string{"--files", "--json"}, "files") || hasBoolFlag([]string{"--file"}, "files") {
 		t.Error("hasBoolFlag mismatch")
+	}
+
+	src := filepath.Join(home, "hashed.txt")
+	if err := os.WriteFile(src, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hashed := lockedFilesFromSpec(&schema.FilesConfig{
+		Links:     []schema.FileLink{{Source: src, Target: "~/hashed.txt", Mode: "managed-link"}},
+		Templates: []schema.FileTemplate{{Source: src, Target: "~/hashed.copy"}},
+		Dirs:      []schema.FileDir{{Target: "~/hashed-dir"}},
+	}, "any", home)
+	if len(hashed) != 3 || hashed[0].ContentHash == "" || hashed[1].ContentHash == "" || hashed[2].ContentHash != "" {
+		t.Fatalf("lockedFilesFromSpec hashes = %#v", hashed)
+	}
+	hashMap := fileContentHashes(hashed)
+	expanded, err := files.ExpandTarget("~/hashed.txt")
+	if err != nil || hashMap[expanded] != hashed[0].ContentHash {
+		t.Fatalf("fileContentHashes = %#v expand=%q err=%v", hashMap, expanded, err)
+	}
+	if fileContentHashes(nil) != nil {
+		t.Error("nil lock hashes should stay nil")
 	}
 
 	plan := filePlanEntries(&files.ApplyResult{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #141.

`status --files` and apply treated a managed-link as `ok` whenever the symlink pointed at the spec source. Apps that write through the link (npmrc, Warp settings, and similar) changed the body and genv never noticed.

## What changed

- Lock `files[]` entries for `link` / `managed-link` / templates now store optional `contentHash` (`sha256:<hex>`). Additive omitempty field; no lock schema bump. Pre-hash locks stay topology-only.
- `genv status --files` reports `drifted` (path shown) when topology is still correct but the live hash differs.
- `genv apply` records the hash after a successful link/template op, including the already-up-to-date path. It never reverts the body; a later apply refreshes the hash to the current content.
- Hashing is always on for those entries. `merge-dir` trees are not hashed.

## Tests

- Modify a linked source after apply: `status --files` exits 4 with `drifted` and the path.
- Re-apply leaves the new body in place and refreshes `contentHash`; status returns to ok.
- Unit coverage for matching hash, missing hash, topology mismatch winning over drift, and template source change after an out-of-band re-render.
- `make ci` locally: 81.8% coverage, cold-start 178ms.

## Out of scope

#144 (declarative launchd/systemd services) and #145 (command-defined adapters).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2da18ccc-b8a4-4ec7-a46d-1ed8a8e29483?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2da18ccc-b8a4-4ec7-a46d-1ed8a8e29483&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

