### PR TITLE
feat: declarative launchd and systemd user services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Spec services can declare a LaunchAgent or systemd --user unit from a
+  template: `services.<name>.launchd.plist` and `services.<name>.systemd.unit`.
+  Paths render like `files.templates[]`. `genv apply` writes the unit, loads it
+  if needed, and re-bootstraps / restarts when the rendered content changes.
+  `genv service status` uses `launchctl print gui/$UID/<Label>` or
+  `systemctl --user is-active`. Removing the service boots it out (or stops
+  the unit) and deletes the file. No postApply hook is required.
 - Schema v8 top-level `adapters` defines command adapters for plugin CLIs
   (Claude Code plugins, gh extensions, editor plugins). Packages with
   `prefer: <adapter>` install, remove, and upgrade via the declared commands
@@ -13,11 +20,12 @@ All notable changes to this project will be documented in this file.
   List parsing is JSON (`idField` / `versionField`) and/or regex (`listMatch`).
   `external` stays track-only. See SCHEMA.md.
 - `genv apply --source-root <dir>` resolves `files.links` / `files.templates`
-  sources against that directory instead of the spec file directory. Use it to
-  dry-run (or apply) a worktree copy of `genv.json` against the live tree so
-  existing links stay `ok` and only real file changes show. A missing or
-  non-directory `--source-root` is refused. Lock, env, and shell paths still
-  follow `--file` / `--lock-file` / `--state-dir`.
+  and service `launchd.plist` / `systemd.unit` sources against that directory
+  instead of the spec file directory. Use it to dry-run (or apply) a worktree
+  copy of `genv.json` against the live tree so existing links stay `ok` and
+  only real file changes show. A missing or non-directory `--source-root` is
+  refused. Lock, env, and shell paths still follow `--file` / `--lock-file` /
+  `--state-dir`.
 - Lock files record a `contentHash` (`sha256:<hex>`) per managed link and
   template after a successful apply. `genv status --files` reports `drifted`
   (with the path) when the live source or rendered body no longer matches that

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Convenience commands (`add` / `remove` / `adopt` / `disown` / `scan`) update the
 | `export` | Single-target snapshot + report + assets |
 | `map` | Assist-only manager mapping suggestions |
 | `init` / `edit` | Wizard / `$EDITOR` |
-| `env` / `shell` / `service` / `files` | Env vars, aliases, user services, `files adopt` |
+| `env` / `shell` / `service` / `files` | Env vars, aliases, user services (`launchd` / `systemd` templates), `files adopt` |
 | `completion` | `bash` / `zsh` / `fish` / `powershell` |
 | `clean` | Clear detected manager caches |
 | `version` / `help` | Build info / usage |
@@ -279,6 +279,21 @@ genv migrate --write
 ```
 
 File mismatches without `--force` no longer block packages/services: non-conflicting file ops still apply, each mismatched path is printed, and apply exits `4` if any remain.
+
+### User services (launchd / systemd)
+
+Declare a LaunchAgent or systemd --user unit in the spec instead of a `postApply` hook:
+
+```json
+"services": {
+  "syncthing": {
+    "launchd": { "plist": "launchd/com.example.syncthing.plist" },
+    "systemd": { "unit": "systemd/syncthing.service" }
+  }
+}
+```
+
+`genv apply` renders the template (`__HOME__` and the other `files.templates[]` placeholders), writes `~/Library/LaunchAgents/<Label>.plist` or `~/.config/systemd/user/<basename>.service`, and loads it. Editing the template and applying again re-bootstraps the launchd job or restarts the systemd unit. `genv service status syncthing` reads supervisor state. Removing the service from the spec unloads it and deletes the unit file. See [SCHEMA.md](SCHEMA.md#v4--services).
 
 ### Updates checker
 

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -217,7 +217,7 @@ Commands are split into argv (quotes supported). There is no shell piping or red
 
 `genv scan` runs each available adapter’s `list` and, for spec adapters, writes `prefer` so the adopted package stays bound. `genv export` copies `adapters` into the snapshot so `prefer` still validates.
 
-`genv apply` consults a live inventory (`ListInstalled` per available manager) and adopts already-installed packages into the lock instead of reinstalling. `genv upgrade` remains the only upgrade path. Apply `--timeout` defaults to 10m. `--skip-packages` applies env/shell/files/services without inventorying or planning packages. `--source-root <dir>` resolves `files.links` / `files.templates` sources against that directory instead of the spec file directory (lock, env, and shell paths stay where `--file` / `--lock-file` / `--state-dir` put them).
+`genv apply` consults a live inventory (`ListInstalled` per available manager) and adopts already-installed packages into the lock instead of reinstalling. `genv upgrade` remains the only upgrade path. Apply `--timeout` defaults to 10m. `--skip-packages` applies env/shell/files/services without inventorying or planning packages. `--source-root <dir>` resolves `files.links` / `files.templates` and service `launchd.plist` / `systemd.unit` sources against that directory instead of the spec file directory (lock, env, and shell paths stay where `--file` / `--lock-file` / `--state-dir` put them).
 
 `genv status` probes live managers by default (`--offline` is lock-only). Unlocked but installed packages are `present`.
 

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -135,7 +135,20 @@ Hooks run as the current user and are arbitrary code by design — treat the spe
 
 ## v4 — services
 
-Map of name → `{ start, stop, restart, status }` argv arrays and/or `brew_formula` (mutually exclusive with `start`).
+Map of name → one backend:
+
+- `{ start, stop, restart, status }` argv arrays
+- `brew_formula` (mutually exclusive with `start`)
+- `launchd: { "plist": "agents/com.example.agent.plist" }` — LaunchAgent template, rendered like `files.templates[]` (`__HOME__` / `__USER__` / `__HOST__` / `__OS__` / `__ARCH__`)
+- `systemd: { "unit": "units/foo.service" }` — systemd --user unit template, same rendering
+
+`launchd` and `systemd` may coexist on one service (portable defaults). They are mutually exclusive with `start` and `brew_formula`.
+
+`genv apply` writes the rendered plist to `~/Library/LaunchAgents/<Label>.plist` and `launchctl bootstrap`s `gui/$UID` when the job is not loaded. A content change boots the job out and bootstraps again. `genv service status <name>` uses `launchctl print gui/$UID/<Label>`. Removing the service from the spec boots it out and deletes the plist.
+
+On Linux, apply writes `~/.config/systemd/user/<basename>.service`, then `systemctl --user daemon-reload` and `enable --now`. Content changes restart the unit. Status uses `systemctl --user is-active`. Removal stops, disables, and deletes the unit.
+
+Relative template paths resolve against the spec directory (or `repo.url` when set), same as `files.templates`.
 
 ## v3 / v2 / v1
 

--- a/completions/genv.bash
+++ b/completions/genv.bash
@@ -283,7 +283,7 @@ _genv() {
 			fi
 		else
 			case "${svc_sub}" in
-			add) opts="--file --start --stop --restart --status --brew-formula --target" ;;
+			add) opts="--file --start --stop --restart --status --brew-formula --launchd-plist --systemd-unit --target" ;;
 			remove | rm) opts="--file --target" ;;
 			list | ls) opts="--file --target" ;;
 			start | stop | status) opts="--file --target" ;;

--- a/completions/genv.fish
+++ b/completions/genv.fish
@@ -294,6 +294,8 @@ complete -c genv -n '__fish_genv_seen_sub service add' -l stop -d 'Command to st
 complete -c genv -n '__fish_genv_seen_sub service add' -l restart -d 'Command to restart the service' -x
 complete -c genv -n '__fish_genv_seen_sub service add' -l status -d 'Command to check service status' -x
 complete -c genv -n '__fish_genv_seen_sub service add' -l brew-formula -d 'Homebrew formula to manage via brew services (macOS only)' -x
+complete -c genv -n '__fish_genv_seen_sub service add' -l launchd-plist -d 'LaunchAgent plist template' -r
+complete -c genv -n '__fish_genv_seen_sub service add' -l systemd-unit -d 'systemd --user unit template' -r
 complete -c genv -n '__fish_genv_seen_sub service add; or __fish_genv_seen_sub service remove; or __fish_genv_seen_sub service rm' -l target -d 'Portable target id for schemaVersion 8 specs' -x
 complete -c genv -n '__fish_genv_seen_sub service list; or __fish_genv_seen_sub service ls; or __fish_genv_seen_sub service start; or __fish_genv_seen_sub service stop; or __fish_genv_seen_sub service status' -l target -d 'Portable target id for schemaVersion 8 specs' -x
 

--- a/completions/genv.ps1
+++ b/completions/genv.ps1
@@ -228,7 +228,7 @@ function script:Get-GenvCompletions {
 				return (& $completeCandidates -Candidates $serviceSubs -ResultType 'ParameterValue')
 			}
 			switch ($serviceSub) {
-				'add' { $flags = @('--file', '--start', '--stop', '--restart', '--status', '--brew-formula', '--target') }
+				'add' { $flags = @('--file', '--start', '--stop', '--restart', '--status', '--brew-formula', '--launchd-plist', '--systemd-unit', '--target') }
 				{ $_ -in 'remove', 'rm' } { $flags = @('--file', '--target') }
 				default { $flags = @('--file') }
 			}

--- a/completions/genv.zsh
+++ b/completions/genv.zsh
@@ -461,6 +461,8 @@ _genv() {
 						'--restart=[Command to restart the service]:command:' \
 						'--status=[Command to check service status]:command:' \
 						'--brew-formula=[Homebrew formula to manage via brew services (macOS only)]:formula:' \
+						'--launchd-plist=[LaunchAgent plist template]:plist:_files' \
+						'--systemd-unit=[systemd --user unit template]:unit:_files' \
 						'--target=[Portable target id for schemaVersion 8 specs]:target:'
 					;;
 				remove | rm)

--- a/internal/commands/service.go
+++ b/internal/commands/service.go
@@ -18,14 +18,29 @@ var ErrServiceNotFound = errors.New("service not found in spec")
 // It upgrades f.SchemaVersion to schema.Version4 if needed.
 // Either start or brewFormula must be provided, but not both.
 func ServiceAdd(f *schema.GenvFile, name string, start, stop, restart, status []string, brewFormula, targetID string) error {
+	return ServicePut(f, name, schema.Service{
+		Start:       start,
+		Stop:        stop,
+		Restart:     restart,
+		Status:      status,
+		BrewFormula: brewFormula,
+	}, targetID)
+}
+
+// ServicePut writes svc under name, validating that a backend is declared.
+func ServicePut(f *schema.GenvFile, name string, svc schema.Service, targetID string) error {
 	if name == "" {
 		return errors.New("service name must not be empty")
 	}
-	if len(start) == 0 && brewFormula == "" {
-		return errors.New("either --start or --brew-formula is required")
+	hasSupervisor := svc.DeclaresLaunchd() || svc.DeclaresSystemd()
+	if len(svc.Start) == 0 && svc.BrewFormula == "" && !hasSupervisor {
+		return errors.New("either --start, --brew-formula, --launchd-plist, or --systemd-unit is required")
 	}
-	if len(start) > 0 && brewFormula != "" {
+	if len(svc.Start) > 0 && svc.BrewFormula != "" {
 		return errors.New("--start and --brew-formula are mutually exclusive")
+	}
+	if hasSupervisor && (len(svc.Start) > 0 || svc.BrewFormula != "") {
+		return errors.New("launchd/systemd templates are mutually exclusive with --start and --brew-formula")
 	}
 	if f.SchemaVersion == schema.Version8 {
 		bundle, err := ActiveBundle(f, targetID)
@@ -35,26 +50,13 @@ func ServiceAdd(f *schema.GenvFile, name string, start, stop, restart, status []
 		if bundle.Services == nil {
 			bundle.Services = make(map[string]*schema.Service)
 		}
-		svc := schema.Service{
-			Start:       start,
-			Stop:        stop,
-			Restart:     restart,
-			Status:      status,
-			BrewFormula: brewFormula,
-		}
 		bundle.Services[name] = &svc
 		return nil
 	}
 	if f.Services == nil {
 		f.Services = make(map[string]schema.Service)
 	}
-	f.Services[name] = schema.Service{
-		Start:       start,
-		Stop:        stop,
-		Restart:     restart,
-		Status:      status,
-		BrewFormula: brewFormula,
-	}
+	f.Services[name] = svc
 	// Raise schema to at least v4 now that a services block is present, without
 	// downgrading a file that already declares a newer version.
 	f.SchemaVersion = schema.AtLeastVersion(f.SchemaVersion, schema.Version4)
@@ -120,7 +122,27 @@ func ServiceList(f *schema.GenvFile, w io.Writer) {
 		if status == "" {
 			status = "—"
 		}
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", name, strings.Join(svc.Start, " "), stop, status)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", name, serviceStartCell(svc), stop, status)
 	}
 	_ = tw.Flush()
+}
+
+func serviceStartCell(svc schema.Service) string {
+	var parts []string
+	if svc.DeclaresLaunchd() {
+		parts = append(parts, "launchd:"+svc.Launchd.Plist)
+	}
+	if svc.DeclaresSystemd() {
+		parts = append(parts, "systemd:"+svc.Systemd.Unit)
+	}
+	if svc.BrewFormula != "" {
+		parts = append(parts, "brew:"+svc.BrewFormula)
+	}
+	if len(svc.Start) > 0 {
+		parts = append(parts, strings.Join(svc.Start, " "))
+	}
+	if len(parts) == 0 {
+		return "—"
+	}
+	return strings.Join(parts, " ")
 }

--- a/internal/commands/service_test.go
+++ b/internal/commands/service_test.go
@@ -61,3 +61,23 @@ func TestServiceCommands(t *testing.T) {
 		t.Errorf("expected 'service not found' error, got %v", err)
 	}
 }
+
+func TestServicePut_LaunchdTemplate(t *testing.T) {
+	f := &schema.GenvFile{SchemaVersion: schema.Version8, Targets: map[string]*schema.TargetBundle{
+		"macos": {},
+	}}
+	err := ServicePut(f, "agent", schema.Service{Launchd: &schema.LaunchdSpec{Plist: "agents/foo.plist"}}, "macos")
+	if err != nil {
+		t.Fatalf("ServicePut launchd: %v", err)
+	}
+	got := f.Targets["macos"].Services["agent"]
+	if got == nil || !got.DeclaresLaunchd() || got.Launchd.Plist != "agents/foo.plist" {
+		t.Fatalf("macos agent = %+v", got)
+	}
+	var buf bytes.Buffer
+	listFile := &schema.GenvFile{Services: map[string]schema.Service{"agent": *got}}
+	ServiceList(listFile, &buf)
+	if !strings.Contains(buf.String(), "launchd:agents/foo.plist") {
+		t.Fatalf("list missing launchd cell:\n%s", buf.String())
+	}
+}

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/ks1686/genv/internal/genvfile"
@@ -38,10 +39,13 @@ func BuildWithOptions(f *schema.GenvFile, targetID string, outDir string, opts O
 		return nil, err
 	}
 
-	report := buildReport(effective.Packages, effective.Files, targetID)
+	report := buildReport(effective.Packages, effective.Files, effective.Services, targetID)
 	bundle, envReport := bundleFromFlat(effective)
 	report = append(report, envReport...)
 	if err := rewriteAndCopyFileAssets(bundle.Files, opts.BaseDir, outDir); err != nil {
+		return report.sorted(), err
+	}
+	if err := rewriteAndCopyServiceAssets(bundle.Services, opts.BaseDir, outDir); err != nil {
 		return report.sorted(), err
 	}
 
@@ -163,7 +167,7 @@ func normalizeBundle(bundle *schema.TargetBundle) *schema.TargetBundle {
 	return bundle
 }
 
-func buildReport(packages []schema.Package, files *schema.FilesConfig, targetID string) Report {
+func buildReport(packages []schema.Package, files *schema.FilesConfig, services map[string]schema.Service, targetID string) Report {
 	var report Report
 	allowed := managerAllowlist(targetID)
 	for _, pkg := range packages {
@@ -187,6 +191,14 @@ func buildReport(packages []schema.Package, files *schema.FilesConfig, targetID 
 			if isAbsolutePath(tpl.Source) {
 				report = append(report, absoluteSourceItem(fmt.Sprintf("files.templates[%d].source", i), tpl.Source))
 			}
+		}
+	}
+	for name, svc := range services {
+		if svc.DeclaresLaunchd() && isAbsolutePath(svc.Launchd.Plist) {
+			report = append(report, absoluteSourceItem("services."+name+".launchd.plist", svc.Launchd.Plist))
+		}
+		if svc.DeclaresSystemd() && isAbsolutePath(svc.Systemd.Unit) {
+			report = append(report, absoluteSourceItem("services."+name+".systemd.unit", svc.Systemd.Unit))
 		}
 	}
 	return report
@@ -288,6 +300,42 @@ func rewriteAndCopyFileAssets(files *schema.FilesConfig, baseDir, outDir string)
 			return err
 		}
 		files.Templates[i].Source = rel
+	}
+	return nil
+}
+
+func rewriteAndCopyServiceAssets(services map[string]*schema.Service, baseDir, outDir string) error {
+	if len(services) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(services))
+	for name := range services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for i, name := range names {
+		svc := services[name]
+		if svc == nil {
+			continue
+		}
+		if svc.DeclaresLaunchd() && svc.Launchd.Plist != "" && !isAbsolutePath(svc.Launchd.Plist) {
+			rel, err := copyAsset(baseDir, outDir, svc.Launchd.Plist, "launchd", i)
+			if err != nil {
+				return err
+			}
+			copied := *svc.Launchd
+			copied.Plist = rel
+			svc.Launchd = &copied
+		}
+		if svc.DeclaresSystemd() && svc.Systemd.Unit != "" && !isAbsolutePath(svc.Systemd.Unit) {
+			rel, err := copyAsset(baseDir, outDir, svc.Systemd.Unit, "systemd", i)
+			if err != nil {
+				return err
+			}
+			copied := *svc.Systemd
+			copied.Unit = rel
+			svc.Systemd = &copied
+		}
 	}
 	return nil
 }
@@ -518,6 +566,14 @@ func copyService(in schema.Service) schema.Service {
 	out.Stop = copyStrings(in.Stop)
 	out.Restart = copyStrings(in.Restart)
 	out.Status = copyStrings(in.Status)
+	if in.Launchd != nil {
+		v := *in.Launchd
+		out.Launchd = &v
+	}
+	if in.Systemd != nil {
+		v := *in.Systemd
+		out.Systemd = &v
+	}
 	return out
 }
 

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -78,6 +78,42 @@ func TestIsAbsolutePathRecognizesTargetPlatformPaths(t *testing.T) {
 	}
 }
 
+func TestBuildCopiesSupervisorTemplates(t *testing.T) {
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plist := filepath.Join(base, "agents", "com.example.agent.plist")
+	if err := os.WriteFile(plist, []byte("<plist/>\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f := &schema.GenvFile{
+		SchemaVersion: schema.Version8,
+		Targets: map[string]*schema.TargetBundle{
+			"macos": {
+				Services: map[string]*schema.Service{
+					"agent": {Launchd: &schema.LaunchdSpec{Plist: "agents/com.example.agent.plist"}},
+				},
+			},
+		},
+	}
+	outDir := t.TempDir()
+	if _, err := BuildWithOptions(f, "macos", outDir, Options{BaseDir: base}); err != nil {
+		t.Fatal(err)
+	}
+	copied := filepath.Join(outDir, "files", "agents", "com.example.agent.plist")
+	if _, err := os.Stat(copied); err != nil {
+		t.Fatalf("expected bundled plist at %s: %v", copied, err)
+	}
+	data, err := os.ReadFile(filepath.Join(outDir, "genv.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "files/agents/com.example.agent.plist") {
+		t.Fatalf("snapshot should rewrite launchd.plist, got:\n%s", data)
+	}
+}
+
 func TestBuildDoesNotDeferNativeLinuxManagers(t *testing.T) {
 	f := &schema.GenvFile{
 		SchemaVersion: schema.Version8,

--- a/internal/genvfile/lockfile.go
+++ b/internal/genvfile/lockfile.go
@@ -51,12 +51,16 @@ type LockedShellConfig struct {
 
 // LockedService records how one service was last applied by genv.
 type LockedService struct {
-	Name        string   `json:"name"`
-	Start       []string `json:"start,omitempty"`
-	Stop        []string `json:"stop,omitempty"`
-	Restart     []string `json:"restart,omitempty"`
-	Status      []string `json:"status,omitempty"`
-	BrewFormula string   `json:"brew_formula,omitempty"`
+	Name         string   `json:"name"`
+	Start        []string `json:"start,omitempty"`
+	Stop         []string `json:"stop,omitempty"`
+	Restart      []string `json:"restart,omitempty"`
+	Status       []string `json:"status,omitempty"`
+	BrewFormula  string   `json:"brew_formula,omitempty"`
+	LaunchdPlist string   `json:"launchdPlist,omitempty"`
+	LaunchdLabel string   `json:"launchdLabel,omitempty"`
+	SystemdUnit  string   `json:"systemdUnit,omitempty"`
+	SystemdName  string   `json:"systemdName,omitempty"`
 }
 
 // LockedFile records a single applied file entry from the spec files block.

--- a/internal/schema/merge.go
+++ b/internal/schema/merge.go
@@ -311,6 +311,14 @@ func copyService(in Service) Service {
 	out.Restart = copyStrings(in.Restart)
 	out.Status = copyStrings(in.Status)
 	out.Host = copyHostPredicate(in.Host)
+	if in.Launchd != nil {
+		v := *in.Launchd
+		out.Launchd = &v
+	}
+	if in.Systemd != nil {
+		v := *in.Systemd
+		out.Systemd = &v
+	}
 	return out
 }
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -356,15 +356,38 @@ type Hook struct {
 }
 
 // Service is a single user-space service declaration.
-// Either Start or BrewFormula must be provided.
+// At least one of Start, BrewFormula, Launchd.Plist, or Systemd.Unit is required.
 // When BrewFormula is set, genv manages the service via `brew services` on macOS.
+// Launchd and Systemd declare user-supervisor units from rendered templates.
 type Service struct {
 	Start       []string      `json:"start,omitempty"`
 	Stop        []string      `json:"stop,omitempty"`
 	Restart     []string      `json:"restart,omitempty"`
 	Status      []string      `json:"status,omitempty"`
 	BrewFormula string        `json:"brew_formula,omitempty"`
+	Launchd     *LaunchdSpec  `json:"launchd,omitempty"`
+	Systemd     *SystemdSpec  `json:"systemd,omitempty"`
 	Host        HostPredicate `json:"host,omitempty"`
+}
+
+// LaunchdSpec points at a LaunchAgent plist template, rendered like files.templates.
+type LaunchdSpec struct {
+	Plist string `json:"plist"`
+}
+
+// SystemdSpec points at a systemd --user unit template, rendered like files.templates.
+type SystemdSpec struct {
+	Unit string `json:"unit"`
+}
+
+// DeclaresLaunchd reports whether svc names a launchd plist template.
+func (s Service) DeclaresLaunchd() bool {
+	return s.Launchd != nil && s.Launchd.Plist != ""
+}
+
+// DeclaresSystemd reports whether svc names a systemd --user unit template.
+func (s Service) DeclaresSystemd() bool {
+	return s.Systemd != nil && s.Systemd.Unit != ""
 }
 
 // ShellConfig is the shell configuration block in genv.json.

--- a/internal/schema/unknown.go
+++ b/internal/schema/unknown.go
@@ -42,7 +42,9 @@ var (
 	shellFields   = strSet("aliases", "functions", "source")
 	aliasFields   = strSet("value", "shell")
 	funcFields    = strSet("body", "shell")
-	serviceFields = strSet("start", "stop", "restart", "status", "brew_formula", "host")
+	serviceFields = strSet("start", "stop", "restart", "status", "brew_formula", "launchd", "systemd", "host")
+	launchdFields = strSet("plist")
+	systemdFields = strSet("unit")
 	filesFields   = strSet("links", "templates", "dirs")
 	linkFields    = strSet("source", "target", "mode", "host", "backup", "perm")
 	tmplFields    = strSet("source", "target", "host", "backup", "perm")
@@ -142,7 +144,25 @@ func walkEnvMap(raw json.RawMessage, path string, positions map[string]Position)
 }
 
 func walkServiceMap(raw json.RawMessage, path string, positions map[string]Position) []ValidationError {
-	return walkKeyedObjects(raw, path, serviceFields, positions)
+	obj, ok := asObject(raw)
+	if !ok {
+		return nil
+	}
+	var errs []ValidationError
+	for key, val := range obj {
+		if isJSONNull(val) {
+			continue
+		}
+		svcPath := path + "." + key
+		svc, ok := asObject(val)
+		if !ok {
+			continue
+		}
+		errs = append(errs, rejectUnknown(svc, svcPath, serviceFields, positions)...)
+		errs = append(errs, walkObject(svc["launchd"], svcPath+".launchd", launchdFields, positions)...)
+		errs = append(errs, walkObject(svc["systemd"], svcPath+".systemd", systemdFields, positions)...)
+	}
+	return errs
 }
 
 func walkShell(raw json.RawMessage, path string, positions map[string]Position) []ValidationError {

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -601,10 +601,11 @@ func validateServiceName(name, fieldPrefix string) []ValidationError {
 
 func validateService(name string, svc Service, fieldPrefix string) []ValidationError {
 	var errs []ValidationError
-	if len(svc.Start) == 0 && svc.BrewFormula == "" {
+	hasSupervisor := svc.DeclaresLaunchd() || svc.DeclaresSystemd()
+	if len(svc.Start) == 0 && svc.BrewFormula == "" && !hasSupervisor {
 		errs = append(errs, ValidationError{
 			Field:   fmt.Sprintf("%s.%s.start", fieldPrefix, name),
-			Message: "start command is required (or set brew_formula for brew-managed services)",
+			Message: "start command is required (or set brew_formula, launchd.plist, or systemd.unit)",
 		})
 	}
 	if svc.BrewFormula != "" && len(svc.Start) > 0 {
@@ -613,16 +614,50 @@ func validateService(name string, svc Service, fieldPrefix string) []ValidationE
 			Message: "brew_formula and start are mutually exclusive; use one or the other",
 		})
 	}
+	if hasSupervisor && (len(svc.Start) > 0 || svc.BrewFormula != "") {
+		errs = append(errs, ValidationError{
+			Field:   fmt.Sprintf("%s.%s", fieldPrefix, name),
+			Message: "launchd/systemd templates are mutually exclusive with start and brew_formula",
+		})
+	}
 	if strings.ContainsAny(svc.BrewFormula, "\r\n") {
 		errs = append(errs, ValidationError{
 			Field:   fmt.Sprintf("%s.%s.brew_formula", fieldPrefix, name),
 			Message: "brew_formula must not contain newlines",
 		})
 	}
+	if svc.Launchd != nil {
+		errs = append(errs, validateServicePath(fieldPrefix, name, "launchd.plist", svc.Launchd.Plist, true)...)
+	}
+	if svc.Systemd != nil {
+		errs = append(errs, validateServicePath(fieldPrefix, name, "systemd.unit", svc.Systemd.Unit, true)...)
+	}
 	errs = append(errs, validateServiceCommand(fieldPrefix, name, "start", svc.Start)...)
 	errs = append(errs, validateServiceCommand(fieldPrefix, name, "stop", svc.Stop)...)
 	errs = append(errs, validateServiceCommand(fieldPrefix, name, "restart", svc.Restart)...)
 	errs = append(errs, validateServiceCommand(fieldPrefix, name, "status", svc.Status)...)
+	return errs
+}
+
+func validateServicePath(fieldPrefix, name, field, path string, required bool) []ValidationError {
+	var errs []ValidationError
+	loc := fmt.Sprintf("%s.%s.%s", fieldPrefix, name, field)
+	if path == "" {
+		if required {
+			errs = append(errs, ValidationError{Field: loc, Message: "path must not be empty"})
+		}
+		return errs
+	}
+	if strings.ContainsAny(path, "\r\n") {
+		errs = append(errs, ValidationError{Field: loc, Message: "path must not contain newlines"})
+	}
+	if expanded, err := expandPath(path); err != nil || expanded == "" {
+		msg := "cannot expand path"
+		if err != nil {
+			msg = fmt.Sprintf("%s: %v", msg, err)
+		}
+		errs = append(errs, ValidationError{Field: loc, Message: msg})
+	}
 	return errs
 }
 

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -937,6 +937,73 @@ func TestParseAndValidate_V4StillValid(t *testing.T) {
 	}
 }
 
+func TestParseAndValidate_LaunchdAndSystemdTemplates(t *testing.T) {
+	input := `{
+		"schemaVersion":"8",
+		"defaults":{},
+		"targets":{"macos":{"services":{
+			"agent":{"launchd":{"plist":"agents/com.example.agent.plist"}},
+			"both":{"launchd":{"plist":"agents/foo.plist"},"systemd":{"unit":"units/foo.service"}}
+		}}}
+	}`
+	f, errs, err := ParseAndValidate([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	if len(errs) > 0 {
+		t.Fatalf("launchd/systemd templates should validate: %v", errs)
+	}
+	got := f.Targets["macos"].Services["agent"]
+	if got == nil || !got.DeclaresLaunchd() || got.Launchd.Plist != "agents/com.example.agent.plist" {
+		t.Fatalf("macos agent launchd = %+v", got)
+	}
+}
+
+func TestParseAndValidate_LaunchdExclusiveWithStart(t *testing.T) {
+	input := `{"schemaVersion":"4","packages":[],"services":{"svc":{"start":["true"],"launchd":{"plist":"a.plist"}}}}`
+	_, errs, err := ParseAndValidate([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	found := false
+	for _, e := range errs {
+		if e.Field == "services.svc" && strings.Contains(e.Message, "mutually exclusive") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected exclusivity error, got: %v", errs)
+	}
+}
+
+func TestParseAndValidate_LaunchdEmptyPlistRejected(t *testing.T) {
+	input := `{"schemaVersion":"4","packages":[],"services":{"svc":{"launchd":{}}}}`
+	_, errs, err := ParseAndValidate([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Fatal("expected empty launchd.plist to fail validation")
+	}
+}
+
+func TestParseAndValidate_UnknownLaunchdFieldRejected(t *testing.T) {
+	input := `{"schemaVersion":"4","packages":[],"services":{"svc":{"launchd":{"plist":"a.plist","program":"x"}}}}`
+	_, errs, err := ParseAndValidate([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	found := false
+	for _, e := range errs {
+		if e.Field == "services.svc.launchd.program" && strings.Contains(e.Message, "unknown field") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected unknown launchd field, got: %v", errs)
+	}
+}
+
 func TestParseAndValidate_AcceptsV7(t *testing.T) {
 	input := `{"schemaVersion":"7","packages":[]}`
 	f, errs, err := ParseAndValidate([]byte(input))

--- a/internal/service/coverage_extra_test.go
+++ b/internal/service/coverage_extra_test.go
@@ -122,12 +122,12 @@ func TestApplyServicesUsesAvailableSupervisor(t *testing.T) {
 	installServiceFakeBinary(t, "launchctl", "exit 0")
 
 	spec := map[string]schema.Service{"managed": {Start: []string{"true"}}}
-	applied, removed, errs := ApplyServices(context.Background(), spec, nil, true)
+	applied, removed, errs := ApplyServices(context.Background(), spec, nil, true, "")
 	if len(errs) != 0 || len(applied) != 1 || applied[0] != "managed" || len(removed) != 0 {
 		t.Fatalf("apply = %v, remove = %v, errors = %v", applied, removed, errs)
 	}
 
-	applied, removed, errs = ApplyServices(context.Background(), nil, []genvfile.LockedService{{Name: "managed"}}, true)
+	applied, removed, errs = ApplyServices(context.Background(), nil, []genvfile.LockedService{{Name: "managed"}}, true, "")
 	if len(errs) != 0 || len(applied) != 0 || len(removed) != 1 || removed[0] != "managed" {
 		t.Fatalf("apply = %v, remove = %v, errors = %v", applied, removed, errs)
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -67,9 +67,10 @@ type ServiceStatusEntry struct {
 
 // ServiceStatus computes the two-way diff between the spec services block and
 // the lock services entries. When probe is true, each in-spec service is also
-// checked for liveness (brew, a custom status command, or systemd). When
-// probe is false, Running is always false and no subprocesses are spawned.
-func ServiceStatus(specServices map[string]schema.Service, lockServices []genvfile.LockedService, probe bool) []ServiceStatusEntry {
+// checked for liveness (brew, launchd, systemd, or a custom status command).
+// When probe is false, Running is always false and no subprocesses are spawned.
+// sourceRoot resolves relative launchd/systemd template paths.
+func ServiceStatus(specServices map[string]schema.Service, lockServices []genvfile.LockedService, probe bool, sourceRoot string) []ServiceStatusEntry {
 	lockByName := make(map[string]genvfile.LockedService, len(lockServices))
 	for _, ls := range lockServices {
 		lockByName[ls.Name] = ls
@@ -107,19 +108,12 @@ func ServiceStatus(specServices map[string]schema.Service, lockServices []genvfi
 		}
 
 		running := false
-		if probe && inSpec && svc.BrewFormula != "" {
-			running = BrewServicesRunning(svc.BrewFormula)
-		} else if probe && inSpec && len(svc.Status) > 0 {
-			// Status commands are user-configured; still bound them so a wedged
-			// probe script cannot stall `genv service list`.
+		if probe && inSpec {
 			if err := resolver.RunTimed(func() error {
-				return exec.Command(svc.Status[0], svc.Status[1:]...).Run()
-			}, resolver.DefaultLiveListTimeout); err == nil {
-				running = true
-			}
-		} else if probe && inSpec && IsSystemdAvailable() {
-			if err := resolver.RunTimed(func() error {
-				return exec.Command("systemctl", "--user", "is-active", "--quiet", systemdUnitName(name)).Run()
+				if ProbeRunning(context.Background(), name, svc, sourceRoot) {
+					return nil
+				}
+				return fmt.Errorf("not running")
 			}, resolver.DefaultLiveListTimeout); err == nil {
 				running = true
 			}
@@ -136,60 +130,47 @@ func ServiceStatus(specServices map[string]schema.Service, lockServices []genvfi
 }
 
 func compareServices(s schema.Service, l genvfile.LockedService) bool {
+	launchdPlist, systemdUnit := "", ""
+	if s.Launchd != nil {
+		launchdPlist = s.Launchd.Plist
+	}
+	if s.Systemd != nil {
+		systemdUnit = s.Systemd.Unit
+	}
 	return strings.Join(s.Start, " ") == strings.Join(l.Start, " ") &&
 		strings.Join(s.Stop, " ") == strings.Join(l.Stop, " ") &&
 		strings.Join(s.Restart, " ") == strings.Join(l.Restart, " ") &&
 		strings.Join(s.Status, " ") == strings.Join(l.Status, " ") &&
-		s.BrewFormula == l.BrewFormula
+		s.BrewFormula == l.BrewFormula &&
+		launchdPlist == l.LaunchdPlist &&
+		systemdUnit == l.SystemdUnit
 }
 
 // ApplyServices reconciles the system state with the desired services.
-// It starts missing/modified services and stops extra services.
-func ApplyServices(ctx context.Context, specServices map[string]schema.Service, lockServices []genvfile.LockedService, verbose bool) (applied, removed []string, errs []error) {
-	statusEntries := ServiceStatus(specServices, lockServices, true)
+// It starts missing/modified services, re-renders supervisor templates, and
+// stops extra services. sourceRoot resolves relative template paths.
+func ApplyServices(ctx context.Context, specServices map[string]schema.Service, lockServices []genvfile.LockedService, verbose bool, sourceRoot string) (applied, removed []string, errs []error) {
+	statusEntries := ServiceStatus(specServices, lockServices, true, sourceRoot)
 
 	for _, e := range statusEntries {
 		switch e.Kind {
-		case ServiceStatusMissing, ServiceStatusModified:
-			svc := specServices[e.Name]
-			if svc.BrewFormula != "" {
-				if !IsBrewServicesAvailable() {
-					errs = append(errs, fmt.Errorf("service %q requires brew services but brew is not available on this platform", e.Name))
-					continue
-				}
-				if verbose {
-					_, _ = fmt.Fprintf(os.Stdout, "  service: starting %s via brew services\n", e.Name)
-				}
-				if err := BrewServicesStart(ctx, svc.BrewFormula); err != nil {
-					errs = append(errs, err)
-				} else {
-					applied = append(applied, e.Name)
-				}
-			} else if IsSystemdAvailable() {
-				if err := applySystemd(ctx, e.Name, svc, verbose); err != nil {
-					errs = append(errs, err)
-				} else {
-					applied = append(applied, e.Name)
-				}
-			} else if IsLaunchdAvailable() {
-				if err := applyLaunchd(ctx, e.Name, svc, verbose); err != nil {
-					errs = append(errs, err)
-				} else {
-					applied = append(applied, e.Name)
-				}
-			} else {
-				if verbose {
-					_, _ = fmt.Fprintf(os.Stdout, "  service: starting %s\n", e.Name)
-				}
-				cmd := exec.CommandContext(ctx, svc.Start[0], svc.Start[1:]...)
-				if err := cmd.Run(); err != nil {
-					errs = append(errs, fmt.Errorf("starting service %q: %w", e.Name, err))
-				} else {
-					applied = append(applied, e.Name)
-				}
+		case ServiceStatusMissing, ServiceStatusModified, ServiceStatusOK:
+			svc, inSpec := specServices[e.Name]
+			if !inSpec {
+				continue
+			}
+			if e.Kind == ServiceStatusOK && !svc.DeclaresLaunchd() && !svc.DeclaresSystemd() {
+				continue
+			}
+			changed, err := applyDeclared(ctx, e.Name, svc, sourceRoot, verbose)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if changed {
+				applied = append(applied, e.Name)
 			}
 		case ServiceStatusExtra:
-			// Find the locked service to get its stop command if possible.
 			var ls genvfile.LockedService
 			for _, l := range lockServices {
 				if l.Name == e.Name {
@@ -197,46 +178,9 @@ func ApplyServices(ctx context.Context, specServices map[string]schema.Service, 
 					break
 				}
 			}
-
-			if ls.BrewFormula != "" {
-				if !IsBrewServicesAvailable() {
-					errs = append(errs, fmt.Errorf("service %q requires brew services but brew is not available on this platform", e.Name))
-					continue
-				}
-				if verbose {
-					_, _ = fmt.Fprintf(os.Stdout, "  service: stopping %s via brew services\n", e.Name)
-				}
-				if err := BrewServicesStop(ctx, ls.BrewFormula); err != nil {
-					errs = append(errs, err)
-				} else {
-					removed = append(removed, e.Name)
-				}
-			} else if IsSystemdAvailable() {
-				if err := removeSystemd(ctx, e.Name, verbose); err != nil {
-					errs = append(errs, err)
-				} else {
-					removed = append(removed, e.Name)
-				}
-			} else if IsLaunchdAvailable() {
-				if err := removeLaunchd(ctx, e.Name, verbose); err != nil {
-					errs = append(errs, err)
-				} else {
-					removed = append(removed, e.Name)
-				}
-			} else if len(ls.Stop) > 0 {
-				if verbose {
-					_, _ = fmt.Fprintf(os.Stdout, "  service: stopping %s\n", e.Name)
-				}
-				cmd := exec.CommandContext(ctx, ls.Stop[0], ls.Stop[1:]...)
-				if err := cmd.Run(); err != nil {
-					errs = append(errs, fmt.Errorf("stopping service %q: %w", e.Name, err))
-				} else {
-					removed = append(removed, e.Name)
-				}
+			if err := removeLocked(ctx, e.Name, ls, verbose); err != nil {
+				errs = append(errs, err)
 			} else {
-				if verbose {
-					_, _ = fmt.Fprintf(os.Stdout, "  service: removed %s from spec (no stop command defined)\n", e.Name)
-				}
 				removed = append(removed, e.Name)
 			}
 		}
@@ -245,20 +189,34 @@ func ApplyServices(ctx context.Context, specServices map[string]schema.Service, 
 }
 
 // SpecToLock converts spec services map to a slice of locked services.
-func SpecToLock(spec map[string]schema.Service) []genvfile.LockedService {
+// sourceRoot is used to resolve and parse supervisor templates when present.
+func SpecToLock(spec map[string]schema.Service, sourceRoot string) []genvfile.LockedService {
 	if len(spec) == 0 {
 		return nil
 	}
 	var lock []genvfile.LockedService
 	for name, svc := range spec {
-		lock = append(lock, genvfile.LockedService{
+		ls := genvfile.LockedService{
 			Name:        name,
 			Start:       svc.Start,
 			Stop:        svc.Stop,
 			BrewFormula: svc.BrewFormula,
 			Restart:     svc.Restart,
 			Status:      svc.Status,
-		})
+		}
+		if svc.DeclaresLaunchd() {
+			ls.LaunchdPlist = svc.Launchd.Plist
+			if label, err := launchdLabelFor(svc, sourceRoot); err == nil {
+				ls.LaunchdLabel = label
+			}
+		}
+		if svc.DeclaresSystemd() {
+			ls.SystemdUnit = svc.Systemd.Unit
+			if unitBase, err := systemdNameFor(name, svc); err == nil {
+				ls.SystemdName = unitBase
+			}
+		}
+		lock = append(lock, ls)
 	}
 	sort.Slice(lock, func(i, j int) bool {
 		return lock[i].Name < lock[j].Name
@@ -408,8 +366,8 @@ func applySystemd(ctx context.Context, name string, svc schema.Service, verbose 
 	}
 
 	// reload daemon, enable and start service
-	_ = exec.CommandContext(ctx, "systemctl", "--user", "daemon-reload").Run()
-	if err := exec.CommandContext(ctx, "systemctl", "--user", "enable", "--now", unitName).Run(); err != nil {
+	_ = systemctlRun(ctx, "--user", "daemon-reload")
+	if err := systemctlRun(ctx, "--user", "enable", "--now", unitName); err != nil {
 		return fmt.Errorf("enabling systemd service %q: %w\nTip: to view logs run: %s", unitName, err, SystemdLogsHint(name))
 	}
 
@@ -428,14 +386,14 @@ func removeSystemd(ctx context.Context, name string, verbose bool) error {
 		_, _ = fmt.Fprintf(os.Stdout, "  service: stopping and removing %s via systemd\n", name)
 	}
 
-	_ = exec.CommandContext(ctx, "systemctl", "--user", "stop", unitName).Run()
-	_ = exec.CommandContext(ctx, "systemctl", "--user", "disable", unitName).Run()
+	_ = systemctlRun(ctx, "--user", "stop", unitName)
+	_ = systemctlRun(ctx, "--user", "disable", unitName)
 
 	if err := os.Remove(unitPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("removing systemd unit file %q: %w", unitPath, err)
 	}
 
-	_ = exec.CommandContext(ctx, "systemctl", "--user", "daemon-reload").Run()
+	_ = systemctlRun(ctx, "--user", "daemon-reload")
 	return nil
 }
 
@@ -460,9 +418,9 @@ func applyLaunchd(ctx context.Context, name string, svc schema.Service, verbose 
 		_, _ = fmt.Fprintf(os.Stdout, "  service: starting %s via launchd\n", name)
 	}
 
-	// unload if already loaded, then load
-	_ = exec.CommandContext(ctx, "launchctl", "unload", plistPath).Run()
-	if err := exec.CommandContext(ctx, "launchctl", "load", plistPath).Run(); err != nil {
+	label := strings.TrimSuffix(plistName, ".plist")
+	_ = bootoutLaunchd(ctx, label)
+	if err := bootstrapLaunchd(ctx, plistPath); err != nil {
 		return fmt.Errorf("loading launchd service %q: %w\nTip: to view logs run: log show --predicate 'subsystem == \"genv\"' --last 1h", name, err)
 	}
 
@@ -481,7 +439,7 @@ func removeLaunchd(ctx context.Context, name string, verbose bool) error {
 		_, _ = fmt.Fprintf(os.Stdout, "  service: stopping and removing %s via launchd\n", name)
 	}
 
-	_ = exec.CommandContext(ctx, "launchctl", "unload", plistPath).Run()
+	_ = bootoutLaunchd(ctx, strings.TrimSuffix(plistName, ".plist"))
 
 	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("removing launchd plist file %q: %w", plistPath, err)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -48,7 +48,7 @@ func TestServiceStatus(t *testing.T) {
 		},
 	}
 
-	entries := ServiceStatus(spec, lock, true)
+	entries := ServiceStatus(spec, lock, true, "")
 
 	expected := map[string]ServiceStatusKind{
 		"ok-service":       ServiceStatusOK,
@@ -85,7 +85,7 @@ func TestServiceStatus_skipProbe(t *testing.T) {
 			Status: []string{"touch", marker},
 		},
 	}
-	entries := ServiceStatus(spec, nil, false)
+	entries := ServiceStatus(spec, nil, false, "")
 	if len(entries) != 1 {
 		t.Fatalf("entries = %d, want 1", len(entries))
 	}
@@ -110,7 +110,7 @@ func TestApplyServices(t *testing.T) {
 	}
 	lock := []genvfile.LockedService{}
 
-	applied, removed, errs := ApplyServices(ctx, spec, lock, false)
+	applied, removed, errs := ApplyServices(ctx, spec, lock, false, "")
 	if len(errs) > 0 {
 		t.Errorf("ApplyServices failed: %v", errs[0])
 	}
@@ -127,7 +127,7 @@ func TestApplyServices(t *testing.T) {
 		{Name: "extra-svc", Stop: []string{"true"}},
 	}
 
-	applied, removed, errs = ApplyServices(ctx, spec, lock, false)
+	applied, removed, errs = ApplyServices(ctx, spec, lock, false, "")
 	if len(errs) > 0 {
 		t.Errorf("ApplyServices failed: %v", errs[0])
 	}
@@ -153,7 +153,7 @@ func TestApplyServicesFailure(t *testing.T) {
 		"bad-svc": {Start: []string{"false"}},
 	}
 
-	applied, removed, errs := ApplyServices(ctx, spec, nil, false)
+	applied, removed, errs := ApplyServices(ctx, spec, nil, false, "")
 	if len(errs) == 0 {
 		t.Error("expected an error when start command fails, got none")
 	}
@@ -179,7 +179,7 @@ func TestApplyServicesModified(t *testing.T) {
 		{Name: "mod-svc", Start: []string{"echo", "old"}},
 	}
 
-	applied, _, errs := ApplyServices(ctx, spec, lock, false)
+	applied, _, errs := ApplyServices(ctx, spec, lock, false, "")
 	if len(errs) > 0 {
 		t.Errorf("unexpected error: %v", errs[0])
 	}
@@ -196,7 +196,7 @@ func TestApplyServicesExtraNoStop(t *testing.T) {
 		{Name: "nostop-svc"},
 	}
 
-	_, removed, errs := ApplyServices(ctx, nil, lock, false)
+	_, removed, errs := ApplyServices(ctx, nil, lock, false, "")
 	if len(errs) > 0 {
 		t.Errorf("unexpected error: %v", errs[0])
 	}
@@ -211,7 +211,7 @@ func TestSpecToLock(t *testing.T) {
 		"svc-a": {Start: []string{"a"}, Status: []string{"check-a"}},
 	}
 
-	lock := SpecToLock(spec)
+	lock := SpecToLock(spec, "")
 
 	if len(lock) != 2 {
 		t.Fatalf("expected 2 locked services, got %d", len(lock))
@@ -229,10 +229,10 @@ func TestSpecToLock(t *testing.T) {
 }
 
 func TestSpecToLockEmpty(t *testing.T) {
-	if got := SpecToLock(nil); got != nil {
+	if got := SpecToLock(nil, ""); got != nil {
 		t.Errorf("expected nil for empty spec, got %v", got)
 	}
-	if got := SpecToLock(map[string]schema.Service{}); got != nil {
+	if got := SpecToLock(map[string]schema.Service{}, ""); got != nil {
 		t.Errorf("expected nil for empty map, got %v", got)
 	}
 }

--- a/internal/service/supervisor.go
+++ b/internal/service/supervisor.go
@@ -1,0 +1,465 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/ks1686/genv/internal/files"
+	"github.com/ks1686/genv/internal/genvfile"
+	"github.com/ks1686/genv/internal/schema"
+)
+
+var (
+	probeSystemd = IsSystemdAvailable
+	probeLaunchd = IsLaunchdAvailable
+	launchctlRun = func(ctx context.Context, args ...string) error {
+		return exec.CommandContext(ctx, "launchctl", args...).Run()
+	}
+	systemctlRun = func(ctx context.Context, args ...string) error {
+		return exec.CommandContext(ctx, "systemctl", args...).Run()
+	}
+)
+
+var launchdLabelRE = regexp.MustCompile(`(?is)<key>\s*Label\s*</key>\s*<string>([^<]*)</string>`)
+
+func launchdGUIDomain() string {
+	return "gui/" + strconv.Itoa(os.Getuid())
+}
+
+func launchdPrintTarget(label string) string {
+	return launchdGUIDomain() + "/" + label
+}
+
+func bootstrapLaunchd(ctx context.Context, plistPath string) error {
+	return launchctlRun(ctx, "bootstrap", launchdGUIDomain(), plistPath)
+}
+
+func bootoutLaunchd(ctx context.Context, label string) error {
+	return launchctlRun(ctx, "bootout", launchdPrintTarget(label))
+}
+
+func printLaunchd(ctx context.Context, label string) ([]byte, error) {
+	return scheduledCommandOutput(ctx, "launchctl", "print", launchdPrintTarget(label))
+}
+
+func launchdJobLoaded(ctx context.Context, label string) bool {
+	_, err := printLaunchd(ctx, label)
+	return err == nil
+}
+
+func launchdJobRunning(ctx context.Context, label string) bool {
+	output, err := printLaunchd(ctx, label)
+	if err != nil {
+		return false
+	}
+	fields := parseLaunchdFields(string(output))
+	return strings.EqualFold(fields["state"], "running")
+}
+
+func systemdUnitActive(ctx context.Context, unitName string) bool {
+	return systemctlRun(ctx, "--user", "is-active", "--quiet", unitName) == nil
+}
+
+// ParseLaunchdLabel returns the Label string from a rendered plist.
+func ParseLaunchdLabel(plist string) (string, error) {
+	m := launchdLabelRE.FindStringSubmatch(plist)
+	if len(m) < 2 {
+		return "", fmt.Errorf("plist is missing a Label string")
+	}
+	label, err := sanitizeSupervisorName(html.UnescapeString(strings.TrimSpace(m[1])))
+	if err != nil {
+		return "", fmt.Errorf("plist Label: %w", err)
+	}
+	return label, nil
+}
+
+func sanitizeSupervisorName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("must not be empty")
+	}
+	if strings.ContainsAny(name, "/\\\x00\r\n") {
+		return "", fmt.Errorf("%q contains an illegal character", name)
+	}
+	if name == "." || name == ".." {
+		return "", fmt.Errorf("%q is not a valid name", name)
+	}
+	return name, nil
+}
+
+func systemdTemplateUnitName(serviceName, unitPath string) (string, error) {
+	base := filepath.Base(unitPath)
+	if strings.HasSuffix(base, ".service") && base != ".service" {
+		return sanitizeSupervisorName(strings.TrimSuffix(base, ".service"))
+	}
+	return strings.TrimSuffix(systemdUnitName(serviceName), ".service"), nil
+}
+
+func launchdAgentPath(label string) (string, error) {
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", label+".plist"), nil
+}
+
+func systemdUserUnitPath(unitName string) (string, error) {
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "systemd", "user", unitName+".service"), nil
+}
+
+func resolveServiceSource(sourceRoot, source string) (string, error) {
+	return files.ResolveSource(sourceRoot, source)
+}
+
+func renderServiceTemplate(sourceRoot, source string) (string, error) {
+	path, err := resolveServiceSource(sourceRoot, source)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read template %s: %w", path, err)
+	}
+	rendered, err := files.RenderString(string(data))
+	if err != nil {
+		return "", fmt.Errorf("render template %s: %w", path, err)
+	}
+	return rendered, nil
+}
+
+func writeIfChanged(path, content string) (changed bool, err error) {
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	if err == nil && string(existing) == content {
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func applyLaunchdTemplate(ctx context.Context, name string, svc schema.Service, sourceRoot string, verbose bool) (bool, error) {
+	rendered, err := renderServiceTemplate(sourceRoot, svc.Launchd.Plist)
+	if err != nil {
+		return false, fmt.Errorf("service %q launchd plist: %w", name, err)
+	}
+	label, err := ParseLaunchdLabel(rendered)
+	if err != nil {
+		return false, fmt.Errorf("service %q launchd plist: %w", name, err)
+	}
+	dest, err := launchdAgentPath(label)
+	if err != nil {
+		return false, err
+	}
+	changed, err := writeIfChanged(dest, rendered)
+	if err != nil {
+		return false, fmt.Errorf("writing launchd plist %q: %w", dest, err)
+	}
+	loaded := launchdJobLoaded(ctx, label)
+	if verbose {
+		_, _ = fmt.Fprintf(os.Stdout, "  service: reconciling %s via launchd (%s)\n", name, label)
+	}
+	if changed && loaded {
+		_ = bootoutLaunchd(ctx, label)
+		if err := bootstrapLaunchd(ctx, dest); err != nil {
+			return false, fmt.Errorf("re-bootstrapping launchd service %q: %w", name, err)
+		}
+		return true, nil
+	}
+	if !loaded {
+		if err := bootstrapLaunchd(ctx, dest); err != nil {
+			return false, fmt.Errorf("bootstrapping launchd service %q: %w", name, err)
+		}
+		return true, nil
+	}
+	return changed, nil
+}
+
+func applySystemdTemplate(ctx context.Context, name string, svc schema.Service, sourceRoot string, verbose bool) (bool, error) {
+	rendered, err := renderServiceTemplate(sourceRoot, svc.Systemd.Unit)
+	if err != nil {
+		return false, fmt.Errorf("service %q systemd unit: %w", name, err)
+	}
+	unitBase, err := systemdTemplateUnitName(name, svc.Systemd.Unit)
+	if err != nil {
+		return false, fmt.Errorf("service %q systemd unit: %w", name, err)
+	}
+	dest, err := systemdUserUnitPath(unitBase)
+	if err != nil {
+		return false, err
+	}
+	changed, err := writeIfChanged(dest, rendered)
+	if err != nil {
+		return false, fmt.Errorf("writing systemd unit %q: %w", dest, err)
+	}
+	unitName := unitBase + ".service"
+	wasActive := systemdUnitActive(ctx, unitName)
+	if verbose {
+		_, _ = fmt.Fprintf(os.Stdout, "  service: reconciling %s via systemd (%s)\n", name, unitName)
+	}
+	_ = systemctlRun(ctx, "--user", "daemon-reload")
+	if err := systemctlRun(ctx, "--user", "enable", "--now", unitName); err != nil {
+		return false, fmt.Errorf("enabling systemd service %q: %w\nTip: to view logs run: %s", unitName, err, SystemdLogsHint(name))
+	}
+	if changed && wasActive {
+		_ = systemctlRun(ctx, "--user", "restart", unitName)
+	}
+	return changed || !wasActive, nil
+}
+
+func removeLaunchdTemplate(ctx context.Context, name, label string, verbose bool) error {
+	if label == "" {
+		label = strings.TrimSuffix(launchdPlistName(name), ".plist")
+	}
+	dest, err := launchdAgentPath(label)
+	if err != nil {
+		return err
+	}
+	if verbose {
+		_, _ = fmt.Fprintf(os.Stdout, "  service: stopping and removing %s via launchd (%s)\n", name, label)
+	}
+	_ = bootoutLaunchd(ctx, label)
+	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing launchd plist %q: %w", dest, err)
+	}
+	return nil
+}
+
+func removeSystemdTemplate(ctx context.Context, name, unitBase string, verbose bool) error {
+	if unitBase == "" {
+		unitBase = strings.TrimSuffix(systemdUnitName(name), ".service")
+	}
+	unitName := unitBase + ".service"
+	dest, err := systemdUserUnitPath(unitBase)
+	if err != nil {
+		return err
+	}
+	if verbose {
+		_, _ = fmt.Fprintf(os.Stdout, "  service: stopping and removing %s via systemd (%s)\n", name, unitName)
+	}
+	_ = systemctlRun(ctx, "--user", "stop", unitName)
+	_ = systemctlRun(ctx, "--user", "disable", unitName)
+	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing systemd unit %q: %w", dest, err)
+	}
+	_ = systemctlRun(ctx, "--user", "daemon-reload")
+	return nil
+}
+
+func launchdLabelFor(svc schema.Service, sourceRoot string) (string, error) {
+	if !svc.DeclaresLaunchd() {
+		return "", fmt.Errorf("service does not declare launchd")
+	}
+	rendered, err := renderServiceTemplate(sourceRoot, svc.Launchd.Plist)
+	if err != nil {
+		return "", err
+	}
+	return ParseLaunchdLabel(rendered)
+}
+
+func systemdNameFor(name string, svc schema.Service) (string, error) {
+	if !svc.DeclaresSystemd() {
+		return "", fmt.Errorf("service does not declare systemd")
+	}
+	return systemdTemplateUnitName(name, svc.Systemd.Unit)
+}
+
+// StartDeclared starts a spec-declared service using brew, a supervisor template,
+// a generated unit, or the raw start command.
+func StartDeclared(ctx context.Context, name string, svc schema.Service, sourceRoot string) error {
+	if svc.BrewFormula != "" {
+		return BrewServicesStart(ctx, svc.BrewFormula)
+	}
+	if svc.DeclaresLaunchd() {
+		if !probeLaunchd() {
+			return fmt.Errorf("service %q requires launchd, which is not available on this host", name)
+		}
+		_, err := applyLaunchdTemplate(ctx, name, svc, sourceRoot, false)
+		return err
+	}
+	if svc.DeclaresSystemd() {
+		if !probeSystemd() {
+			return fmt.Errorf("service %q requires systemd --user, which is not available on this host", name)
+		}
+		_, err := applySystemdTemplate(ctx, name, svc, sourceRoot, false)
+		return err
+	}
+	if probeSystemd() {
+		return applySystemd(ctx, name, svc, false)
+	}
+	if probeLaunchd() {
+		return applyLaunchd(ctx, name, svc, false)
+	}
+	if len(svc.Start) == 0 {
+		return fmt.Errorf("service %q has no start command", name)
+	}
+	return exec.CommandContext(ctx, svc.Start[0], svc.Start[1:]...).Run()
+}
+
+// StopDeclared stops a spec-declared service.
+func StopDeclared(ctx context.Context, name string, svc schema.Service, sourceRoot string) error {
+	if svc.BrewFormula != "" {
+		return BrewServicesStop(ctx, svc.BrewFormula)
+	}
+	if svc.DeclaresLaunchd() {
+		if !probeLaunchd() {
+			return fmt.Errorf("service %q requires launchd, which is not available on this host", name)
+		}
+		label, err := launchdLabelFor(svc, sourceRoot)
+		if err != nil {
+			return fmt.Errorf("service %q: %w", name, err)
+		}
+		if err := bootoutLaunchd(ctx, label); err != nil {
+			return fmt.Errorf("stopping launchd service %q: %w", name, err)
+		}
+		return nil
+	}
+	if svc.DeclaresSystemd() {
+		if !probeSystemd() {
+			return fmt.Errorf("service %q requires systemd --user, which is not available on this host", name)
+		}
+		unitBase, err := systemdNameFor(name, svc)
+		if err != nil {
+			return err
+		}
+		if err := systemctlRun(ctx, "--user", "stop", unitBase+".service"); err != nil {
+			return fmt.Errorf("stopping systemd service %q: %w", name, err)
+		}
+		return nil
+	}
+	if len(svc.Stop) == 0 {
+		return fmt.Errorf("no stop command defined for service %q", name)
+	}
+	return exec.CommandContext(ctx, svc.Stop[0], svc.Stop[1:]...).Run()
+}
+
+// ProbeRunning reports whether the declared service looks live.
+func ProbeRunning(ctx context.Context, name string, svc schema.Service, sourceRoot string) bool {
+	if svc.BrewFormula != "" {
+		return BrewServicesRunning(svc.BrewFormula)
+	}
+	if svc.DeclaresLaunchd() && probeLaunchd() {
+		label, err := launchdLabelFor(svc, sourceRoot)
+		if err != nil {
+			return false
+		}
+		return launchdJobRunning(ctx, label)
+	}
+	if svc.DeclaresSystemd() && probeSystemd() {
+		unitBase, err := systemdNameFor(name, svc)
+		if err != nil {
+			return false
+		}
+		return systemdUnitActive(ctx, unitBase+".service")
+	}
+	if len(svc.Status) > 0 {
+		if err := exec.CommandContext(ctx, svc.Status[0], svc.Status[1:]...).Run(); err == nil {
+			return true
+		}
+		return false
+	}
+	if probeSystemd() {
+		return systemdUnitActive(ctx, systemdUnitName(name))
+	}
+	if probeLaunchd() {
+		return launchdJobRunning(ctx, strings.TrimSuffix(launchdPlistName(name), ".plist"))
+	}
+	return false
+}
+
+func applyDeclared(ctx context.Context, name string, svc schema.Service, sourceRoot string, verbose bool) (bool, error) {
+	if svc.BrewFormula != "" {
+		if !IsBrewServicesAvailable() {
+			return false, fmt.Errorf("service %q requires brew services but brew is not available on this platform", name)
+		}
+		if verbose {
+			_, _ = fmt.Fprintf(os.Stdout, "  service: starting %s via brew services\n", name)
+		}
+		return true, BrewServicesStart(ctx, svc.BrewFormula)
+	}
+	if svc.DeclaresLaunchd() && probeLaunchd() {
+		return applyLaunchdTemplate(ctx, name, svc, sourceRoot, verbose)
+	}
+	if svc.DeclaresSystemd() && probeSystemd() {
+		return applySystemdTemplate(ctx, name, svc, sourceRoot, verbose)
+	}
+	if svc.DeclaresLaunchd() || svc.DeclaresSystemd() {
+		if verbose {
+			_, _ = fmt.Fprintf(os.Stdout, "  service: skipping %s (supervisor not available on this host)\n", name)
+		}
+		return false, nil
+	}
+	if probeSystemd() {
+		return true, applySystemd(ctx, name, svc, verbose)
+	}
+	if probeLaunchd() {
+		return true, applyLaunchd(ctx, name, svc, verbose)
+	}
+	if verbose {
+		_, _ = fmt.Fprintf(os.Stdout, "  service: starting %s\n", name)
+	}
+	if len(svc.Start) == 0 {
+		return false, fmt.Errorf("starting service %q: no start command", name)
+	}
+	if err := exec.CommandContext(ctx, svc.Start[0], svc.Start[1:]...).Run(); err != nil {
+		return false, fmt.Errorf("starting service %q: %w", name, err)
+	}
+	return true, nil
+}
+
+func removeLocked(ctx context.Context, name string, ls genvfile.LockedService, verbose bool) error {
+	if ls.BrewFormula != "" {
+		if !IsBrewServicesAvailable() {
+			return fmt.Errorf("service %q requires brew services but brew is not available on this platform", name)
+		}
+		if verbose {
+			_, _ = fmt.Fprintf(os.Stdout, "  service: stopping %s via brew services\n", name)
+		}
+		return BrewServicesStop(ctx, ls.BrewFormula)
+	}
+	if ls.LaunchdPlist != "" || ls.LaunchdLabel != "" {
+		if !probeLaunchd() {
+			return nil
+		}
+		return removeLaunchdTemplate(ctx, name, ls.LaunchdLabel, verbose)
+	}
+	if ls.SystemdUnit != "" || ls.SystemdName != "" {
+		if !probeSystemd() {
+			return nil
+		}
+		return removeSystemdTemplate(ctx, name, ls.SystemdName, verbose)
+	}
+	if probeSystemd() {
+		return removeSystemd(ctx, name, verbose)
+	}
+	if probeLaunchd() {
+		return removeLaunchd(ctx, name, verbose)
+	}
+	if len(ls.Stop) > 0 {
+		if verbose {
+			_, _ = fmt.Fprintf(os.Stdout, "  service: stopping %s\n", name)
+		}
+		return exec.CommandContext(ctx, ls.Stop[0], ls.Stop[1:]...).Run()
+	}
+	if verbose {
+		_, _ = fmt.Fprintf(os.Stdout, "  service: removed %s from spec (no stop command defined)\n", name)
+	}
+	return nil
+}

--- a/internal/service/supervisor.go
+++ b/internal/service/supervisor.go
@@ -301,12 +301,6 @@ func StartDeclared(ctx context.Context, name string, svc schema.Service, sourceR
 		_, err := applySystemdTemplate(ctx, name, svc, sourceRoot, false)
 		return err
 	}
-	if probeSystemd() {
-		return applySystemd(ctx, name, svc, false)
-	}
-	if probeLaunchd() {
-		return applyLaunchd(ctx, name, svc, false)
-	}
 	if len(svc.Start) == 0 {
 		return fmt.Errorf("service %q has no start command", name)
 	}

--- a/internal/service/supervisor_test.go
+++ b/internal/service/supervisor_test.go
@@ -1,0 +1,316 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ks1686/genv/internal/genvfile"
+	"github.com/ks1686/genv/internal/schema"
+	"github.com/ks1686/genv/internal/testutil"
+)
+
+func samplePlist(label, program string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>` + label + `</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>` + program + `</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>__HOME__</string>
+</dict>
+</plist>
+`
+}
+
+func sampleUnit(desc, exec string) string {
+	return "[Unit]\nDescription=" + desc + "\n\n[Service]\nExecStart=" + exec + "\n\n[Install]\nWantedBy=default.target\n"
+}
+
+func installSupervisorFakes(t *testing.T, home string) string {
+	t.Helper()
+	logPath := filepath.Join(home, "supervisor.log")
+	loaded := filepath.Join(home, "launchd-loaded")
+	installServiceFakeBinary(t, "launchctl", `
+log="`+logPath+`"
+echo "launchctl $*" >> "$log"
+if [ "$1" = print ]; then
+  if [ -f "`+loaded+`" ]; then
+    printf 'state = running\n'
+    exit 0
+  fi
+  echo "Could not find service" >&2
+  exit 1
+fi
+if [ "$1" = bootstrap ]; then
+  touch "`+loaded+`"
+fi
+if [ "$1" = bootout ]; then
+  rm -f "`+loaded+`"
+fi
+exit 0
+`)
+	installServiceFakeBinary(t, "systemctl", `
+log="`+logPath+`"
+echo "systemctl $*" >> "$log"
+if [ "$1" = --user ] && [ "$2" = is-active ]; then
+  if [ -f "`+filepath.Join(home, "systemd-active")+`" ]; then
+    exit 0
+  fi
+  exit 1
+fi
+if [ "$1" = --user ] && [ "$2" = enable ]; then
+  touch "`+filepath.Join(home, "systemd-active")+`"
+fi
+if [ "$1" = --user ] && [ "$2" = stop ]; then
+  rm -f "`+filepath.Join(home, "systemd-active")+`"
+fi
+exit 0
+`)
+	return logPath
+}
+
+func supervisorLog(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read supervisor log: %v", err)
+	}
+	return string(data)
+}
+
+func TestParseLaunchdLabel(t *testing.T) {
+	got, err := ParseLaunchdLabel(samplePlist("com.example.agent", "/bin/true"))
+	if err != nil {
+		t.Fatalf("ParseLaunchdLabel: %v", err)
+	}
+	if got != "com.example.agent" {
+		t.Fatalf("label = %q", got)
+	}
+	if _, err := ParseLaunchdLabel("<plist></plist>"); err == nil {
+		t.Fatal("expected missing Label to fail")
+	}
+	if _, err := ParseLaunchdLabel(samplePlist("evil/label", "/bin/true")); err == nil {
+		t.Fatal("expected illegal Label to fail")
+	}
+}
+
+func TestApplyServices_LaunchdTemplateBootstrapAndRerender(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	root := t.TempDir()
+	src := filepath.Join(root, "agents", "com.example.agent.plist")
+	if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte(samplePlist("com.example.agent", "/bin/true")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	logPath := installSupervisorFakes(t, home)
+	t.Cleanup(func() {
+		probeLaunchd = IsLaunchdAvailable
+		probeSystemd = IsSystemdAvailable
+	})
+	probeLaunchd = func() bool { return true }
+	probeSystemd = func() bool { return false }
+
+	spec := map[string]schema.Service{
+		"agent": {Launchd: &schema.LaunchdSpec{Plist: "agents/com.example.agent.plist"}},
+	}
+	applied, removed, errs := ApplyServices(context.Background(), spec, nil, true, root)
+	if len(errs) != 0 || len(removed) != 0 || len(applied) != 1 || applied[0] != "agent" {
+		t.Fatalf("first apply = %v remove = %v errs = %v", applied, removed, errs)
+	}
+	dest := filepath.Join(home, "Library", "LaunchAgents", "com.example.agent.plist")
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !strings.Contains(string(got), home) || strings.Contains(string(got), "__HOME__") {
+		t.Fatalf("rendered plist should expand __HOME__, got:\n%s", got)
+	}
+	log := supervisorLog(t, logPath)
+	if !strings.Contains(log, "launchctl bootstrap gui/") || !strings.Contains(log, dest) {
+		t.Fatalf("expected bootstrap of %s, log:\n%s", dest, log)
+	}
+	if strings.Contains(log, "bootout") {
+		t.Fatalf("first apply should not bootout, log:\n%s", log)
+	}
+
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	applied, _, errs = ApplyServices(context.Background(), spec, SpecToLock(spec, root), false, root)
+	if len(errs) != 0 {
+		t.Fatalf("noop apply: %v", errs)
+	}
+	if len(applied) != 0 {
+		t.Fatalf("unchanged loaded job should not re-apply, got %v", applied)
+	}
+	log = supervisorLog(t, logPath)
+	if strings.Contains(log, "bootstrap") || strings.Contains(log, "bootout") {
+		t.Fatalf("unchanged apply should not re-bootstrap, log:\n%s", log)
+	}
+
+	if err := os.WriteFile(src, []byte(samplePlist("com.example.agent", "/bin/false")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	applied, _, errs = ApplyServices(context.Background(), spec, SpecToLock(spec, root), false, root)
+	if len(errs) != 0 || len(applied) != 1 {
+		t.Fatalf("rerender apply = %v errs = %v", applied, errs)
+	}
+	log = supervisorLog(t, logPath)
+	if !strings.Contains(log, "bootout gui/") || !strings.Contains(log, "com.example.agent") {
+		t.Fatalf("content change should bootout, log:\n%s", log)
+	}
+	if !strings.Contains(log, "bootstrap") {
+		t.Fatalf("content change should bootstrap, log:\n%s", log)
+	}
+	got, err = os.ReadFile(dest)
+	if err != nil || !strings.Contains(string(got), "/bin/false") {
+		t.Fatalf("dest after rerender = %q err=%v", got, err)
+	}
+
+	if !ProbeRunning(context.Background(), "agent", spec["agent"], root) {
+		t.Fatal("ProbeRunning should use launchctl print state=running")
+	}
+
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, removed, errs = ApplyServices(context.Background(), nil, SpecToLock(spec, root), true, root)
+	if len(errs) != 0 || len(removed) != 1 || removed[0] != "agent" {
+		t.Fatalf("remove = %v errs = %v", removed, errs)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("plist should be deleted: %v", err)
+	}
+	log = supervisorLog(t, logPath)
+	if !strings.Contains(log, "bootout") {
+		t.Fatalf("remove should bootout, log:\n%s", log)
+	}
+}
+
+func TestApplyServices_SystemdTemplateEnableAndRerender(t *testing.T) {
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	root := t.TempDir()
+	src := filepath.Join(root, "units", "syncthing.service")
+	if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte(sampleUnit("sync", "/usr/bin/syncthing")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	logPath := installSupervisorFakes(t, home)
+	t.Cleanup(func() {
+		probeLaunchd = IsLaunchdAvailable
+		probeSystemd = IsSystemdAvailable
+	})
+	probeLaunchd = func() bool { return false }
+	probeSystemd = func() bool { return true }
+
+	spec := map[string]schema.Service{
+		"sync": {Systemd: &schema.SystemdSpec{Unit: "units/syncthing.service"}},
+	}
+	applied, _, errs := ApplyServices(context.Background(), spec, nil, true, root)
+	if len(errs) != 0 || len(applied) != 1 {
+		t.Fatalf("first apply = %v errs = %v", applied, errs)
+	}
+	dest := filepath.Join(home, ".config", "systemd", "user", "syncthing.service")
+	got, err := os.ReadFile(dest)
+	if err != nil || !strings.Contains(string(got), "/usr/bin/syncthing") {
+		t.Fatalf("unit = %q err=%v", got, err)
+	}
+	log := supervisorLog(t, logPath)
+	if !strings.Contains(log, "systemctl --user enable --now syncthing.service") {
+		t.Fatalf("expected enable --now, log:\n%s", log)
+	}
+
+	if err := os.WriteFile(src, []byte(sampleUnit("sync", "/usr/bin/syncthing --home __HOME__")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	applied, _, errs = ApplyServices(context.Background(), spec, SpecToLock(spec, root), false, root)
+	if len(errs) != 0 || len(applied) != 1 {
+		t.Fatalf("rerender apply = %v errs = %v", applied, errs)
+	}
+	got, err = os.ReadFile(dest)
+	if err != nil || !strings.Contains(string(got), home) || strings.Contains(string(got), "__HOME__") {
+		t.Fatalf("rendered unit should expand __HOME__, got:\n%s err=%v", got, err)
+	}
+	log = supervisorLog(t, logPath)
+	if !strings.Contains(log, "restart syncthing.service") {
+		t.Fatalf("content change should restart, log:\n%s", log)
+	}
+
+	if !ProbeRunning(context.Background(), "sync", spec["sync"], root) {
+		t.Fatal("ProbeRunning should see systemd is-active")
+	}
+
+	_, removed, errs := ApplyServices(context.Background(), nil, []genvfile.LockedService{{
+		Name:        "sync",
+		SystemdUnit: "units/syncthing.service",
+		SystemdName: "syncthing",
+	}}, true, root)
+	if len(errs) != 0 || len(removed) != 1 {
+		t.Fatalf("remove = %v errs = %v", removed, errs)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("unit should be deleted: %v", err)
+	}
+}
+
+func TestApplyServices_SupervisorTemplateSkippedWhenUnavailable(t *testing.T) {
+	t.Cleanup(func() {
+		probeLaunchd = IsLaunchdAvailable
+		probeSystemd = IsSystemdAvailable
+	})
+	probeLaunchd = func() bool { return false }
+	probeSystemd = func() bool { return false }
+	spec := map[string]schema.Service{
+		"agent": {Launchd: &schema.LaunchdSpec{Plist: "missing.plist"}},
+	}
+	applied, removed, errs := ApplyServices(context.Background(), spec, nil, false, t.TempDir())
+	if len(errs) != 0 || len(removed) != 0 || len(applied) != 0 {
+		t.Fatalf("skip apply = %v remove = %v errs = %v", applied, removed, errs)
+	}
+}
+
+func TestSpecToLock_SupervisorFields(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "com.example.agent.plist")
+	if err := os.WriteFile(src, []byte(samplePlist("com.example.agent", "/bin/true")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lock := SpecToLock(map[string]schema.Service{
+		"agent": {
+			Launchd: &schema.LaunchdSpec{Plist: "com.example.agent.plist"},
+			Systemd: &schema.SystemdSpec{Unit: "units/foo.service"},
+		},
+	}, root)
+	if len(lock) != 1 {
+		t.Fatalf("lock len = %d", len(lock))
+	}
+	if lock[0].LaunchdPlist != "com.example.agent.plist" || lock[0].LaunchdLabel != "com.example.agent" {
+		t.Fatalf("launchd lock = %+v", lock[0])
+	}
+	if lock[0].SystemdUnit != "units/foo.service" || lock[0].SystemdName != "foo" {
+		t.Fatalf("systemd lock = %+v", lock[0])
+	}
+}

--- a/internal/service/supervisor_test.go
+++ b/internal/service/supervisor_test.go
@@ -292,6 +292,30 @@ func TestApplyServices_SupervisorTemplateSkippedWhenUnavailable(t *testing.T) {
 	}
 }
 
+func TestStartDeclared_RawStartFailsWhenSupervisorPresent(t *testing.T) {
+	// `genv service start` for a start/stop/status service must run the start
+	// argv. Generating a systemd/launchd unit would hide a failing command
+	// (systemctl enable --now exits 0 even when ExecStart is `false`).
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	installServiceFakeBinary(t, "systemctl", "exit 0")
+	installServiceFakeBinary(t, "launchctl", "exit 0")
+	t.Cleanup(func() {
+		probeLaunchd = IsLaunchdAvailable
+		probeSystemd = IsSystemdAvailable
+	})
+	probeLaunchd = func() bool { return true }
+	probeSystemd = func() bool { return true }
+
+	err := StartDeclared(context.Background(), "failing", schema.Service{Start: []string{"false"}}, "")
+	if err == nil {
+		t.Fatal("StartDeclared(false) = nil, want the start command's failure")
+	}
+	if err := StartDeclared(context.Background(), "ok", schema.Service{Start: []string{"true"}}, ""); err != nil {
+		t.Fatalf("StartDeclared(true) = %v", err)
+	}
+}
+
 func TestSpecToLock_SupervisorFields(t *testing.T) {
 	root := t.TempDir()
 	src := filepath.Join(root, "com.example.agent.plist")

--- a/main.go
+++ b/main.go
@@ -4859,7 +4859,7 @@ Apply-specific flags:
   --target <id>        Portable target id for schemaVersion 8 specs
   --force-new-lock     Back up a foreign lock and start a new local lock
   --state-dir <dir>    Directory for lock and env/shell fragments (default: directory of --file)
-  --source-root <dir>  Resolve files.links/templates sources relative to this directory
+  --source-root <dir>  Resolve files.links/templates and service template sources relative to this directory
 
 Export-specific flags:
   --target <id>        Target id to export

--- a/main.go
+++ b/main.go
@@ -1327,7 +1327,7 @@ func applyCmd(args []string) int {
 	fs.StringVar(&opts.Host, "host", "", "host name for host-specific records (defaults to host classification)")
 	fs.StringVar(&opts.Target, "target", "", "portable target id for schemaVersion 8 specs (defaults to $GENV_TARGET or host classification)")
 	fs.BoolVar(&opts.ForceNewLock, "force-new-lock", false, "back up a foreign lock file and start with a new local lock")
-	fs.StringVar(&opts.SourceRoot, "source-root", "", "resolve files.links/templates sources relative to this directory instead of the spec file directory")
+	fs.StringVar(&opts.SourceRoot, "source-root", "", "resolve files.links/templates and service launchd/systemd template sources relative to this directory instead of the spec file directory")
 
 	if err := fs.Parse(args); err != nil {
 		return flagParseExit(err)
@@ -1516,7 +1516,7 @@ func runApplyJSON(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	if shellErr != nil {
 		errs = append(errs, shellErr.Error())
 	}
-	_, _, svcErrs := applyServices(ctx, f, lf, false)
+	_, _, svcErrs := applyServices(ctx, f, lf, false, applySourceRoot(opts, f))
 	if len(svcErrs) > 0 {
 		errs = append(errs, errStrings(svcErrs)...)
 	}
@@ -1604,7 +1604,7 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 		}
 	}
 	var serviceChanges int
-	for _, e := range service.ServiceStatus(f.Services, lf.Services, false) {
+	for _, e := range service.ServiceStatus(f.Services, lf.Services, false, "") {
 		if e.Kind != service.ServiceStatusOK {
 			serviceChanges++
 		}
@@ -1693,7 +1693,7 @@ func runApplyText(ctx context.Context, opts applyOptions, lockPath string, f *sc
 	if _, _, err := applyShellCfg(f, lf, !opts.Quiet, opts.resolvedStateDir); err != nil {
 		fileErrs = append(fileErrs, err)
 	}
-	_, _, svcErrs = applyServices(ctx, f, lf, !opts.Quiet)
+	_, _, svcErrs = applyServices(ctx, f, lf, !opts.Quiet, applySourceRoot(opts, f))
 	var filePlanErr error
 	appliedFiles, filePlanErr = applyFiles(ctx, opts, f, lf)
 	if filePlanErr != nil {
@@ -1931,7 +1931,7 @@ func buildPlanResult(f *schema.GenvFile, lf *genvfile.LockFile, result resolver.
 	}
 
 	var toStart, toStop []string
-	for _, e := range service.ServiceStatus(f.Services, lf.Services, false) {
+	for _, e := range service.ServiceStatus(f.Services, lf.Services, false, "") {
 		switch e.Kind {
 		case service.ServiceStatusMissing, service.ServiceStatusModified:
 			toStart = append(toStart, e.Name)
@@ -2044,7 +2044,7 @@ func sourceRootForSpec(file string, f *schema.GenvFile) string {
 	return filepath.Dir(file)
 }
 
-// applySourceRoot is the files.links/templates root for apply.
+// applySourceRoot is the files.links/templates and service template root for apply.
 // --source-root wins so a spec copy can preview against the live tree.
 func applySourceRoot(opts applyOptions, f *schema.GenvFile) string {
 	if opts.SourceRoot != "" {
@@ -3344,7 +3344,7 @@ func statusCmd(args []string) int {
 	}
 	envEntries := genvenv.EnvStatus(f.Env, lf.Env)
 	shellEntries := shellcfg.ShellStatus(f.Shell, lf.Shell)
-	serviceEntries := service.ServiceStatus(f.Services, lf.Services, true)
+	serviceEntries := service.ServiceStatus(f.Services, lf.Services, true, sourceRootForSpec(*file, f))
 
 	if *jsonOut {
 		jsonEntries := make([]output.StatusEntry, 0, len(entries))
@@ -3545,14 +3545,14 @@ func statusCmd(args []string) int {
 // applyServices reconciles services, updates lf.Services in memory, and
 // returns lists of applied and removed service names. The caller writes the lock.
 // If verbose is true, it prints progress lines to stdout.
-func applyServices(ctx context.Context, f *schema.GenvFile, lf *genvfile.LockFile, verbose bool) (applied, removed []string, errs []error) {
+func applyServices(ctx context.Context, f *schema.GenvFile, lf *genvfile.LockFile, verbose bool, sourceRoot string) (applied, removed []string, errs []error) {
 	if len(f.Services) == 0 && len(lf.Services) == 0 {
 		return nil, nil, nil
 	}
 
-	applied, removed, errs = service.ApplyServices(ctx, f.Services, lf.Services, verbose)
+	applied, removed, errs = service.ApplyServices(ctx, f.Services, lf.Services, verbose, sourceRoot)
 	if len(errs) == 0 {
-		lf.Services = service.SpecToLock(f.Services)
+		lf.Services = service.SpecToLock(f.Services, sourceRoot)
 	}
 
 	return applied, removed, errs
@@ -4971,6 +4971,8 @@ func printServiceUsage() {
 	fPrintln(os.Stderr, "subcommands:")
 	fPrintln(os.Stderr, "  add <name> --start <cmd> [--stop <cmd>] [--restart <cmd>] [--status <cmd>]   Add or update a service (raw commands)")
 	fPrintln(os.Stderr, "  add <name> --brew-formula <formula>                                          Add a brew-managed service (macOS)")
+	fPrintln(os.Stderr, "  add <name> --launchd-plist <path>                                            Add a launchd user agent from a plist template")
+	fPrintln(os.Stderr, "  add <name> --systemd-unit <path>                                             Add a systemd --user unit from a unit template")
 	fPrintln(os.Stderr, "  remove <name>                                                              Remove a service from the spec")
 	fPrintln(os.Stderr, "  list                                                                        Show all declared services")
 	fPrintln(os.Stderr, "  start <name>                                                               Start a service")
@@ -4984,6 +4986,8 @@ func serviceAddCmd(args []string) int {
 	fs.Usage = func() {
 		fPrintln(os.Stderr, "usage: genv service add <name> --start <cmd> [flags]")
 		fPrintln(os.Stderr, "       genv service add <name> --brew-formula <formula> [flags]")
+		fPrintln(os.Stderr, "       genv service add <name> --launchd-plist <path> [flags]")
+		fPrintln(os.Stderr, "       genv service add <name> --systemd-unit <path> [flags]")
 		fPrintln(os.Stderr)
 		fPrintln(os.Stderr, "flags:")
 		fs.PrintDefaults()
@@ -4994,6 +4998,8 @@ func serviceAddCmd(args []string) int {
 	restart := fs.String("restart", "", "command to restart the service")
 	status := fs.String("status", "", "command to check service status")
 	brewFormula := fs.String("brew-formula", "", "homebrew formula to manage via `brew services` (macOS only)")
+	launchdPlist := fs.String("launchd-plist", "", "LaunchAgent plist template (rendered like files.templates)")
+	systemdUnit := fs.String("systemd-unit", "", "systemd --user unit template (rendered like files.templates)")
 	targetFlag := fs.String("target", "", "portable target id for schemaVersion 8 specs")
 
 	name, flagArgs := extractPositional(args)
@@ -5005,8 +5011,8 @@ func serviceAddCmd(args []string) int {
 		fs.Usage()
 		return exitUsage
 	}
-	if *start == "" && *brewFormula == "" {
-		fPrintln(os.Stderr, "genv service add: either --start or --brew-formula is required")
+	if *start == "" && *brewFormula == "" && *launchdPlist == "" && *systemdUnit == "" {
+		fPrintln(os.Stderr, "genv service add: either --start, --brew-formula, --launchd-plist, or --systemd-unit is required")
 		fs.Usage()
 		return exitUsage
 	}
@@ -5055,7 +5061,20 @@ func serviceAddCmd(args []string) int {
 	if exit != exitOK {
 		return exit
 	}
-	if err := commands.ServiceAdd(f, name, startCmd, stopCmd, restartCmd, statusCmd, *brewFormula, targetID); err != nil {
+	svc := schema.Service{
+		Start:       startCmd,
+		Stop:        stopCmd,
+		Restart:     restartCmd,
+		Status:      statusCmd,
+		BrewFormula: *brewFormula,
+	}
+	if *launchdPlist != "" {
+		svc.Launchd = &schema.LaunchdSpec{Plist: *launchdPlist}
+	}
+	if *systemdUnit != "" {
+		svc.Systemd = &schema.SystemdSpec{Unit: *systemdUnit}
+	}
+	if err := commands.ServicePut(f, name, svc, targetID); err != nil {
 		fprintf(os.Stderr, "genv: %v\n", err)
 		return exitUsage
 	}
@@ -5185,20 +5204,16 @@ func serviceStartCmd(args []string) int {
 		return exitLogic
 	}
 
-	if svc.BrewFormula != "" {
+	if svc.DeclaresLaunchd() {
+		fprintf(os.Stdout, "Starting service %q via launchd\n", name)
+	} else if svc.DeclaresSystemd() {
+		fprintf(os.Stdout, "Starting service %q via systemd --user\n", name)
+	} else if svc.BrewFormula != "" {
 		fprintf(os.Stdout, "Starting service %q via brew services: %s\n", name, svc.BrewFormula)
-		if err := service.BrewServicesStart(context.Background(), svc.BrewFormula); err != nil {
-			fprintf(os.Stderr, "genv: %v\n", err)
-			return exitLogic
-		}
-		return exitOK
+	} else {
+		fprintf(os.Stdout, "Starting service %q: %s\n", name, strings.Join(svc.Start, " "))
 	}
-
-	fprintf(os.Stdout, "Starting service %q: %s\n", name, strings.Join(svc.Start, " "))
-	cmd := exec.Command(svc.Start[0], svc.Start[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := service.StartDeclared(context.Background(), name, svc, sourceRootForSpec(*file, f)); err != nil {
 		fprintf(os.Stderr, "genv: failed to start service %q: %v\n", name, err)
 		if service.IsSystemdAvailable() {
 			fprintf(os.Stderr, "Tip: to view logs run: %s\n", service.SystemdLogsHint(name))
@@ -5234,25 +5249,19 @@ func serviceStopCmd(args []string) int {
 		return exitLogic
 	}
 
-	if svc.BrewFormula != "" {
+	if svc.DeclaresLaunchd() {
+		fprintf(os.Stdout, "Stopping service %q via launchd\n", name)
+	} else if svc.DeclaresSystemd() {
+		fprintf(os.Stdout, "Stopping service %q via systemd --user\n", name)
+	} else if svc.BrewFormula != "" {
 		fprintf(os.Stdout, "Stopping service %q via brew services: %s\n", name, svc.BrewFormula)
-		if err := service.BrewServicesStop(context.Background(), svc.BrewFormula); err != nil {
-			fprintf(os.Stderr, "genv: %v\n", err)
-			return exitLogic
-		}
-		return exitOK
-	}
-
-	if len(svc.Stop) == 0 {
+	} else if len(svc.Stop) == 0 {
 		fprintf(os.Stderr, "genv: no stop command defined for service %q\n", name)
 		return exitLogic
+	} else {
+		fprintf(os.Stdout, "Stopping service %q: %s\n", name, strings.Join(svc.Stop, " "))
 	}
-
-	fprintf(os.Stdout, "Stopping service %q: %s\n", name, strings.Join(svc.Stop, " "))
-	cmd := exec.Command(svc.Stop[0], svc.Stop[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := service.StopDeclared(context.Background(), name, svc, sourceRootForSpec(*file, f)); err != nil {
 		fprintf(os.Stderr, "genv: failed to stop service %q: %v\n", name, err)
 		return exitLogic
 	}
@@ -5285,25 +5294,15 @@ func serviceStatusCmd(args []string) int {
 		return exitLogic
 	}
 
-	if svc.BrewFormula != "" {
-		if service.BrewServicesRunning(svc.BrewFormula) {
-			fprintf(os.Stdout, "service %q is running\n", name)
-			return exitOK
-		}
-		fprintf(os.Stdout, "service %q is NOT running\n", name)
-		return exitLogic
-	}
-
-	if len(svc.Status) == 0 {
+	if !svc.DeclaresLaunchd() && !svc.DeclaresSystemd() && svc.BrewFormula == "" && len(svc.Status) == 0 && !service.IsSystemdAvailable() && !service.IsLaunchdAvailable() {
 		fprintf(os.Stderr, "genv: no status command defined for service %q\n", name)
 		return exitLogic
 	}
 
-	cmd := exec.Command(svc.Status[0], svc.Status[1:]...)
-	if err := cmd.Run(); err != nil {
-		fprintf(os.Stdout, "service %q is NOT running\n", name)
-		return exitLogic
+	if service.ProbeRunning(context.Background(), name, svc, sourceRootForSpec(*file, f)) {
+		fprintf(os.Stdout, "service %q is running\n", name)
+		return exitOK
 	}
-	fprintf(os.Stdout, "service %q is running\n", name)
-	return exitOK
+	fprintf(os.Stdout, "service %q is NOT running\n", name)
+	return exitLogic
 }

--- a/main_apply_files_test.go
+++ b/main_apply_files_test.go
@@ -618,6 +618,82 @@ func TestApply_SourceRootMissingIsRefused(t *testing.T) {
 	}
 }
 
+func TestApply_SourceRootResolvesServiceTemplates(t *testing.T) {
+	// A worktree spec copy must resolve launchd/systemd templates from
+	// --source-root, same as files.links / files.templates.
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	testutil.InstallFakeBinary(t, "systemctl", "exit 0")
+	testutil.InstallFakeBinary(t, "launchctl", "exit 0")
+
+	liveDir := filepath.Join(t.TempDir(), "live")
+	workDir := filepath.Join(t.TempDir(), "work")
+	if err := os.MkdirAll(filepath.Join(liveDir, "units"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(liveDir, "units", "agent.service"),
+		"[Unit]\nDescription=agent\n\n[Service]\nExecStart=/bin/true\n")
+	writeTestFile(t, filepath.Join(liveDir, "units", "com.example.agent.plist"),
+		`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>com.example.agent</string>
+<key>ProgramArguments</key><array><string>/bin/true</string></array>
+</dict></plist>
+`)
+	spec := `{` +
+		`"schemaVersion":"6","packages":[],` +
+		`"services":{"agent":{` +
+		`"launchd":{"plist":"units/com.example.agent.plist"},` +
+		`"systemd":{"unit":"units/agent.service"}` +
+		`}}}`
+	workSpec := filepath.Join(workDir, "genv.json")
+	writeTestFile(t, workSpec, spec)
+
+	lockPath := filepath.Join(t.TempDir(), "genv.lock.json")
+	applyArgs := func(extra ...string) []string {
+		return append([]string{
+			"apply", "--file", workSpec, "--lock-file", lockPath,
+			"--skip-packages", "--yes", "--no-hooks",
+		}, extra...)
+	}
+
+	var stderr string
+	code := 0
+	stderr = captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			code = run(applyArgs())
+		})
+	})
+	if code == exitOK {
+		t.Fatalf("apply without --source-root should fail to find the unit template; stderr=%s", stderr)
+	}
+
+	stderr = captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			code = run(applyArgs("--source-root", liveDir))
+		})
+	})
+	if code != exitOK {
+		t.Fatalf("apply --source-root: expected exitOK, got %d; stderr=%s", code, stderr)
+	}
+
+	var dest string
+	switch runtime.GOOS {
+	case "darwin":
+		dest = filepath.Join(home, "Library", "LaunchAgents", "com.example.agent.plist")
+	default:
+		dest = filepath.Join(home, ".config", "systemd", "user", "agent.service")
+	}
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("expected applied unit at %s: %v", dest, err)
+	}
+}
+
 func applyJSONFileKinds(t *testing.T, stdout string) map[string]string {
 	t.Helper()
 	var env struct {

--- a/main_apply_files_test.go
+++ b/main_apply_files_test.go
@@ -621,6 +621,9 @@ func TestApply_SourceRootMissingIsRefused(t *testing.T) {
 func TestApply_SourceRootResolvesServiceTemplates(t *testing.T) {
 	// A worktree spec copy must resolve launchd/systemd templates from
 	// --source-root, same as files.links / files.templates.
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("declarative service templates apply only under launchd or systemd")
+	}
 	home := t.TempDir()
 	testutil.SetHome(t, home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))

--- a/main_service_test.go
+++ b/main_service_test.go
@@ -67,6 +67,26 @@ func TestServiceCLICommands(t *testing.T) {
 	}
 }
 
+func TestServiceStart_RawCommandFailsUnderSystemd(t *testing.T) {
+	// Linux CI has systemd --user. `service start` must still run the declared
+	// start argv so a failing command exits 4, not enable a generated unit.
+	home := t.TempDir()
+	testutil.SetHome(t, home)
+	testutil.InstallFakeBinary(t, "systemctl", "exit 0")
+	testutil.InstallFakeBinary(t, "launchctl", "exit 0")
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "genv.json")
+	writeEmptyV1Spec(t, path)
+	if code := run([]string{"service", "add", "failing", "--file", path, "--start", "false"}); code != exitOK {
+		t.Fatalf("add failing service: got %d, want %d", code, exitOK)
+	}
+	if code := run([]string{"service", "start", "failing", "--file", path}); code != exitLogic {
+		t.Fatalf("service start failure path: got exit code %d, want %d", code, exitLogic)
+	}
+}
+
 func TestServiceCLIUsageErrors(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "genv.json")

--- a/schema/v8/genv.json
+++ b/schema/v8/genv.json
@@ -85,7 +85,7 @@
         "services": {
           "type": "object",
           "additionalProperties": {
-            "type": "object"
+            "$ref": "#/$defs/service"
           }
         },
         "hooks": {
@@ -127,7 +127,7 @@
           "additionalProperties": {
             "anyOf": [
               {
-                "type": "object"
+                "$ref": "#/$defs/service"
               },
               {
                 "type": "null"
@@ -148,6 +148,59 @@
         },
         "sensitive": {
           "type": "boolean"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "start": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "stop": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "restart": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "brew_formula": {
+          "type": "string"
+        },
+        "launchd": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "plist": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "systemd": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "unit": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto latest `main` after #158 (per-entry `backup` / `genv files adopt`) merged.

## Conflict report

Two files conflicted on the first commit:

- **`README.md`** (CLI table `env`/`shell`/`service` row): kept both `launchd`/`systemd` templates and `files adopt`.
- **`internal/files/paths.go`**: kept #158 `ExpandPath` export and the existing `ResolveSource` (used by service templates).

`CHANGELOG.md` auto-merged: Unreleased Added still has launchd/systemd, adapters, `--source-root` (service templates), `contentHash`, per-entry backup, and `files adopt`. Completions and `main.go` dispatch auto-merged (`files` + `service --launchd-plist` / `--systemd-unit`).

## Preserved

- Declarative launchd user agents and systemd --user units
- Exit-4 fix: command-based `service start` still runs the declared start argv
- #159 `--source-root` for files and service templates
- #162 lock `contentHash` / `status --files` `drifted`
- #164 v8 spec-level command adapters
- #158 per-entry `backup: true` and `genv files adopt`

## Summary

Adds optional `services.<name>.launchd.plist` and `services.<name>.systemd.unit` so a spec can declare a LaunchAgent or systemd --user unit from a template. `genv apply` renders the file (`__HOME__` / `__USER__` / `__HOST__` / `__OS__` / `__ARCH__`), writes it to the user supervisor directory, and loads it. Content changes re-bootstrap (launchd) or restart (systemd). `genv service status` uses `launchctl print gui/$UID/<Label>` or `systemctl --user is-active`. Removing the service unloads the unit and deletes the file. No `postApply` hook is required.

`launchd` and `systemd` may coexist on one service (portable defaults). They are mutually exclusive with `start` and `brew_formula`.

Closes #144.

Out of scope: #145 (custom adapters). Updates scheduled job still uses `launchctl load`/`unload`; only spec-declared services use bootstrap/bootout.

## Test plan

- [x] Rebase onto latest main; Unreleased changelog keeps services + adapters + `--source-root` + `contentHash` + #158 backup/adopt
- [x] `go test` for service CLI (`TestServiceCLICommands`, `TestServiceStart_RawCommandFailsUnderSystemd`)
- [x] `go test ./...`
- [ ] CI green on the rebased branch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0f18312-2a53-4eb1-8799-f6d492a23f46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f18312-2a53-4eb1-8799-f6d492a23f46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

