### PR TITLE
feat: spec-level command adapters for plugin ecosystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Schema v8 top-level `adapters` defines command adapters for plugin CLIs
+  (Claude Code plugins, gh extensions, editor plugins). Packages with
+  `prefer: <adapter>` install, remove, and upgrade via the declared commands
+  and participate in `status`, `scan`, `updates check`, and `upgrade`.
+  List parsing is JSON (`idField` / `versionField`) and/or regex (`listMatch`).
+  `external` stays track-only. See SCHEMA.md.
 - `genv apply --source-root <dir>` resolves `files.links` / `files.templates`
   sources against that directory instead of the spec file directory. Use it to
   dry-run (or apply) a worktree copy of `genv.json` against the live tree so

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ WSL2 does **not** inherit native `arch` automatically. Put shared bits in `defau
 
 `external` is a track-only pseudo-manager: packages installed outside any manager (official installers, vendor downloads). Apply records them in the lock when the binary is on PATH; genv never installs or removes them itself.
 
+Schema v8 also accepts top-level `adapters` for plugin CLIs genv does not ship built-in (`claude plugin`, `gh extension`, …). Set `prefer` to the adapter name. Details and examples: [SCHEMA.md](SCHEMA.md#spec-adapters-v8).
+
 Native `apt`, `dnf`, and `apk` adapters are registered system managers (`prefer: apt|dnf|apk`). Use `genv map` / `genv export` when moving a spec across Linux families.
 
 ---
@@ -295,7 +297,7 @@ File mismatches without `--force` no longer block packages/services: non-conflic
 
 ## Resolution and upgrades (summary)
 
-**Install resolution:** detect available managers → honor `prefer` → try `managers` map → fall back to system managers using the package `id`. Language / toolchain / plugin managers are **explicit-only** (must set `prefer` or `managers`) so `git` never silently resolves through npm.
+**Install resolution:** detect available managers → honor `prefer` → try `managers` map → fall back to system managers using the package `id`. Language / toolchain / plugin managers (including v8 spec `adapters`) are **explicit-only** (must set `prefer` or `managers`) so `git` never silently resolves through npm.
 
 **Upgrades:** `genv upgrade` applies tracked-package updates, then OS vendor updates for the active target (macOS `softwareupdate`, Windows Update Agent COM via PowerShell, Arch `pacman -Syu`, Ubuntu `apt-get upgrade`). Firmware uses `fwupdmgr` on Linux when present; macOS firmware ships through `softwareupdate`, and Windows firmware is skipped as vendor-specific. `genv updates check` and the timer stay tracked-packages-only and share the tracked planner with `upgrade`. Before outdated detection, the planner refreshes each index-based manager that still has candidates (`brew update`, `sudo apt-get update`, `sudo pacman -Sy`, and the equivalents on paru/yay/dnf/apk/scoop/winget). Live registries (mas, npm/bun, uv/pipx, cargo, volta, choco, snap, vscode) are queried as-is. A failed refresh keeps that manager's packages and prints a warning — same conservative rule as a failed outdated query. A manager whose binary is gone (`Available()` false) is skipped with an explicit reason instead of planning `brew update` / `brew upgrade` that cannot run. By default they plan packages with a detected update; `--all` on `upgrade` still refreshes, then plans every unconstrained tracked package. Leftover positional IDs (`genv upgrade git`) are treated as `--only`. Human `upgrade` prompts unless `--yes`; `upgrade --json` wet-run also requires `--yes` (or `--dry-run` to plan only). Packages with a non-empty `version` are always skipped; genv does not yet plan range-satisfying upgrades. Batched where the manager allows (`brew`, `pacman`/`paru`/`yay`, `apt`/`dnf`/`apk`, `mas`, `snap`, `scoop`, `choco`, …). The `vscode` manager compares against the marketplace's newest **stable** version (pre-release builds are ignored; `--install-extension --force` cannot install them). It invokes `cursor` when that CLI is on PATH, otherwise `code`. `brew outdated` uses `--greedy` so auto-updating casks are not hidden after the index fetch.
 

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -13,7 +13,7 @@ Canonical structs: `internal/schema/schema.go`. Validation: `internal/schema/val
 | v5 | `"5"` | `files`, `hooks`, per-record `host`, `repo` |
 | v6 | `"6"` | expanded lifecycle hooks, `updates` |
 | v7 | `"7"` | `"shell": "powershell"` targeting |
-| v8 | `"8"` | portable `defaults` + `targets.*` |
+| v8 | `"8"` | portable `defaults` + `targets.*`; optional top-level `adapters` |
 
 Older versions still load. Prefer **v8** for new multi-machine specs. Convert with `genv migrate`.
 
@@ -62,7 +62,7 @@ Older versions still load. Prefer **v8** for new multi-machine specs. Convert wi
 
 - Top-level `packages`, `env`, `shell`, `files`, `services`, and `hooks` are **invalid** in v8. Put them under `defaults` and/or `targets.<id>`.
 - `targets` must be non-empty; keys must be known target IDs.
-- `repo` and `updates` remain top-level.
+- `repo`, `updates`, and `adapters` remain top-level.
 - Bundles support the same blocks as the flat schema: `packages`, `env`, `shell`, `files`, `services`, `hooks`.
 
 ### Merge and tombstones
@@ -143,9 +143,64 @@ Map of name → `{ start, stop, restart, status }` argv arrays and/or `brew_form
 
 ## Manager resolution
 
-`prefer` and `managers` accept registered manager IDs (see README table). Without an explicit selection, fallback uses **system** package managers only. Language, toolchain, and plugin managers are explicit-only.
+`prefer` and `managers` accept registered manager IDs (see README table) or a v8 `adapters` name. Without an explicit selection, fallback uses **system** package managers only. Language, toolchain, and plugin managers are explicit-only.
 
 `external` is a track-only manager for apps with an official installer (not winget/scoop). Apply records them when the binary is on PATH; it never installs them.
+
+## Spec adapters (v8)
+
+Top-level `adapters` defines installable command adapters for plugin CLIs that genv does not ship built-in. `external` stays track-only. A package with `prefer: <adapter-name>` then participates in apply, adopt, status, scan, updates, and upgrade.
+
+```json
+{
+  "schemaVersion": "8",
+  "adapters": {
+    "claude-plugin": {
+      "list": "claude plugin list --json",
+      "install": "claude plugin install {{id}} --scope user",
+      "remove": "claude plugin uninstall {{id}}",
+      "upgrade": "claude plugin update {{id}}",
+      "idField": "name",
+      "versionField": "version"
+    },
+    "gh-extension": {
+      "list": "gh extension list",
+      "install": "gh extension install {{id}}",
+      "remove": "gh extension remove {{id}}",
+      "upgrade": "gh extension upgrade {{id}}",
+      "listMatch": "(?m)^(?P<id>\\S+)\\s+(?P<version>\\S+)"
+    }
+  },
+  "targets": {
+    "macos": {
+      "packages": [
+        { "id": "slack@claude-plugins-official", "prefer": "claude-plugin" },
+        { "id": "github/gh-copilot", "prefer": "gh-extension" }
+      ]
+    }
+  }
+}
+```
+
+### Adapter fields
+
+| Field | Required | Role |
+| ----- | -------- | ---- |
+| `list` | yes | Inventory command. Used for Query, scan, status, and apply adopt-if-present. |
+| `install` | yes | Argv template. `{{id}}` and `{{name}}` expand to the package id. |
+| `remove` | yes | Uninstall template. |
+| `upgrade` | no | Upgrade template. Omitted → same argv as `install`. |
+| `version` | no | Per-package version command (`{{id}}`). Omitted → `versionField` from `list`. |
+| `outdated` | no | Optional outdated inventory, parsed like `list`. Omit to keep the built-in “no detector → keep all” updates behavior. |
+| `idField` | no | JSON object field (or dotted path, e.g. `plugins.name`) for the package id. |
+| `versionField` | no | JSON field on the same object for the installed version. |
+| `listMatch` | no | Regex. Capture group 1, or named `(?P<id>…)` / `(?P<name>…)` and `(?P<version>…)`. |
+
+List parsing order: JSON when `idField` is set and stdout looks like JSON; else `listMatch`; else the first whitespace-separated field per line.
+
+Commands are split into argv (quotes supported). There is no shell piping or redirection — wrap in `sh -c` if needed. Adapter names are `claude-plugin`-style kebab-case and must not collide with a built-in manager. Spec adapters are explicit-only: they never win `genv add git` fallback.
+
+`genv scan` runs each available adapter’s `list` and, for spec adapters, writes `prefer` so the adopted package stays bound. `genv export` copies `adapters` into the snapshot so `prefer` still validates.
 
 `genv apply` consults a live inventory (`ListInstalled` per available manager) and adopts already-installed packages into the lock instead of reinstalling. `genv upgrade` remains the only upgrade path. Apply `--timeout` defaults to 10m. `--skip-packages` applies env/shell/files/services without inventorying or planning packages. `--source-root <dir>` resolves `files.links` / `files.templates` sources against that directory instead of the spec file directory (lock, env, and shell paths stay where `--file` / `--lock-file` / `--state-dir` put them).
 

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -200,8 +200,17 @@ var All = []Adapter{
 }
 
 // ByName returns the adapter whose Name() matches name, or nil if none match.
+// Spec-level command adapters registered via SetSpecAdapters are searched
+// after the built-in registry.
 func ByName(name string) Adapter {
 	for _, a := range All {
+		if a.Name() == name {
+			return a
+		}
+	}
+	specMu.RLock()
+	defer specMu.RUnlock()
+	for _, a := range specAdapters {
 		if a.Name() == name {
 			return a
 		}

--- a/internal/adapter/command.go
+++ b/internal/adapter/command.go
@@ -1,0 +1,438 @@
+package adapter
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+// CommandDef is the runtime form of a spec-level adapter. Fields match
+// schema.AdapterDef; this package does not import schema so built-in
+// adapters stay independent of spec parsing.
+type CommandDef struct {
+	List         string
+	Install      string
+	Remove       string
+	Upgrade      string
+	Version      string
+	Outdated     string
+	ListMatch    string
+	IDField      string
+	VersionField string
+}
+
+// Command is a spec-defined adapter. Install, remove, upgrade, and inventory
+// all run the declared command templates. It is never a default fallback.
+type Command struct {
+	name string
+	def  CommandDef
+}
+
+// NewCommand builds a spec adapter. name is the adapters map key (prefer value).
+func NewCommand(name string, def CommandDef) Command {
+	return Command{name: name, def: def}
+}
+
+func (c Command) Name() string { return c.name }
+
+func (c Command) Available() bool {
+	tmpl := c.def.List
+	if strings.TrimSpace(tmpl) == "" {
+		tmpl = c.def.Install
+	}
+	argv, err := splitCommand(expandTemplate(tmpl, "id"))
+	if err != nil || len(argv) == 0 {
+		return false
+	}
+	_, err = lookPath(argv[0])
+	return err == nil
+}
+
+func (c Command) NormalizeID(id string, managers map[string]string) (string, bool) {
+	return normalizeID(c.name, id, managers)
+}
+
+func (c Command) PlanInstall(pkgName string) []string {
+	return planCommand(c.def.Install, pkgName)
+}
+
+func (c Command) PlanUninstall(pkgName string) []string {
+	return planCommand(c.def.Remove, pkgName)
+}
+
+func (c Command) PlanUpgrade(pkgName string) []string {
+	if strings.TrimSpace(c.def.Upgrade) == "" {
+		return c.PlanInstall(pkgName)
+	}
+	return planCommand(c.def.Upgrade, pkgName)
+}
+
+func (c Command) PlanClean() [][]string { return nil }
+
+func (c Command) Query(pkgName string) (bool, error) {
+	names, err := c.ListInstalled()
+	if err != nil {
+		return false, err
+	}
+	for _, name := range names {
+		if name == pkgName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (c Command) ListInstalled() ([]string, error) {
+	entries, _, err := c.listEntries(c.def.List)
+	return entries, err
+}
+
+func (c Command) QueryVersion(pkgName string) (string, error) {
+	if strings.TrimSpace(c.def.Version) != "" {
+		argv, err := splitCommand(expandTemplate(c.def.Version, pkgName))
+		if err != nil || len(argv) == 0 {
+			return "", err
+		}
+		return runVersionOutput(argv[0], argv[1:]...)
+	}
+	_, versions, err := c.listEntries(c.def.List)
+	if err != nil {
+		return "", err
+	}
+	return versions[pkgName], nil
+}
+
+func (c Command) ListInstalledVersions() (map[string]string, error) {
+	names, versions, err := c.listEntries(c.def.List)
+	if err != nil {
+		return nil, err
+	}
+	if len(versions) > 0 {
+		return versions, nil
+	}
+	out := make(map[string]string, len(names))
+	for _, name := range names {
+		out[name] = ""
+	}
+	return out, nil
+}
+
+// commandWithOutdated is a Command that can report outdated packages.
+// Command itself does not implement OutdatedLister: without an outdated
+// command, FilterOutdated keeps every tracked package (same as go/asdf).
+type commandWithOutdated struct {
+	Command
+}
+
+func (c commandWithOutdated) ListOutdated(pkgNames []string) (map[string]string, error) {
+	names, versions, err := c.listEntries(c.def.Outdated)
+	if err != nil {
+		return nil, err
+	}
+	want := make(map[string]bool, len(pkgNames))
+	for _, name := range pkgNames {
+		want[name] = true
+	}
+	out := make(map[string]string)
+	for _, name := range names {
+		if len(want) > 0 && !want[name] {
+			continue
+		}
+		out[name] = versions[name]
+	}
+	return out, nil
+}
+
+func (c Command) listEntries(tmpl string) ([]string, map[string]string, error) {
+	argv, err := splitCommand(expandTemplate(tmpl, "id"))
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(argv) == 0 {
+		return nil, nil, nil
+	}
+	out, err := runProbe(argv[0], argv[1:]...)
+	if err != nil {
+		return nil, nil, classifyListErr(err)
+	}
+	return parseListOutput(out, c.def)
+}
+
+func classifyListErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	type exitCoder interface{ ExitCode() int }
+	if _, ok := err.(exitCoder); ok {
+		return nil
+	}
+	return err
+}
+
+func planCommand(tmpl, pkgName string) []string {
+	argv, err := splitCommand(expandTemplate(tmpl, pkgName))
+	if err != nil {
+		return nil
+	}
+	return argv
+}
+
+func expandTemplate(tmpl, id string) string {
+	s := strings.ReplaceAll(tmpl, "{{id}}", id)
+	return strings.ReplaceAll(s, "{{name}}", id)
+}
+
+// splitCommand tokenizes an argv template. Quotes are stripped; there is no
+// shell expansion, piping, or redirection — wrap in `sh -c` if needed.
+func splitCommand(s string) ([]string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, fmt.Errorf("empty command")
+	}
+	var parts []string
+	var buf strings.Builder
+	var quote rune
+	escaped := false
+	flush := func() {
+		if buf.Len() == 0 {
+			return
+		}
+		parts = append(parts, buf.String())
+		buf.Reset()
+	}
+	for _, r := range s {
+		switch {
+		case escaped:
+			buf.WriteRune(r)
+			escaped = false
+		case r == '\\' && quote != '\'':
+			escaped = true
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				buf.WriteRune(r)
+			}
+		case r == '"' || r == '\'':
+			quote = r
+		case unicode.IsSpace(r):
+			flush()
+		default:
+			buf.WriteRune(r)
+		}
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unclosed quote in command")
+	}
+	if escaped {
+		return nil, fmt.Errorf("trailing backslash in command")
+	}
+	flush()
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("empty command")
+	}
+	return parts, nil
+}
+
+func parseListOutput(out []byte, def CommandDef) ([]string, map[string]string, error) {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil, nil, nil
+	}
+	if def.IDField != "" && looksLikeJSON(trimmed) {
+		ids, versions, err := extractJSONIDs([]byte(trimmed), def.IDField, def.VersionField)
+		if err == nil {
+			return ids, versions, nil
+		}
+		if def.ListMatch == "" {
+			return nil, nil, fmt.Errorf("parse list JSON: %w", err)
+		}
+	}
+	if def.ListMatch != "" {
+		return extractRegexIDs(trimmed, def.ListMatch)
+	}
+	return extractLineIDs(trimmed), nil, nil
+}
+
+func looksLikeJSON(s string) bool {
+	return strings.HasPrefix(s, "{") || strings.HasPrefix(s, "[")
+}
+
+func extractLineIDs(s string) []string {
+	var ids []string
+	for _, line := range strings.Split(s, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		ids = append(ids, fields[0])
+	}
+	return ids
+}
+
+func extractRegexIDs(s, pattern string) ([]string, map[string]string, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, nil, err
+	}
+	idIdx := 1
+	verIdx := 0
+	for i, name := range re.SubexpNames() {
+		switch name {
+		case "id", "name":
+			idIdx = i
+		case "version":
+			verIdx = i
+		}
+	}
+	matches := re.FindAllStringSubmatch(s, -1)
+	var ids []string
+	versions := make(map[string]string)
+	seen := make(map[string]bool)
+	for _, m := range matches {
+		if idIdx >= len(m) || m[idIdx] == "" {
+			continue
+		}
+		id := m[idIdx]
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+		if verIdx > 0 && verIdx < len(m) && m[verIdx] != "" {
+			versions[id] = m[verIdx]
+		}
+	}
+	if len(versions) == 0 {
+		versions = nil
+	}
+	return ids, versions, nil
+}
+
+func extractJSONIDs(data []byte, idField, versionField string) ([]string, map[string]string, error) {
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, nil, err
+	}
+	path := strings.Split(idField, ".")
+	var ids []string
+	versions := make(map[string]string)
+	walkJSONIDs(v, path, versionField, &ids, versions)
+	if len(versions) == 0 {
+		versions = nil
+	}
+	return ids, versions, nil
+}
+
+func walkJSONIDs(v any, idPath []string, versionField string, ids *[]string, versions map[string]string) {
+	switch x := v.(type) {
+	case []any:
+		for _, item := range x {
+			walkJSONIDs(item, idPath, versionField, ids, versions)
+		}
+	case map[string]any:
+		if len(idPath) > 1 {
+			if next, ok := x[idPath[0]]; ok {
+				walkJSONIDs(next, idPath[1:], versionField, ids, versions)
+				return
+			}
+		}
+		if id, ok := jsonStringField(x, idPath[len(idPath)-1]); ok {
+			*ids = append(*ids, id)
+			if versionField != "" {
+				if ver, ok := jsonStringField(x, versionField); ok {
+					versions[id] = ver
+				}
+			}
+			return
+		}
+		for _, child := range x {
+			walkJSONIDs(child, idPath, versionField, ids, versions)
+		}
+	}
+}
+
+func jsonStringField(obj map[string]any, key string) (string, bool) {
+	v, ok := obj[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	switch t := v.(type) {
+	case string:
+		if t == "" {
+			return "", false
+		}
+		return t, true
+	case json.Number:
+		return t.String(), true
+	case float64:
+		return fmt.Sprintf("%g", t), true
+	default:
+		return fmt.Sprint(t), true
+	}
+}
+
+var (
+	specMu       sync.RWMutex
+	specAdapters []Adapter
+)
+
+// SetSpecAdapters replaces the process-wide spec adapter set. Pass nil to clear.
+// Commands call this after reading genv.json so Detect/ByName/scan see them.
+func SetSpecAdapters(adapters []Adapter) {
+	specMu.Lock()
+	defer specMu.Unlock()
+	if len(adapters) == 0 {
+		specAdapters = nil
+		return
+	}
+	specAdapters = append([]Adapter(nil), adapters...)
+}
+
+// CommandsFromDefs builds Command adapters from a name→def map, sorted by name.
+func CommandsFromDefs(defs map[string]CommandDef) []Adapter {
+	if len(defs) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(defs))
+	for name := range defs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]Adapter, 0, len(names))
+	for _, name := range names {
+		cmd := NewCommand(name, defs[name])
+		if strings.TrimSpace(defs[name].Outdated) != "" {
+			out = append(out, commandWithOutdated{Command: cmd})
+		} else {
+			out = append(out, cmd)
+		}
+	}
+	return out
+}
+
+// Registered returns built-in adapters followed by the current spec adapters.
+func Registered() []Adapter {
+	specMu.RLock()
+	defer specMu.RUnlock()
+	out := make([]Adapter, 0, len(All)+len(specAdapters))
+	out = append(out, All...)
+	out = append(out, specAdapters...)
+	return out
+}
+
+// SpecName reports whether name is a currently bound spec adapter.
+func SpecName(name string) bool {
+	specMu.RLock()
+	defer specMu.RUnlock()
+	for _, a := range specAdapters {
+		if a.Name() == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/adapter/command_test.go
+++ b/internal/adapter/command_test.go
@@ -1,0 +1,292 @@
+package adapter
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSplitCommand(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    []string
+		wantErr bool
+	}{
+		{"claude plugin install {{id}} --scope user", []string{"claude", "plugin", "install", "{{id}}", "--scope", "user"}, false},
+		{`gh extension install "foo bar"`, []string{"gh", "extension", "install", "foo bar"}, false},
+		{"  list   --json  ", []string{"list", "--json"}, false},
+		{"", nil, true},
+		{`echo "unterminated`, nil, true},
+	}
+	for _, tc := range tests {
+		got, err := splitCommand(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("splitCommand(%q) err=nil, want error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("splitCommand(%q): %v", tc.in, err)
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("splitCommand(%q)=%v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestExpandTemplate(t *testing.T) {
+	got := expandTemplate("claude plugin install {{id}} --scope user", "slack@official")
+	if got != "claude plugin install slack@official --scope user" {
+		t.Fatalf("expand {{id}}: %q", got)
+	}
+	got = expandTemplate("tool add {{name}}", "pkg")
+	if got != "tool add pkg" {
+		t.Fatalf("expand {{name}}: %q", got)
+	}
+}
+
+func TestParseListOutput_LinesJSONRegex(t *testing.T) {
+	t.Run("lines", func(t *testing.T) {
+		ids, versions, err := parseListOutput([]byte("cli/gh-copilot\t1.0.0\nowner/other 2.0\n"), CommandDef{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(ids, []string{"cli/gh-copilot", "owner/other"}) {
+			t.Fatalf("ids=%v", ids)
+		}
+		if versions != nil {
+			t.Fatalf("versions=%v, want nil", versions)
+		}
+	})
+
+	t.Run("json array", func(t *testing.T) {
+		raw := `[{"name":"slack@official","version":"1.2.3"},{"name":"other@src","version":"0.1.0"}]`
+		ids, versions, err := parseListOutput([]byte(raw), CommandDef{IDField: "name", VersionField: "version"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(ids, []string{"slack@official", "other@src"}) {
+			t.Fatalf("ids=%v", ids)
+		}
+		if versions["slack@official"] != "1.2.3" || versions["other@src"] != "0.1.0" {
+			t.Fatalf("versions=%v", versions)
+		}
+	})
+
+	t.Run("json path", func(t *testing.T) {
+		raw := `{"plugins":[{"id":"a","version":"2"},{"id":"b","version":"3"}]}`
+		ids, versions, err := parseListOutput([]byte(raw), CommandDef{IDField: "plugins.id", VersionField: "version"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(ids, []string{"a", "b"}) {
+			t.Fatalf("ids=%v", ids)
+		}
+		if versions["a"] != "2" {
+			t.Fatalf("versions=%v", versions)
+		}
+	})
+
+	t.Run("regex named groups", func(t *testing.T) {
+		raw := "cli/gh-copilot\tv1.2.3\ttrue\nowner/ext\tv9.0\tfalse\n"
+		ids, versions, err := parseListOutput([]byte(raw), CommandDef{
+			ListMatch: `(?m)^(?P<id>\S+)\s+(?P<version>\S+)`,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(ids, []string{"cli/gh-copilot", "owner/ext"}) {
+			t.Fatalf("ids=%v", ids)
+		}
+		if versions["cli/gh-copilot"] != "v1.2.3" {
+			t.Fatalf("versions=%v", versions)
+		}
+	})
+}
+
+func TestCommand_PlansAndInventory(t *testing.T) {
+	installFakeBinary(t, "plugctl", `
+case "$1" in
+  list)
+    printf '%s\n' 'slack@official 1.2.3' 'other@src 0.1.0'
+    ;;
+  version)
+    if [ "$2" = "slack@official" ]; then printf '1.2.3\n'; else exit 1; fi
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`)
+	c := NewCommand("plug", CommandDef{
+		List:    "plugctl list",
+		Install: "plugctl install {{id}} --user",
+		Remove:  "plugctl remove {{id}}",
+		Upgrade: "plugctl update {{id}}",
+		Version: "plugctl version {{id}}",
+	})
+	if c.Name() != "plug" {
+		t.Fatalf("Name=%q", c.Name())
+	}
+	if !c.Available() {
+		t.Fatal("Available()=false, want true")
+	}
+	if got := c.PlanInstall("slack@official"); !reflect.DeepEqual(got, []string{"plugctl", "install", "slack@official", "--user"}) {
+		t.Fatalf("PlanInstall=%v", got)
+	}
+	if got := c.PlanUninstall("slack@official"); !reflect.DeepEqual(got, []string{"plugctl", "remove", "slack@official"}) {
+		t.Fatalf("PlanUninstall=%v", got)
+	}
+	if got := c.PlanUpgrade("slack@official"); !reflect.DeepEqual(got, []string{"plugctl", "update", "slack@official"}) {
+		t.Fatalf("PlanUpgrade=%v", got)
+	}
+	if IsDefaultFallbackEligible(c) {
+		t.Fatal("spec adapters must not be default fallback")
+	}
+
+	ids, err := c.ListInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(ids, []string{"slack@official", "other@src"}) {
+		t.Fatalf("ListInstalled=%v", ids)
+	}
+	ok, err := c.Query("slack@official")
+	if err != nil || !ok {
+		t.Fatalf("Query installed: %v %v", ok, err)
+	}
+	ok, err = c.Query("missing")
+	if err != nil || ok {
+		t.Fatalf("Query missing: %v %v", ok, err)
+	}
+	ver, err := c.QueryVersion("slack@official")
+	if err != nil || ver != "1.2.3" {
+		t.Fatalf("QueryVersion=%q %v", ver, err)
+	}
+}
+
+func TestCommand_UpgradeFallsBackToInstall(t *testing.T) {
+	c := NewCommand("plug", CommandDef{Install: "plugctl add {{id}}"})
+	if got := c.PlanUpgrade("x"); !reflect.DeepEqual(got, []string{"plugctl", "add", "x"}) {
+		t.Fatalf("PlanUpgrade fallback=%v", got)
+	}
+}
+
+func TestCommand_UnavailableWithoutBinary(t *testing.T) {
+	c := NewCommand("plug", CommandDef{List: "definitely-not-a-genv-bin list", Install: "definitely-not-a-genv-bin add {{id}}"})
+	if c.Available() {
+		t.Fatal("Available()=true for missing binary")
+	}
+}
+
+func TestSetSpecAdapters_ByNameAndRegistered(t *testing.T) {
+	t.Cleanup(func() { SetSpecAdapters(nil) })
+	if ByName("plug") != nil {
+		t.Fatal("ByName(plug) should be nil before bind")
+	}
+	SetSpecAdapters(CommandsFromDefs(map[string]CommandDef{
+		"plug": {List: "true", Install: "true", Remove: "true"},
+	}))
+	got := ByName("plug")
+	if got == nil || got.Name() != "plug" {
+		t.Fatalf("ByName(plug)=%v", got)
+	}
+	if !SpecName("plug") {
+		t.Fatal("SpecName(plug)=false")
+	}
+	found := false
+	for _, a := range Registered() {
+		if a.Name() == "plug" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Registered() missing spec adapter")
+	}
+	if ByName("brew") == nil {
+		t.Fatal("built-in ByName(brew) still works")
+	}
+	SetSpecAdapters(nil)
+	if ByName("plug") != nil {
+		t.Fatal("ByName(plug) after clear")
+	}
+}
+
+func TestCommandsFromDefs_OutdatedImplementsLister(t *testing.T) {
+	plain := CommandsFromDefs(map[string]CommandDef{
+		"plain": {List: "true", Install: "true", Remove: "true"},
+	})
+	if _, ok := plain[0].(OutdatedLister); ok {
+		t.Fatal("plain command must not implement OutdatedLister")
+	}
+	with := CommandsFromDefs(map[string]CommandDef{
+		"with": {List: "true", Install: "true", Remove: "true", Outdated: "true"},
+	})
+	if _, ok := with[0].(OutdatedLister); !ok {
+		t.Fatal("outdated command should implement OutdatedLister")
+	}
+}
+
+func TestCommand_ListOutdated(t *testing.T) {
+	installFakeBinary(t, "outdatedctl", `printf '%s\n' 'keep-me' 'skip-me'`)
+	c := commandWithOutdated{Command: NewCommand("plug", CommandDef{Outdated: "outdatedctl"})}
+	got, err := c.ListOutdated([]string{"keep-me"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["keep-me"]; !ok {
+		t.Fatalf("got=%v, want keep-me", got)
+	}
+	if _, ok := got["skip-me"]; ok {
+		t.Fatalf("got=%v, skip-me should be filtered", got)
+	}
+}
+
+func TestCommand_JSONInventoryFromFakeBin(t *testing.T) {
+	installFakeBinary(t, "jsonplug", `printf '%s\n' '[{"name":"a@src","version":"9"},{"name":"b@src","version":"8"}]'`)
+	c := NewCommand("jsonplug", CommandDef{
+		List:         "jsonplug",
+		Install:      "jsonplug add {{id}}",
+		Remove:       "jsonplug rm {{id}}",
+		IDField:      "name",
+		VersionField: "version",
+	})
+	vers, err := c.ListInstalledVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vers["a@src"] != "9" || vers["b@src"] != "8" {
+		t.Fatalf("versions=%v", vers)
+	}
+	ver, err := c.QueryVersion("a@src")
+	if err != nil || ver != "9" {
+		t.Fatalf("QueryVersion from list=%q %v", ver, err)
+	}
+}
+
+func TestCommand_EmptyListIsEmpty(t *testing.T) {
+	installFakeBinary(t, "emptylist", "exit 1")
+	c := NewCommand("empty", CommandDef{List: "emptylist"})
+	ids, err := c.ListInstalled()
+	if err != nil {
+		t.Fatalf("non-zero list exit should be empty, not error: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("ids=%v", ids)
+	}
+}
+
+func TestParseListOutput_JSONFallbackToRegex(t *testing.T) {
+	raw := "not-json\nfoo-id v1\n"
+	ids, _, err := parseListOutput([]byte(raw), CommandDef{
+		IDField:   "name",
+		ListMatch: `(?m)^(?P<id>\S+)`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(strings.Join(ids, ","), "foo-id") {
+		t.Fatalf("ids=%v", ids)
+	}
+}

--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -41,13 +41,13 @@ func Add(f *schema.GenvFile, id, version, prefer string, managers map[string]str
 		}
 	}
 
-	if prefer != "" && !schema.KnownManagers[prefer] {
-		return fmt.Errorf("unknown manager %q for --prefer; valid managers: %s", prefer, KnownManagerList())
+	if prefer != "" && !schema.KnownManager(f, prefer) {
+		return fmt.Errorf("unknown manager %q for --prefer; valid managers: %s", prefer, KnownManagerListFor(f))
 	}
 
 	for mgr, pkgName := range managers {
-		if !schema.KnownManagers[mgr] {
-			return fmt.Errorf("unknown manager %q in --manager; valid managers: %s", mgr, KnownManagerList())
+		if !schema.KnownManager(f, mgr) {
+			return fmt.Errorf("unknown manager %q in --manager; valid managers: %s", mgr, KnownManagerListFor(f))
 		}
 		if !schema.ValidPackageName(pkgName) {
 			return fmt.Errorf("invalid package name %q for manager %q: must not be empty, start with '-', or contain whitespace", pkgName, mgr)

--- a/internal/commands/add_test.go
+++ b/internal/commands/add_test.go
@@ -75,6 +75,24 @@ func TestAdd_UnknownPrefer(t *testing.T) {
 	}
 }
 
+func TestAdd_SpecAdapterPrefer(t *testing.T) {
+	f := &schema.GenvFile{
+		SchemaVersion: schema.Version8,
+		Adapters: map[string]schema.AdapterDef{
+			"claude-plugin": {List: "claude plugin list", Install: "claude plugin install {{id}}", Remove: "claude plugin uninstall {{id}}"},
+		},
+		Targets: map[string]*schema.TargetBundle{
+			"macos": {Packages: []schema.Package{}},
+		},
+	}
+	if err := Add(f, "slack@official", "", "claude-plugin", nil, "macos"); err != nil {
+		t.Fatalf("Add with spec adapter prefer: %v", err)
+	}
+	if got := f.Targets["macos"].Packages[0].Prefer; got != "claude-plugin" {
+		t.Fatalf("prefer=%q", got)
+	}
+}
+
 func TestAdd_UnknownManagerKey(t *testing.T) {
 	f := newFile()
 	if err := Add(f, "git", "*", "", map[string]string{"yum": "git"}, ""); err == nil {

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -21,6 +21,22 @@ var knownManagerList = func() string {
 // KnownManagerList returns a sorted, comma-separated string of all known manager names.
 func KnownManagerList() string { return knownManagerList }
 
+// KnownManagerListFor is KnownManagerList plus any spec-defined adapter names.
+func KnownManagerListFor(f *schema.GenvFile) string {
+	if f == nil || len(f.Adapters) == 0 {
+		return knownManagerList
+	}
+	names := make([]string, 0, len(schema.KnownManagers)+len(f.Adapters))
+	for k := range schema.KnownManagers {
+		names = append(names, k)
+	}
+	for k := range f.Adapters {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
 // RedactValue returns value unchanged unless sensitive is true, in which case
 // it returns "[redacted]". Use for any user-facing output that may expose secrets.
 func RedactValue(value string, sensitive bool) string {

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -48,7 +48,7 @@ func BuildWithOptions(f *schema.GenvFile, targetID string, outDir string, opts O
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return report.sorted(), fmt.Errorf("creating export directory %s: %w", outDir, err)
 	}
-	if err := writeSnapshot(filepath.Join(outDir, "genv.json"), targetID, bundle); err != nil {
+	if err := writeSnapshot(filepath.Join(outDir, "genv.json"), targetID, bundle, f.Adapters); err != nil {
 		return report.sorted(), err
 	}
 	if err := writeReport(filepath.Join(outDir, "report.json"), report); err != nil {
@@ -62,12 +62,14 @@ func BuildWithOptions(f *schema.GenvFile, targetID string, outDir string, opts O
 
 type snapshotDocument struct {
 	SchemaVersion string                          `json:"schemaVersion"`
+	Adapters      map[string]schema.AdapterDef    `json:"adapters,omitempty"`
 	Targets       map[string]*schema.TargetBundle `json:"targets"`
 }
 
-func writeSnapshot(path, targetID string, bundle *schema.TargetBundle) error {
+func writeSnapshot(path, targetID string, bundle *schema.TargetBundle, adapters map[string]schema.AdapterDef) error {
 	doc := snapshotDocument{
 		SchemaVersion: schema.Version8,
+		Adapters:      adapters,
 		Targets: map[string]*schema.TargetBundle{
 			targetID: bundle,
 		},

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -29,7 +29,7 @@ func fprint(w io.Writer, a ...any)                 { _, _ = fmt.Fprint(w, a...) 
 // by checking each registered adapter's binary in PATH.
 func Detect() map[string]bool {
 	available := make(map[string]bool)
-	for _, a := range adapter.All {
+	for _, a := range adapter.Registered() {
 		if a.Available() {
 			available[a.Name()] = true
 		}
@@ -83,7 +83,7 @@ func resolveOnGOOS(pkg schema.Package, available map[string]bool, goos string) A
 
 	// 2. Pick the first available adapter in registry order whose manager name
 	//    appears in the package's explicit managers map.
-	for _, a := range adapter.All {
+	for _, a := range adapter.Registered() {
 		if _, ok := pkg.Managers[a.Name()]; ok && available[a.Name()] {
 			name, _ := a.NormalizeID(pkg.ID, pkg.Managers)
 			return Action{Pkg: pkg, Manager: a.Name(), PkgName: name, Cmd: a.PlanInstall(name), UninstallCmd: a.PlanUninstall(name)}
@@ -96,7 +96,7 @@ func resolveOnGOOS(pkg schema.Package, available map[string]bool, goos string) A
 	//    (reachable via prefer or the managers map above) so `genv add git`
 	//    never silently resolves to npm/cargo/go just because one happens to be
 	//    installed.
-	for _, a := range adapter.All {
+	for _, a := range adapter.Registered() {
 		if available[a.Name()] && adapter.IsDefaultFallbackEligible(a) && adapter.AutomaticOnGOOS(a.Name(), goos) {
 			name, _ := a.NormalizeID(pkg.ID, pkg.Managers)
 			return Action{Pkg: pkg, Manager: a.Name(), PkgName: name, Cmd: a.PlanInstall(name), UninstallCmd: a.PlanUninstall(name)}

--- a/internal/schema/merge.go
+++ b/internal/schema/merge.go
@@ -21,6 +21,7 @@ func MergeTarget(f *GenvFile, targetID string) (*GenvFile, error) {
 		SchemaVersion: Version8,
 		Repo:          copyRepo(f.Repo),
 		Updates:       copyUpdatesConfig(f.Updates),
+		Adapters:      copyAdapters(f.Adapters),
 	}
 	defaults := f.Defaults
 	out.Packages = mergePackages(defaults, target)
@@ -265,6 +266,17 @@ func copyRepo(in *Repo) *Repo {
 	}
 	out := *in
 	return &out
+}
+
+func copyAdapters(in map[string]AdapterDef) map[string]AdapterDef {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]AdapterDef, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 func copyUpdatesConfig(in *UpdatesConfig) *UpdatesConfig {

--- a/internal/schema/merge_test.go
+++ b/internal/schema/merge_test.go
@@ -74,6 +74,7 @@ func TestMergeTarget_DeepCopiesAndReplacesArrays(t *testing.T) {
 		SchemaVersion: Version8,
 		Repo:          &Repo{URL: "https://example.com/repo", Ref: "main"},
 		Updates:       &UpdatesConfig{Enabled: true, Interval: "24h", OnlyManagers: []string{"brew"}},
+		Adapters:      map[string]AdapterDef{"gh-extension": {List: "gh extension list", Install: "gh extension install {{id}}", Remove: "gh extension remove {{id}}"}},
 		Defaults: &TargetBundle{
 			Packages: []Package{{ID: "default-pkg", Prefer: "brew", Managers: map[string]string{"brew": "default-pkg"}}},
 			Env:      map[string]*EnvVar{"KEEP": {Value: "1"}},
@@ -113,6 +114,13 @@ func TestMergeTarget_DeepCopiesAndReplacesArrays(t *testing.T) {
 	}
 	if got.Repo == f.Repo || got.Repo.URL != f.Repo.URL || got.Updates == f.Updates || got.Updates.Interval != f.Updates.Interval {
 		t.Fatalf("repo/updates not deep-copied: got repo=%p src=%p updates=%p src=%p", got.Repo, f.Repo, got.Updates, f.Updates)
+	}
+	if len(got.Adapters) != 1 || got.Adapters["gh-extension"].List != "gh extension list" {
+		t.Fatalf("adapters should copy onto the flat spec: %+v", got.Adapters)
+	}
+	got.Adapters["gh-extension"] = AdapterDef{List: "mutated"}
+	if f.Adapters["gh-extension"].List != "gh extension list" {
+		t.Fatal("MergeTarget mutated source adapters")
 	}
 	if len(got.Packages) != 1 || got.Packages[0].ID != "target-pkg" {
 		t.Fatalf("target packages should replace defaults: %+v", got.Packages)

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -176,6 +176,7 @@ type GenvFile struct {
 	Hooks         *HooksConfig             `json:"hooks,omitempty"`
 	Repo          *Repo                    `json:"repo,omitempty"`
 	Updates       *UpdatesConfig           `json:"updates,omitempty"`
+	Adapters      map[string]AdapterDef    `json:"adapters,omitempty"`
 	Defaults      *TargetBundle            `json:"defaults,omitempty"`
 	Targets       map[string]*TargetBundle `json:"targets,omitempty"`
 }
@@ -198,6 +199,7 @@ func (f GenvFile) MarshalJSON() ([]byte, error) {
 		Hooks         *HooksConfig             `json:"hooks,omitempty"`
 		Repo          *Repo                    `json:"repo,omitempty"`
 		Updates       *UpdatesConfig           `json:"updates,omitempty"`
+		Adapters      map[string]AdapterDef    `json:"adapters,omitempty"`
 		Defaults      *TargetBundle            `json:"defaults,omitempty"`
 		Targets       map[string]*TargetBundle `json:"targets,omitempty"`
 	}
@@ -211,9 +213,53 @@ func (f GenvFile) MarshalJSON() ([]byte, error) {
 		Hooks:         f.Hooks,
 		Repo:          f.Repo,
 		Updates:       f.Updates,
+		Adapters:      f.Adapters,
 		Defaults:      f.Defaults,
 		Targets:       f.Targets,
 	})
+}
+
+// AdapterDef is a spec-level command adapter for plugin ecosystems that genv
+// does not ship a built-in manager for (Claude Code plugins, gh extensions, …).
+// Commands are argv templates: {{id}} (and {{name}}) expand to the package id.
+// list output is parsed as JSON (idField / versionField) and/or regex (listMatch).
+type AdapterDef struct {
+	List         string `json:"list"`
+	Install      string `json:"install"`
+	Remove       string `json:"remove"`
+	Upgrade      string `json:"upgrade,omitempty"`
+	Version      string `json:"version,omitempty"`
+	Outdated     string `json:"outdated,omitempty"`
+	ListMatch    string `json:"listMatch,omitempty"`
+	IDField      string `json:"idField,omitempty"`
+	VersionField string `json:"versionField,omitempty"`
+}
+
+// KnownManager reports whether name is a built-in manager or a spec-defined adapter.
+func KnownManager(f *GenvFile, name string) bool {
+	if KnownManagers[name] {
+		return true
+	}
+	if f == nil || name == "" {
+		return false
+	}
+	_, ok := f.Adapters[name]
+	return ok
+}
+
+// ValidAdapterName reports whether name is a legal spec adapter key:
+// lowercase letter, then lowercase letters, digits, or hyphens.
+func ValidAdapterName(name string) bool {
+	if name == "" || name[0] < 'a' || name[0] > 'z' {
+		return false
+	}
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // TargetBundle is a v8 defaults or target-scoped config block.

--- a/internal/schema/unknown.go
+++ b/internal/schema/unknown.go
@@ -18,6 +18,7 @@ func validateUnknownKeys(raw map[string]json.RawMessage, positions map[string]Po
 	errs = append(errs, walkHooks(raw["hooks"], "hooks", positions)...)
 	errs = append(errs, walkObject(raw["repo"], "repo", repoFields, positions)...)
 	errs = append(errs, walkObject(raw["updates"], "updates", updatesFields, positions)...)
+	errs = append(errs, walkAdapters(raw["adapters"], positions)...)
 	errs = append(errs, walkBundle(raw["defaults"], "defaults", positions)...)
 	if targets, ok := asObject(raw["targets"]); ok {
 		for name, body := range targets {
@@ -30,7 +31,11 @@ func validateUnknownKeys(raw map[string]json.RawMessage, positions map[string]Po
 var (
 	rootFields = strSet(
 		"$schema", "schemaVersion", "packages", "env", "shell", "services",
-		"files", "hooks", "repo", "updates", "defaults", "targets",
+		"files", "hooks", "repo", "updates", "adapters", "defaults", "targets",
+	)
+	adapterFields = strSet(
+		"list", "install", "remove", "upgrade", "version", "outdated",
+		"listMatch", "idField", "versionField",
 	)
 	packageFields = strSet("id", "version", "prefer", "managers", "host")
 	envVarFields  = strSet("value", "sensitive")
@@ -85,6 +90,18 @@ func walkObject(raw json.RawMessage, path string, allowed map[string]bool, posit
 		return nil
 	}
 	return rejectUnknown(obj, path, allowed, positions)
+}
+
+func walkAdapters(raw json.RawMessage, positions map[string]Position) []ValidationError {
+	obj, ok := asObject(raw)
+	if !ok {
+		return nil
+	}
+	var errs []ValidationError
+	for name, body := range obj {
+		errs = append(errs, walkObject(body, "adapters."+name, adapterFields, positions)...)
+	}
+	return errs
 }
 
 func walkBundle(raw json.RawMessage, path string, positions map[string]Position) []ValidationError {

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -90,6 +91,7 @@ func ParseAndValidate(data []byte) (*GenvFile, []ValidationError, error) {
 	errs = append(errs, validateHooks(f, raw, positions)...)
 	errs = append(errs, validateRepo(f, raw, positions)...)
 	errs = append(errs, validateUpdates(f, raw, positions)...)
+	errs = append(errs, validateAdapters(f, raw, positions)...)
 	errs = append(errs, validateV8(f, positions)...)
 
 	return f, errs, nil
@@ -247,12 +249,12 @@ func validatePackages(f *GenvFile, raw map[string]json.RawMessage, positions map
 			})
 		}
 	} else {
-		errs = append(errs, validatePackageList(f.Packages, "packages", positions)...)
+		errs = append(errs, validatePackageList(f, f.Packages, "packages", positions)...)
 	}
 	return errs
 }
 
-func validatePackageList(packages []Package, fieldPrefix string, positions map[string]Position) []ValidationError {
+func validatePackageList(f *GenvFile, packages []Package, fieldPrefix string, positions map[string]Position) []ValidationError {
 	var errs []ValidationError
 	seen := make(map[string]int) // id → first index
 	for i, pkg := range packages {
@@ -281,7 +283,7 @@ func validatePackageList(packages []Package, fieldPrefix string, positions map[s
 			seen[pkg.ID] = i
 		}
 
-		if pkg.Prefer != "" && !KnownManagers[pkg.Prefer] {
+		if pkg.Prefer != "" && !KnownManager(f, pkg.Prefer) {
 			errs = append(errs, ValidationError{
 				Position: positions[pkgPath+".prefer"],
 				Field:    pkgPath + ".prefer",
@@ -291,7 +293,7 @@ func validatePackageList(packages []Package, fieldPrefix string, positions map[s
 
 		for mgr, pkgName := range pkg.Managers {
 			field := fmt.Sprintf("%s.managers.%s", pkgPath, mgr)
-			if !KnownManagers[mgr] {
+			if !KnownManager(f, mgr) {
 				errs = append(errs, ValidationError{
 					Position: positions[field],
 					Field:    field,
@@ -883,8 +885,8 @@ func validateUpdates(f *GenvFile, raw map[string]json.RawMessage, positions map[
 	if f.Updates == nil {
 		return errs
 	}
-	errs = append(errs, validateUpdatesManagers("updates.onlyManagers", f.Updates.OnlyManagers, positions)...)
-	errs = append(errs, validateUpdatesManagers("updates.skipManagers", f.Updates.SkipManagers, positions)...)
+	errs = append(errs, validateUpdatesManagers(f, "updates.onlyManagers", f.Updates.OnlyManagers, positions)...)
+	errs = append(errs, validateUpdatesManagers(f, "updates.skipManagers", f.Updates.SkipManagers, positions)...)
 	if !f.Updates.Enabled {
 		return errs
 	}
@@ -915,10 +917,10 @@ func validateUpdates(f *GenvFile, raw map[string]json.RawMessage, positions map[
 	return errs
 }
 
-func validateUpdatesManagers(field string, managers []string, positions map[string]Position) []ValidationError {
+func validateUpdatesManagers(f *GenvFile, field string, managers []string, positions map[string]Position) []ValidationError {
 	var errs []ValidationError
 	for i, mgr := range managers {
-		if KnownManagers[mgr] {
+		if KnownManager(f, mgr) {
 			continue
 		}
 		elem := fmt.Sprintf("%s[%d]", field, i)
@@ -927,6 +929,71 @@ func validateUpdatesManagers(field string, managers []string, positions map[stri
 			Field:    elem,
 			Message:  fmt.Sprintf("unknown manager %q", mgr),
 		})
+	}
+	return errs
+}
+
+func validateAdapters(f *GenvFile, raw map[string]json.RawMessage, positions map[string]Position) []ValidationError {
+	var errs []ValidationError
+	if _, hasAdapters := raw["adapters"]; !hasAdapters {
+		return errs
+	}
+	if f.SchemaVersion != Version8 {
+		errs = append(errs, ValidationError{
+			Position: positions["adapters"],
+			Field:    "adapters",
+			Message:  fmt.Sprintf("adapters block requires schemaVersion %q (current: %q)", Version8, f.SchemaVersion),
+		})
+	}
+	if len(f.Adapters) == 0 {
+		return errs
+	}
+	for name, def := range f.Adapters {
+		path := "adapters." + name
+		if !ValidAdapterName(name) {
+			errs = append(errs, ValidationError{
+				Position: positions[path],
+				Field:    path,
+				Message:  fmt.Sprintf("invalid adapter name %q: must be lowercase letters, digits, and hyphens, starting with a letter", name),
+			})
+		}
+		if KnownManagers[name] {
+			errs = append(errs, ValidationError{
+				Position: positions[path],
+				Field:    path,
+				Message:  fmt.Sprintf("adapter name %q collides with a built-in manager", name),
+			})
+		}
+		if strings.TrimSpace(def.List) == "" {
+			errs = append(errs, ValidationError{
+				Position: positions[path+".list"],
+				Field:    path + ".list",
+				Message:  "required field is missing or empty",
+			})
+		}
+		if strings.TrimSpace(def.Install) == "" {
+			errs = append(errs, ValidationError{
+				Position: positions[path+".install"],
+				Field:    path + ".install",
+				Message:  "required field is missing or empty",
+			})
+		}
+		if strings.TrimSpace(def.Remove) == "" {
+			errs = append(errs, ValidationError{
+				Position: positions[path+".remove"],
+				Field:    path + ".remove",
+				Message:  "required field is missing or empty",
+			})
+		}
+		if def.ListMatch != "" {
+			if _, err := regexp.Compile(def.ListMatch); err != nil {
+				errs = append(errs, ValidationError{
+					Position: positions[path+".listMatch"],
+					Field:    path + ".listMatch",
+					Message:  fmt.Sprintf("invalid listMatch regexp: %v", err),
+				})
+			}
+		}
 	}
 	return errs
 }
@@ -1095,7 +1162,7 @@ func hasDefaultService(defaults *TargetBundle, name string) bool {
 
 func validateTargetBundle(f *GenvFile, bundle *TargetBundle, fieldPrefix string, allowTombstones bool, positions map[string]Position) []ValidationError {
 	var errs []ValidationError
-	errs = append(errs, validatePackageList(bundle.Packages, fieldPrefix+".packages", positions)...)
+	errs = append(errs, validatePackageList(f, bundle.Packages, fieldPrefix+".packages", positions)...)
 	errs = append(errs, validateNoPackageHosts(bundle.Packages, fieldPrefix+".packages", positions)...)
 	errs = append(errs, validateTargetEnvMap(bundle.Env, fieldPrefix+".env", allowTombstones)...)
 	errs = append(errs, validateTargetShellConfig(f, bundle.Shell, fieldPrefix+".shell", allowTombstones)...)

--- a/internal/schema/validate_test.go
+++ b/internal/schema/validate_test.go
@@ -1686,3 +1686,165 @@ func TestValidPackageName(t *testing.T) {
 		})
 	}
 }
+
+func TestValidAdapterName(t *testing.T) {
+	tests := []struct {
+		name string
+		ok   bool
+	}{
+		{"claude-plugin", true},
+		{"gh-extension", true},
+		{"a", true},
+		{"a1", true},
+		{"", false},
+		{"Brew", false},
+		{"1gh", false},
+		{"gh_extension", false},
+		{"gh extension", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidAdapterName(tc.name); got != tc.ok {
+				t.Fatalf("ValidAdapterName(%q)=%v, want %v", tc.name, got, tc.ok)
+			}
+		})
+	}
+}
+
+func TestParseAndValidate_V8AdaptersAcceptCustomPrefer(t *testing.T) {
+	raw := `{
+	  "schemaVersion":"8",
+	  "adapters":{
+	    "claude-plugin":{
+	      "list":"claude plugin list --json",
+	      "install":"claude plugin install {{id}} --scope user",
+	      "remove":"claude plugin uninstall {{id}}",
+	      "upgrade":"claude plugin update {{id}}",
+	      "idField":"name",
+	      "versionField":"version"
+	    }
+	  },
+	  "targets":{
+	    "macos":{
+	      "packages":[{"id":"slack@claude-plugins-official","prefer":"claude-plugin"}]
+	    }
+	  }
+	}`
+	f, errs, err := ParseAndValidate([]byte(raw))
+	if err != nil || len(errs) > 0 {
+		t.Fatalf("unexpected: err=%v errs=%v", err, errs)
+	}
+	if _, ok := f.Adapters["claude-plugin"]; !ok {
+		t.Fatal("expected claude-plugin adapter")
+	}
+	if !KnownManager(f, "claude-plugin") {
+		t.Fatal("KnownManager should accept spec adapter")
+	}
+	if KnownManager(f, "not-a-manager") {
+		t.Fatal("KnownManager should reject unknown names")
+	}
+}
+
+func TestParseAndValidate_AdaptersRequireV8(t *testing.T) {
+	raw := `{
+	  "schemaVersion":"7",
+	  "packages":[],
+	  "adapters":{
+	    "claude-plugin":{
+	      "list":"claude plugin list",
+	      "install":"claude plugin install {{id}}",
+	      "remove":"claude plugin uninstall {{id}}"
+	    }
+	  }
+	}`
+	_, errs, err := ParseAndValidate([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasValidationField(errs, "adapters") {
+		t.Fatalf("expected adapters to require v8, got: %v", errs)
+	}
+}
+
+func TestParseAndValidate_AdapterRejectsBuiltinName(t *testing.T) {
+	raw := `{
+	  "schemaVersion":"8",
+	  "adapters":{
+	    "brew":{
+	      "list":"brew list",
+	      "install":"brew install {{id}}",
+	      "remove":"brew uninstall {{id}}"
+	    }
+	  },
+	  "targets":{"macos":{"packages":[]}}
+	}`
+	_, errs, err := ParseAndValidate([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasValidationField(errs, "adapters.brew") {
+		t.Fatalf("expected collision error, got: %v", errs)
+	}
+}
+
+func TestParseAndValidate_AdapterRequiresCommands(t *testing.T) {
+	raw := `{
+	  "schemaVersion":"8",
+	  "adapters":{"gh-extension":{"list":"","install":"gh extension install {{id}}"}},
+	  "targets":{"macos":{"packages":[]}}
+	}`
+	_, errs, err := ParseAndValidate([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasValidationField(errs, "adapters.gh-extension.list") {
+		t.Fatalf("expected missing list, got: %v", errs)
+	}
+	if !hasValidationField(errs, "adapters.gh-extension.remove") {
+		t.Fatalf("expected missing remove, got: %v", errs)
+	}
+}
+
+func TestParseAndValidate_AdapterUnknownField(t *testing.T) {
+	raw := `{
+	  "schemaVersion":"8",
+	  "adapters":{
+	    "gh-extension":{
+	      "list":"gh extension list",
+	      "install":"gh extension install {{id}}",
+	      "remove":"gh extension remove {{id}}",
+	      "shell":"true"
+	    }
+	  },
+	  "targets":{"macos":{"packages":[]}}
+	}`
+	_, errs, err := ParseAndValidate([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasValidationField(errs, "adapters.gh-extension.shell") {
+		t.Fatalf("expected unknown field, got: %v", errs)
+	}
+}
+
+func TestParseAndValidate_AdapterInvalidListMatch(t *testing.T) {
+	raw := `{
+	  "schemaVersion":"8",
+	  "adapters":{
+	    "gh-extension":{
+	      "list":"gh extension list",
+	      "install":"gh extension install {{id}}",
+	      "remove":"gh extension remove {{id}}",
+	      "listMatch":"("
+	    }
+	  },
+	  "targets":{"macos":{"packages":[]}}
+	}`
+	_, errs, err := ParseAndValidate([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasValidationField(errs, "adapters.gh-extension.listMatch") {
+		t.Fatalf("expected invalid listMatch, got: %v", errs)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -257,10 +257,35 @@ func resolveMutationTarget(commandName, file string, f *schema.GenvFile, targetF
 
 // resolveEffectiveSpec flattens a schemaVersion 8 target (MergeTarget) or applies
 // legacy host filtering so callers can read top-level packages/env/shell/services.
+// useSpecAdapters binds command adapters declared in f so Detect, ByName,
+// scan, and upgrade treat prefer: <custom> as a real manager.
+func useSpecAdapters(f *schema.GenvFile) {
+	if f == nil || len(f.Adapters) == 0 {
+		adapter.SetSpecAdapters(nil)
+		return
+	}
+	defs := make(map[string]adapter.CommandDef, len(f.Adapters))
+	for name, d := range f.Adapters {
+		defs[name] = adapter.CommandDef{
+			List:         d.List,
+			Install:      d.Install,
+			Remove:       d.Remove,
+			Upgrade:      d.Upgrade,
+			Version:      d.Version,
+			Outdated:     d.Outdated,
+			ListMatch:    d.ListMatch,
+			IDField:      d.IDField,
+			VersionField: d.VersionField,
+		}
+	}
+	adapter.SetSpecAdapters(adapter.CommandsFromDefs(defs))
+}
+
 func resolveEffectiveSpec(f *schema.GenvFile, hostName, targetFlag string) (*schema.GenvFile, string, error) {
 	if f == nil {
 		return nil, "", fmt.Errorf("genv file is nil")
 	}
+	useSpecAdapters(f)
 	if f.SchemaVersion == schema.Version8 {
 		targetID, err := target.Resolve(targetFlag)
 		if err != nil {
@@ -558,7 +583,11 @@ func addCmd(args []string) int {
 	}
 
 	// Detect available managers once; used by both the search picker (step 0)
-	// and the resolver (step 2).
+	// and the resolver (step 2). Bind spec adapters first so prefer: <custom>
+	// can resolve before the spec is rewritten.
+	if existing, err := genvfile.Read(*file); err == nil {
+		useSpecAdapters(existing)
+	}
 	available := resolver.Detect()
 
 	// 0. When no explicit manager mapping is given and stdin is a terminal,
@@ -1402,6 +1431,7 @@ func applyLockGate(cmd, lockPath string, lf *genvfile.LockFile, activeTarget str
 }
 
 func runApplyWithSpecAndLock(ctx context.Context, opts applyOptions, f *schema.GenvFile, lf *genvfile.LockFile, lockPath string) int {
+	useSpecAdapters(f)
 	available := resolver.Detect()
 	if lf == nil {
 		lf = &genvfile.LockFile{SchemaVersion: schema.Version}
@@ -2925,6 +2955,7 @@ func scanCmd(args []string) int {
 		return exit
 	}
 
+	useSpecAdapters(f)
 	available := resolver.Detect()
 	if len(available) == 0 {
 		if *jsonOut {
@@ -3038,7 +3069,11 @@ func scanCmd(args []string) int {
 
 	var added int
 	for _, c := range candidates {
-		if err := commands.Add(f, c.id, "", "", nil, targetID); err != nil {
+		prefer := ""
+		if adapter.SpecName(c.manager) {
+			prefer = c.manager
+		}
+		if err := commands.Add(f, c.id, "", prefer, nil, targetID); err != nil {
 			// ErrAlreadyTracked can race with trackedInSpec; skip silently.
 			skipped++
 			continue
@@ -3140,7 +3175,7 @@ func skipScanPackage(manager, id string) bool {
 
 func scanAdaptersOnGOOS(available map[string]bool, goos string) []adapter.Adapter {
 	selected := make([]adapter.Adapter, 0, len(adapter.All))
-	for _, a := range adapter.All {
+	for _, a := range adapter.Registered() {
 		if available[a.Name()] && adapter.AutomaticOnGOOS(a.Name(), goos) {
 			selected = append(selected, a)
 		}
@@ -3853,8 +3888,11 @@ func completeInternalCmd(args []string) int {
 			fPrintln(os.Stdout, p.ID)
 		}
 	case "managers":
+		if spec, err := genvfile.Read(defaultSpecPath()); err == nil {
+			useSpecAdapters(spec)
+		}
 		available := resolver.Detect()
-		for _, a := range adapter.All {
+		for _, a := range adapter.Registered() {
 			if available[a.Name()] {
 				fPrintln(os.Stdout, a.Name())
 			}

--- a/main_spec_adapter_test.go
+++ b/main_spec_adapter_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ks1686/genv/internal/adapter"
+	"github.com/ks1686/genv/internal/genvfile"
+)
+
+func TestSpecAdapter_ApplyStatusScanAndUpdates(t *testing.T) {
+	t.Cleanup(func() { adapter.SetSpecAdapters(nil) })
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	bin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := filepath.Join(dir, "plug-state")
+	t.Setenv("PLUGCTL_STATE", stateDir)
+	script := "#!/bin/sh\n" +
+		"state=${PLUGCTL_STATE:-/tmp/plug-state}\n" +
+		"mkdir -p \"$state\"\n" +
+		"case \"$1\" in\n" +
+		"  list)\n" +
+		"    printf '%s\\n' 'slack@official 1.0.0' 'extra@src 0.2.0'\n" +
+		"    for f in \"$state\"/*; do\n" +
+		"      [ -f \"$f\" ] || continue\n" +
+		"      printf '%s\\n' \"$(basename \"$f\")\"\n" +
+		"    done\n" +
+		"    ;;\n" +
+		"  install)\n" +
+		"    : > \"$state/$2\"\n" +
+		"    ;;\n" +
+		"  uninstall|update) exit 0 ;;\n" +
+		"  *) exit 0 ;;\n" +
+		"esac\n"
+	plug := filepath.Join(bin, "plugctl")
+	if runtime.GOOS == "windows" {
+		t.Skip("spec-adapter CLI test uses a POSIX fake binary")
+	}
+	if err := os.WriteFile(plug, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	specPath := filepath.Join(dir, "genv.json")
+	lockPath := filepath.Join(dir, "genv.lock.json")
+	spec := `{
+	  "schemaVersion":"8",
+	  "adapters":{
+	    "plug":{
+	      "list":"plugctl list",
+	      "install":"plugctl install {{id}}",
+	      "remove":"plugctl uninstall {{id}}",
+	      "upgrade":"plugctl update {{id}}"
+	    }
+	  },
+	  "targets":{
+	    "linux":{
+	      "packages":[
+	        {"id":"slack@official","prefer":"plug"},
+	        {"id":"needed@src","prefer":"plug"}
+	      ]
+	    }
+	  }
+	}`
+	if err := os.WriteFile(specPath, []byte(spec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var applyOut string
+	var code int
+	applyOut = captureStdout(t, func() {
+		code = run([]string{"apply", "--file", specPath, "--lock-file", lockPath, "--target", "linux", "--dry-run"})
+	})
+	if code != exitOK {
+		t.Fatalf("apply --dry-run: exit %d\n%s", code, applyOut)
+	}
+	if !strings.Contains(applyOut, "via plug") {
+		t.Fatalf("apply dry-run should resolve via plug:\n%s", applyOut)
+	}
+	if !strings.Contains(applyOut, "plugctl install needed@src") {
+		t.Fatalf("apply dry-run missing install for uninstalled package:\n%s", applyOut)
+	}
+
+	applyOut = captureStdout(t, func() {
+		code = run([]string{"apply", "--file", specPath, "--lock-file", lockPath, "--target", "linux", "--yes"})
+	})
+	if code != exitOK {
+		t.Fatalf("apply: exit %d\n%s", code, applyOut)
+	}
+	lf, err := genvfile.ReadLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lf.Packages) < 2 {
+		t.Fatalf("lock packages=%+v, want slack@official and needed@src", lf.Packages)
+	}
+	for _, lp := range lf.Packages {
+		if lp.Manager != "plug" {
+			t.Fatalf("lock entry %+v: manager want plug", lp)
+		}
+	}
+
+	var statusOut string
+	statusOut = captureStdout(t, func() {
+		code = run([]string{"status", "--file", specPath, "--lock-file", lockPath, "--target", "linux"})
+	})
+	if code != exitOK {
+		t.Fatalf("status: exit %d\n%s", code, statusOut)
+	}
+
+	var scanOut string
+	scanOut = captureStdout(t, func() {
+		code = run([]string{"scan", "--file", specPath, "--lock-file", lockPath, "--target", "linux", "--dry-run"})
+	})
+	if code != exitOK {
+		t.Fatalf("scan: exit %d\n%s", code, scanOut)
+	}
+	if !strings.Contains(scanOut, "extra@src") || !strings.Contains(scanOut, "via plug") {
+		t.Fatalf("scan should propose extra@src via plug:\n%s", scanOut)
+	}
+	if strings.Contains(scanOut, "slack@official") {
+		t.Fatalf("scan should skip already-tracked slack@official:\n%s", scanOut)
+	}
+
+	scanOut = captureStdout(t, func() {
+		code = run([]string{"scan", "--file", specPath, "--lock-file", lockPath, "--target", "linux", "--yes"})
+	})
+	if code != exitOK {
+		t.Fatalf("scan --yes: exit %d\n%s", code, scanOut)
+	}
+	f, err := genvfile.Read(specPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, p := range f.Targets["linux"].Packages {
+		if p.ID == "extra@src" && p.Prefer == "plug" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("scan should persist prefer:plug for extra@src: %+v", f.Targets["linux"].Packages)
+	}
+
+	var updatesOut string
+	updatesOut = captureStdout(t, func() {
+		code = run([]string{"updates", "check", "--file", specPath, "--lock-file", lockPath, "--target", "linux"})
+	})
+	if code != exitOK {
+		t.Fatalf("updates check: exit %d\n%s", code, updatesOut)
+	}
+	if !strings.Contains(updatesOut, "slack@official") && !strings.Contains(updatesOut, "plugctl update") && !strings.Contains(updatesOut, "plug") {
+		t.Fatalf("updates check should cover spec-adapter packages:\n%s", updatesOut)
+	}
+}

--- a/schema/v8/genv.json
+++ b/schema/v8/genv.json
@@ -51,6 +51,12 @@
     },
     "updates": {
       "type": "object"
+    },
+    "adapters": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/adapterDef"
+      }
     }
   },
   "$defs": {
@@ -168,6 +174,43 @@
           "additionalProperties": {
             "type": "string"
           }
+        }
+      }
+    },
+    "adapterDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["list", "install", "remove"],
+      "properties": {
+        "list": {
+          "type": "string",
+          "minLength": 1
+        },
+        "install": {
+          "type": "string",
+          "minLength": 1
+        },
+        "remove": {
+          "type": "string",
+          "minLength": 1
+        },
+        "upgrade": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "outdated": {
+          "type": "string"
+        },
+        "listMatch": {
+          "type": "string"
+        },
+        "idField": {
+          "type": "string"
+        },
+        "versionField": {
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #145.

Schema v8 specs can declare installable command adapters so plugin ecosystems (`claude plugin`, `gh extension`, and similar) are normal packages instead of postApply hooks.

## Example

```json
{
  "schemaVersion": "8",
  "adapters": {
    "claude-plugin": {
      "list": "claude plugin list --json",
      "install": "claude plugin install {{id}} --scope user",
      "remove": "claude plugin uninstall {{id}}",
      "upgrade": "claude plugin update {{id}}",
      "idField": "name",
      "versionField": "version"
    },
    "gh-extension": {
      "list": "gh extension list",
      "install": "gh extension install {{id}}",
      "remove": "gh extension remove {{id}}",
      "upgrade": "gh extension upgrade {{id}}",
      "listMatch": "(?m)^(?P<id>\\S+)\\s+(?P<version>\\S+)"
    }
  },
  "targets": {
    "macos": {
      "packages": [
        { "id": "slack@claude-plugins-official", "prefer": "claude-plugin" }
      ]
    }
  }
}
```

`prefer: claude-plugin` then works for apply, adopt, status, scan, updates check, and upgrade. `external` is unchanged (track-only).

## Design

- Top-level `adapters` on v8 only (same layer as `repo` / `updates`). Additive; built-in brew/apt/etc. stay in `adapter.All`.
- Runtime type `adapter.Command` implements `Adapter` (and `VersionLister`). Bound via `SetSpecAdapters` so `Detect` / `ByName` / scan see them.
- **Parsing:** if `idField` is set and stdout looks like JSON, walk objects (field or dotted path like `plugins.name`); else `listMatch` (group 1 or named `id`/`name`/`version`); else first field per line.
- Templates: `{{id}}` and `{{name}}`. Commands are argv-split (quotes ok, no shell pipes).
- Spec adapters are explicit-only (not default fallback). Names are kebab-case and cannot collide with built-in managers.
- No `OutdatedLister` unless `outdated` is set, so `updates check` keeps them (same as go/asdf). Optional `outdated` command uses the same list parser.
- `genv scan` includes available spec adapters and writes `prefer` on adopt so the package stays bound.
- `genv export` copies `adapters` into the snapshot so `prefer` still validates.

## Verification

- `go test ./...`
- `make ci` (race + cover-gate 81.9% + bench-gate 172ms)

## Deferred

- No `search` / `clean` / `bin` fields
- No `query` command (membership in `list`)
- Adapters are top-level only (not defaults/targets overlays)
- No built-in Claude/gh adapters — spec-defined only
- #144 launchd/systemd rework is out of scope

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bea461e-8dc4-4984-9435-2dbb78dc914a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bea461e-8dc4-4984-9435-2dbb78dc914a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

