### PR TITLE
fix: drop deprecated Homebrew cask postflight hook

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,18 +87,16 @@ homebrew_casks:
     description: "Track, sync, and reproduce your software environment across Linux, macOS, Windows, and WSL2."
     license: MIT
     skip_upload: auto  # skips pre-releases automatically
-    # Darwin release binaries are Developer ID signed and notarized. After a cask
-    # upgrade the binary path under Caskroom changes; reload the updates
-    # LaunchAgent so launchd picks up the new ProgramArguments path.
-    hooks:
-      post:
-        install: |
-          if OS.mac?
-            plist = File.expand_path("~/Library/LaunchAgents/genv.updates.plist")
-            if File.exist?(plist)
-              system_command "#{staged_path}/genv", args: ["updates", "start"]
-            end
-          end
+    # PreferStable makes a Caskroom reload unnecessary: modern
+    # `genv updates start` registers a PATH-stable brew prefix bin path,
+    # so launchd does not pin a versioned Caskroom binary. GoReleaser's
+    # homebrew_casks.hooks.post.install always renders as a legacy Ruby
+    # `postflight do` block; there is no field that emits postflight_steps
+    # yet. Caveats below cover agents registered before PreferStable.
+    caveats: |
+      If you use the hourly updates LaunchAgent and it was registered
+      before PATH-stable paths (or `genv updates status` hints a missing
+      executable), run `genv updates start` after upgrading.
 
 # ── Snap Store ────────────────────────────────────────────────────────────────
 # Publishes a snap to the Snap Store on every non-prerelease tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v4.3.3 - 2026-09-05
+
+### Changed
+
+- Homebrew cask no longer ships a legacy `postflight` hook that re-ran
+  `genv updates start` after upgrades. GoReleaser can only emit
+  `postflight`, not `postflight_steps`, which triggered a brew
+  deprecation warning. Modern `genv updates start` already registers a
+  PATH-stable brew prefix bin path via `selfpath.PreferStable`, so the
+  Caskroom reload is unnecessary. The cask caveat tells users with older
+  LaunchAgents (or a missing-executable hint from `genv updates status`)
+  to run `genv updates start` after upgrading.
+
 ## v4.3.2 - 2026-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ genv map --target arch                # assist-only manager suggestions
 **Linux x86-64 example** (replace the version to match [Releases](https://github.com/ks1686/genv/releases/latest)):
 
 ```bash
-curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.3.2_linux_amd64.tar.gz
+curl -Lo genv.tar.gz https://github.com/ks1686/genv/releases/latest/download/genv_4.3.3_linux_amd64.tar.gz
 tar -xzf genv.tar.gz
 sudo mv genv /usr/local/bin/
 genv version
@@ -50,7 +50,7 @@ The bucket is self-hosted (not Scoop extras). `scoop install genv` needs a root
 **Windows (PowerShell zip):**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.3.2_windows_amd64.zip -OutFile genv.zip
+Invoke-WebRequest -Uri https://github.com/ks1686/genv/releases/latest/download/genv_4.3.3_windows_amd64.zip -OutFile genv.zip
 Expand-Archive genv.zip -DestinationPath .
 # put genv.exe on PATH, then:
 genv version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,6 +43,7 @@ follow-up macOS workflow job publishes the AUR packages.
 | `v4.3.0` | Windows updates scheduler, vscode stable-only outdated detection, lock/apply recovery, and `genv upgrade` OS/firmware steps |
 | `v4.3.1` | Index refresh before outdated; user-facing `scan` default; apply `--skip-packages` quiet; vscode prefers `cursor`; hidden Windows updates host; upgrade `--json`/`--only` polish |
 | `v4.3.2` | Spec adapters; apply `--source-root`; file `contentHash` / `perm` / per-entry backup; `files adopt`; launchd/systemd service templates; hook `continueOnError`; lock/adopt/disown fixes |
+| `v4.3.3` | Drop legacy Homebrew cask `postflight` hook (PreferStable + caveat); silences brew `postflight_steps` deprecation |
 
 Use pre-release suffixes (`-beta.N`, `-rc.N`) for any release that is not fully
 validated. GoReleaser's `skip_upload: auto` setting skips the Homebrew, Scoop,

--- a/main_updates_daemon.go
+++ b/main_updates_daemon.go
@@ -65,7 +65,8 @@ func updatesStartCmd(args []string) int {
 		return exitIO
 	}
 	// Prefer a PATH-stable invocation path (e.g. Homebrew's bin/genv symlink)
-	// over a version-pinned Caskroom path from os.Executable / cask post_install.
+	// over a version-pinned Caskroom path from os.Executable. The Homebrew
+	// cask no longer re-runs updates start after upgrades.
 	exe = selfpath.PreferStable(exe, os.Args[0], updatesSelfLookPath)
 	absFile, err := filepath.Abs(*file)
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Homebrew warns `Calling postflight is deprecated! Use postflight_steps instead` on `ks1686/homebrew-tap` `Casks/genv.rb`.

GoReleaser’s `homebrew_casks.hooks.post.install` always renders as a legacy Ruby `postflight do` block. There is no GoReleaser field that emits `postflight_steps`, so renaming the stanza through hooks is impossible.

Modern `genv updates start` already prefers a PATH-stable brew prefix bin path via `selfpath.PreferStable`, so LaunchAgents registered today do not pin a Caskroom version path. The postflight reload was belt-and-suspenders for upgrades when the agent still pointed at a versioned binary.

## Changes

- Remove the `homebrew_casks` `hooks:` block from `.goreleaser.yml`.
- Add a cask `caveats:` string: if the hourly updates LaunchAgent was registered before PATH-stable paths (or `genv updates status` hints a missing executable), run `genv updates start` after upgrading.
- Comment explains PreferStable + why GoReleaser cannot emit `postflight_steps`.
- Tighten the `updatesStartCmd` comment so it no longer implies we still ship a cask post-install hook.
- Changelog / README / RELEASING pins for **v4.3.3**.

## After merge

Tag `v4.3.3` (not in this PR). The regenerated cask should have no `postflight` stanza, so brew no longer warns.

Does not edit `ks1686/homebrew-tap` directly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ead46b6f-b7bf-4893-85ac-17331efa8048?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ead46b6f-b7bf-4893-85ac-17331efa8048&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

