### PR TITLE
chore: prepare v4.3.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v4.3.2 - 2026-09-05
+
 ### Added
 
 - Spec services can declare a LaunchAgent or systemd --user unit from a
@@ -34,6 +36,12 @@ All notable changes to this project will be documented in this file.
   refreshes the hash. Pre-hash locks omit the field and stay topology-only.
   Hashing is always on for `link` / `managed-link` / templates; `merge-dir`
   trees are not hashed.
+- `files.links[]`, `files.templates[]`, and `files.dirs[]` accept optional
+  `perm`, an octal string (`0600`, `0700`). Apply chmods the managed-link
+  source, rendered template, or directory after creating the entry. A second
+  apply is a no-op when the mode already matches. `genv status` reports
+  `perm-mismatch`. `mode` on links stays the link kind (`link` /
+  `managed-link` / `merge-dir`); it is still rejected on dirs.
 - Per-entry `backup: true` on a files link (or template) replaces that
   entry's mismatched regular file without `--force`, and keeps a
   `*.backup.*` copy. Other mismatches still report and still need `--force`.
@@ -41,6 +49,29 @@ All notable changes to this project will be documented in this file.
 - `genv files adopt <target>` seeds a missing source from the live file,
   backs the live file up, creates the link, and records it in the lock.
   `--dry-run` prints the copy/backup/link steps without writing.
+- Lifecycle hooks now receive `GENV_SPEC_FILE`, `GENV_SPEC_DIR`, and
+  `GENV_LOCK_FILE`. A hook with `continueOnError: true` reports a failure
+  without failing apply. Each hook phase prints a name/exit/duration
+  summary after hooks run.
+
+### Fixed
+
+- `genv adopt` and `genv disown` rewrite only the changed `packages` arrays
+  when the rest of the spec is unchanged, so empty objects and original key
+  order survive in `genv.json`.
+- Applying a spec with `--file` no longer rewrites the live default lock or
+  env/shell fragments. Lock and fragments default to the spec directory;
+  `--state-dir` relocates all three. Plan output names the paths.
+  `adopt --file` reads the sibling lock. Wet apply refuses writes outside
+  that directory without an explicit `--lock-file` or `--state-dir`.
+- `genv adopt` now queries the adapter for the installed version and writes
+  it to the lock. `genv status` shows `*` for no constraint and `?` when the
+  installed version is unknown. Apply backfills empty lock versions from
+  `VersionLister` inventory so existing adopted entries pick up versions on
+  the next apply.
+- Lock mutations no longer leave a zero-byte `<lock>.mutex` sidecar after
+  apply and other writes. Unlock unlinks it, re-checking inode identity so
+  concurrent holders stay exclusive.
 
 ## v4.3.1 - 2026-09-05
 
@@ -78,12 +109,6 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `files.links[]`, `files.templates[]`, and `files.dirs[]` accept optional
-  `perm`, an octal string (`0600`, `0700`). Apply chmods the managed-link
-  source, rendered template, or directory after creating the entry. A second
-  apply is a no-op when the mode already matches. `genv status` reports
-  `perm-mismatch`. `mode` on links stays the link kind (`link` /
-  `managed-link` / `merge-dir`); it is still rejected on dirs.
 - Tracked-package planning now refreshes each index-based manager once before
   outdated detection. `genv upgrade`, `genv updates check`, and the hourly
   `__run-once` / `autoApply` worker share that path. Refresh argv: `brew update`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ genv map --target arch                # assist-only manager suggestions
 **Linux x86-64 example** (replace the version to match [Releases](https://github.com/ks1686/genv/releases/latest)):
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.3.1_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.3.2_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 genv version
@@ -50,7 +50,7 @@ The bucket is self-hosted (not Scoop extras). `scoop install genv` needs a root
 **Windows (PowerShell zip):**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.3.1_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.3.2_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .
 # put genv.exe on PATH, then:
 genv version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,6 +42,7 @@ follow-up macOS workflow job publishes the AUR packages.
 | `v4.2.2` | Every manager probe bounded (scan/search/upgrade/outdated/services); crash-safe fsync'd spec & lock writes; atomic pull; docs/completions/CI fixes; updates worker shutdown grace |
 | `v4.3.0` | Windows updates scheduler, vscode stable-only outdated detection, lock/apply recovery, and `genv upgrade` OS/firmware steps |
 | `v4.3.1` | Index refresh before outdated; user-facing `scan` default; apply `--skip-packages` quiet; vscode prefers `cursor`; hidden Windows updates host; upgrade `--json`/`--only` polish |
+| `v4.3.2` | Spec adapters; apply `--source-root`; file `contentHash` / `perm` / per-entry backup; `files adopt`; launchd/systemd service templates; hook `continueOnError`; lock/adopt/disown fixes |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew, Scoop,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Promote Unreleased to `v4.3.2` (2026-09-05 America/New_York) so a later annotated tag can trigger GoReleaser. Docs only. Does not create the tag.

## Changelog shape

**Added** (from Unreleased + missing post-4.3.1 features):

- launchd/systemd service templates (`#163`)
- spec-level `adapters` (`#164`)
- `apply --source-root` (`#159`)
- lock `contentHash` (`#162`)
- files `perm` (`#161`) — moved out of `## v4.3.1`; it was never in the tagged `v4.3.1` tree
- per-entry `backup` + `genv files adopt` (`#158`)
- hook spec paths, `continueOnError`, and phase summary (`#160`)

**Fixed:**

- empty `genv.json` blocks survive adopt/disown (`#154`)
- lock + env/shell fragments stay next to `--file` (`#155`)
- adopt records installed versions; apply backfills (`#156`)
- lock mutex sidecar unlinked on unlock (`#157`)

Empty `## Unreleased` is kept for the next cycle.

## Version pins (same as #151)

- README Linux/Windows archive examples: `4.3.1` → `4.3.2`
- RELEASING.md Versioning table: new `v4.3.2` row

Platform walkthroughs still pin `4.1.0`; #151 left those alone.

## After merge

A human/agent should push annotated tag `v4.3.2` to trigger GoReleaser. This PR does not tag.

## Test plan

- Docs-only diff (`CHANGELOG.md`, `README.md`, `RELEASING.md`)
- Local `go test ./...` after push
- Do not merge from this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-058aac27-09b3-4a7c-90e6-f31c7a88aac0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-058aac27-09b3-4a7c-90e6-f31c7a88aac0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

